### PR TITLE
Fixes -c in retrieve-contract 

### DIFF
--- a/packages/tools/pactjs-cli/src/retrieve-contract/index.ts
+++ b/packages/tools/pactjs-cli/src/retrieve-contract/index.ts
@@ -21,7 +21,7 @@ const Options = z.object({
       invalid_type_error: 'Error: -c, --chain must be a number',
     })
     .min(0)
-    .max(20),
+    .max(19),
   /* eslint-enable @typescript-eslint/naming-convention */
 });
 
@@ -45,8 +45,8 @@ export function retrieveContractCommand(
       'mainnet',
     )
     .addOption(
-      new Option('-c, --chain <chain>', 'Chain to retrieve from (default 1)')
-        .argParser(parseInt)
+      new Option('-c, --chain <number>', 'Chain to retrieve from (default 1)')
+        .argParser((value) => parseInt(value, 10))
         .default(1),
     )
     .action(async (args: TOptions) => {

--- a/packages/tools/pactjs-cli/src/retrieve-contract/index.ts
+++ b/packages/tools/pactjs-cli/src/retrieve-contract/index.ts
@@ -45,7 +45,7 @@ export function retrieveContractCommand(
       'mainnet',
     )
     .addOption(
-      new Option('-c, --chain <network>', 'Chain to retrieve from (default 1)')
+      new Option('-c, --chain <chain>', 'Chain to retrieve from (default 1)')
         .argParser(parseInt)
         .default(1),
     )

--- a/packages/tools/pactjs-cli/src/retrieve-contract/retrieve-contract.ts
+++ b/packages/tools/pactjs-cli/src/retrieve-contract/retrieve-contract.ts
@@ -30,12 +30,13 @@ export function retrieveContract(
         networkMap[network].network
       }\\",\\"payload\\":{\\"exec\\":{\\"code\\":\\"(describe-module \\\\\\"${module}\\\\\\")\\",\\"data\\":{}}}}","hash":"${hash}","sigs":[]}`;
 
-    const { textResponse } = await callLocal(network, createBody());
+    const { textResponse } = await callLocal(network, chain, createBody());
 
     const hashFromResponse = textResponse?.split(' ').splice(-1, 1)[0];
 
     const { jsonResponse } = await callLocal(
       network,
+      chain,
       createBody(hashFromResponse),
     );
 
@@ -49,6 +50,7 @@ export function retrieveContract(
 
 async function callLocal(
   network: TOptions['network'],
+  chain: TOptions['chain'],
   body: string,
 ): Promise<{
   textResponse: string | undefined;

--- a/packages/tools/pactjs-cli/src/retrieve-contract/retrieve-contract.ts
+++ b/packages/tools/pactjs-cli/src/retrieve-contract/retrieve-contract.ts
@@ -26,7 +26,9 @@ export function retrieveContract(
     const now = new Date();
 
     const createBody = (hash: string = ''): string =>
-      `{"cmd":"{\\"signers\\":[],\\"meta\\":{\\"creationTime\\":${now.getTime()},\\"ttl\\":600,\\"chainId\\":\\"${chain}\\",\\"gasPrice\\":1.0e-8,\\"gasLimit\\":2500,\\"sender\\":\\"sender00\\"},\\"nonce\\":\\"CW:${now.toUTCString()}\\",\\"networkId\\":\\"${network}\\",\\"payload\\":{\\"exec\\":{\\"code\\":\\"(describe-module \\\\\\"${module}\\\\\\")\\",\\"data\\":{}}}}","hash":"${hash}","sigs":[]}`;
+      `{"cmd":"{\\"signers\\":[],\\"meta\\":{\\"creationTime\\":${now.getTime()},\\"ttl\\":600,\\"chainId\\":\\"${chain}\\",\\"gasPrice\\":1.0e-8,\\"gasLimit\\":2500,\\"sender\\":\\"sender00\\"},\\"nonce\\":\\"CW:${now.toUTCString()}\\",\\"networkId\\":\\"${
+        networkMap[network].network
+      }\\",\\"payload\\":{\\"exec\\":{\\"code\\":\\"(describe-module \\\\\\"${module}\\\\\\")\\",\\"data\\":{}}}}","hash":"${hash}","sigs":[]}`;
 
     const { textResponse } = await callLocal(network, createBody());
 
@@ -61,7 +63,7 @@ async function callLocal(
 }> {
   const response = await fetch(
     `https://${networkMap[network].api}/chainweb/0.0/` +
-      `${networkMap[network].network}/chain/0/pact/api/v1/local`,
+      `${networkMap[network].network}/chain/${chain}/pact/api/v1/local`,
     {
       headers: {
         accept: 'application/json;charset=utf-8, application/json',


### PR DESCRIPTION
## Changes made (preferably with images/screenshots):

- Fixes broken `-c` in retrieve-contract
- change `network` to `networkMap[network].networkId` in command body. (This doesn't break in `/local` calls, but it should use the networkId.)

## Check off the following:

- [ ] I have reviewed my changes and run the appropriate tests.
- [ ] I have added/edited docs.
- [ ] I have added tutorials.
- [ ] I have double checked and DEFINITELY added docs.

