### PR TITLE
[libs/client] Reset cmd when a transaction gets changed

### DIFF
--- a/common/changes/@kadena/client/feat-remove-cmd-malleable_2022-12-05-12-16.json
+++ b/common/changes/@kadena/client/feat-remove-cmd-malleable_2022-12-05-12-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "Remove `cmd` from the transaction when the properties of this transaction change, so it gets recalculated. Also reset signatures (if any) in that case, because the signatures do no longer match the transaction",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/common/changes/@kadena/client/feat-remove-cmd-malleable_2022-12-05-12-16.json
+++ b/common/changes/@kadena/client/feat-remove-cmd-malleable_2022-12-05-12-16.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@kadena/client",
-      "comment": "Remove `cmd` from the transaction when the properties of this transaction change, so it gets recalculated. Also reset signatures (if any) in that case, because the signatures do no longer match the transaction",
+      "comment": "When proprerties of a non-malleable transaction change, remove `cmd`, `hash` and `signatures` from the transaction to issue a recalculation of the `cmd` and `hash`.",
       "type": "patch"
     }
   ],

--- a/packages/libs/client/src/signing/tests/signWithChainweaver.test.ts
+++ b/packages/libs/client/src/signing/tests/signWithChainweaver.test.ts
@@ -79,7 +79,7 @@ describe('signWithChainweaver', () => {
     });
   });
 
-  it('adds signatures in multisig fasion to the transactions', async () => {
+  it('adds signatures in multisig fashion to the transactions', async () => {
     const mockedResponse: { results: IChainweaverSignedCommand[] } = {
       results: [{ cmd: '', sigs: { 'gas-signer-pubkey': 'gas-key-sig' } }],
     };

--- a/packages/libs/client/src/tests/pact.test.ts
+++ b/packages/libs/client/src/tests/pact.test.ts
@@ -199,7 +199,7 @@ describe('Pact proxy', () => {
   });
 });
 
-describe('The hash and signers for a transaction are reset', () => {
+describe('TransactionCommand', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const pact = Pact as any;
   const sender =

--- a/packages/libs/client/src/tests/pact.test.ts
+++ b/packages/libs/client/src/tests/pact.test.ts
@@ -5,7 +5,7 @@ jest.mock('cross-fetch', () => {
   };
 });
 import { IUnsignedTransaction } from '../interfaces/IUnsignedTransaction';
-import { ICommandBuilder, Pact } from '../pact';
+import { ICommandBuilder, Pact, PactCommand } from '../pact';
 
 import fetch from 'cross-fetch';
 
@@ -57,7 +57,7 @@ describe('Pact proxy', () => {
     const receiver =
       'k:e34b62cb48526f89e419dae4e918996d66582b5951361c98ee387665a94b7ad8';
     const amount = 0.23;
-    const signerAccount = sender.split('k:')[1];
+    const signerPubKey = sender.split('k:')[1];
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const pact = Pact as any;
@@ -68,8 +68,8 @@ describe('Pact proxy', () => {
       () => "(read-keyset 'ks)",
       amount,
     )
-      .addCap('coin.GAS', signerAccount)
-      .addCap('coin.TRANSFER', signerAccount, sender, receiver, amount)
+      .addCap('coin.GAS', signerPubKey)
+      .addCap('coin.TRANSFER', signerPubKey, sender, receiver, amount)
       .addData({
         ks: {
           keys: [
@@ -82,7 +82,7 @@ describe('Pact proxy', () => {
         {
           gasLimit: 1000,
           gasPrice: 1.0e-6,
-          sender: signerAccount,
+          sender: signerPubKey,
           ttl: 10 * 60, // 10 minutes
         },
         'testnet04',
@@ -196,5 +196,99 @@ describe('Pact proxy', () => {
     );
 
     expect(() => builder.poll('fake-api-host.local.co')).toThrow();
+  });
+});
+
+describe('The hash and signers for a transaction are reset', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pact = Pact as any;
+  const sender =
+    'k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94' as const;
+  const receiver =
+    'k:e34b62cb48526f89e419dae4e918996d66582b5951361c98ee387665a94b7ad8';
+  const amount = 0.23;
+  const senderPubKey = sender.split('k:')[1];
+  const receiverPubKey = receiver.split('k:')[1];
+
+  let transactionCommand: PactCommand;
+
+  beforeEach(() => {
+    transactionCommand = pact.modules.coin['transfer-create'](
+      sender,
+      receiver,
+      () => "(read-keyset 'ks)",
+      amount,
+    )
+      .addCap('coin.GAS', senderPubKey)
+      .addCap('coin.TRANSFER', senderPubKey, sender, receiver, amount)
+      .addData({
+        ks: {
+          keys: [
+            '554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94',
+          ],
+          pred: 'keys-all',
+        },
+      })
+      .setMeta(
+        {
+          sender: senderPubKey,
+        },
+        'testnet04',
+      );
+  });
+
+  it('when setMeta is called', async () => {
+    const transaction = transactionCommand.createCommand();
+
+    const updatedTransactionCommand = transactionCommand.setMeta(
+      {
+        sender: receiverPubKey,
+      },
+      'testnet04',
+    );
+
+    expect(updatedTransactionCommand.sigs).toEqual([undefined]);
+
+    const updatedTransaction = updatedTransactionCommand.createCommand();
+
+    expect(transaction.cmd).not.toEqual(updatedTransaction.cmd);
+    expect(transaction.hash).not.toEqual(updatedTransaction.hash);
+  });
+
+  it('when addData is called', async () => {
+    const transaction = transactionCommand.createCommand();
+
+    const updatedTransactionCommand = transactionCommand.addData({
+      ks: {
+        keys: [
+          '554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94',
+          '1c131be8d83f1d712b33ae0c7afd60bca0db80f362f5de9ba8792c6f4e7df488',
+        ],
+        pred: 'keys-all',
+      },
+    });
+
+    expect(updatedTransactionCommand.sigs).toEqual([undefined]);
+
+    const updatedTransaction = updatedTransactionCommand.createCommand();
+
+    expect(transaction.cmd).not.toEqual(updatedTransaction.cmd);
+    expect(transaction.hash).not.toEqual(updatedTransaction.hash);
+  });
+
+  it('when addCap is called', async () => {
+    const transaction = transactionCommand.createCommand();
+
+    const updatedTransactionCommand = transactionCommand.addCap(
+      'coin.GAS',
+      senderPubKey,
+    );
+
+    expect(updatedTransactionCommand.sigs).toEqual([undefined]);
+
+    const updatedTransaction = updatedTransactionCommand.createCommand();
+
+    expect(transaction.cmd).not.toEqual(updatedTransaction.cmd);
+    expect(transaction.hash).not.toEqual(updatedTransaction.hash);
   });
 });

--- a/packages/libs/client/src/tests/pact.test.ts
+++ b/packages/libs/client/src/tests/pact.test.ts
@@ -237,7 +237,7 @@ describe('TransactionCommand', () => {
       );
   });
 
-  it('when setMeta is called', async () => {
+  it('resets `cmd` `hash` and `signatures` when `setMeta` is called', async () => {
     const transaction = transactionCommand.createCommand();
 
     const updatedTransactionCommand = transactionCommand.setMeta(
@@ -255,7 +255,7 @@ describe('TransactionCommand', () => {
     expect(transaction.hash).not.toEqual(updatedTransaction.hash);
   });
 
-  it('when addData is called', async () => {
+  it('resets `cmd` `hash` and `signatures` when `addData` is called', async () => {
     const transaction = transactionCommand.createCommand();
 
     const updatedTransactionCommand = transactionCommand.addData({
@@ -276,7 +276,7 @@ describe('TransactionCommand', () => {
     expect(transaction.hash).not.toEqual(updatedTransaction.hash);
   });
 
-  it('when addCap is called', async () => {
+  it('resets `cmd` `hash` and `signatures` when `addCap` is called', async () => {
     const transaction = transactionCommand.createCommand();
 
     const updatedTransactionCommand = transactionCommand.addCap(


### PR DESCRIPTION
When a transaction gets changed after being finalized, we need to reset the hash and signatures (if applicable) because they do not match the transaction it was calculated/signed for.

Closes #107

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203499728801195