### PR TITLE
Up test coverage for chainweb-node-client

### DIFF
--- a/packages/libs/chainweb-node-client/src/pact/tests/index.test.ts
+++ b/packages/libs/chainweb-node-client/src/pact/tests/index.test.ts
@@ -1,0 +1,23 @@
+import {
+  listen,
+  poll,
+  send,
+  spv,
+  local,
+  mkCap,
+  parseResponse,
+  parseResponseTEXT,
+  stringifyAndMakePOSTRequest,
+} from '../index';
+
+test('Expects functions to be exposed', async () => {
+  expect(listen).toBeDefined();
+  expect(poll).toBeDefined();
+  expect(send).toBeDefined();
+  expect(spv).toBeDefined();
+  expect(local).toBeDefined();
+  expect(mkCap).toBeDefined();
+  expect(parseResponse).toBeDefined();
+  expect(parseResponseTEXT).toBeDefined();
+  expect(stringifyAndMakePOSTRequest).toBeDefined();
+});

--- a/packages/libs/chainweb-node-client/src/test/index.test.ts
+++ b/packages/libs/chainweb-node-client/src/test/index.test.ts
@@ -1,0 +1,5 @@
+import { pact } from '../index';
+
+test('Expects functions to be exposed', async () => {
+  expect(pact).toBeDefined();
+});


### PR DESCRIPTION
## Reason:
Test coverage was below threshold

## Check off the following:

- [ x] I have reviewed my changes and run the appropriate tests.

