### PR TITLE
Migrated hexToBin function from pact-lang-api

### DIFF
--- a/src/crypto/hexToBin.ts
+++ b/src/crypto/hexToBin.ts
@@ -1,0 +1,6 @@
+/**
+ * Takes in hex string and outputs Uint8Array binary object.
+ */
+export default function hexToBin(hexString: string): Uint8Array {
+  return new Uint8Array(Buffer.from(hexString, 'hex'));
+}

--- a/src/crypto/tests/hexToBin.spec.ts
+++ b/src/crypto/tests/hexToBin.spec.ts
@@ -1,0 +1,16 @@
+import hexToBin from '../hexToBin';
+
+test('should convert hex string to Uint8Array binary object', () => {
+  var hexString =
+    '8693e641ae2bbe9ea802c736f42027b03f86afe63cae315e7169c9c496c17332ba54b224d1924dd98403f5c751abdd10de6cd81b0121800bf7bdbdcfaec7388d';
+
+  const actual = hexToBin(hexString);
+  const expected = new Uint8Array([
+    134, 147, 230, 65, 174, 43, 190, 158, 168, 2, 199, 54, 244, 32, 39, 176, 63,
+    134, 175, 230, 60, 174, 49, 94, 113, 105, 201, 196, 150, 193, 115, 50, 186,
+    84, 178, 36, 209, 146, 77, 217, 132, 3, 245, 199, 81, 171, 221, 16, 222,
+    108, 216, 27, 1, 33, 128, 11, 247, 189, 189, 207, 174, 199, 56, 141,
+  ]);
+
+  expect(expected).toEqual(actual);
+});


### PR DESCRIPTION
Small example of how to start the migration.
We also need to check if we want to change some of the naming of the functions from pact-lang-api while migrating