### PR TITLE
Update README.md

### DIFF
--- a/packages/libs/client/README.md
+++ b/packages/libs/client/README.md
@@ -81,8 +81,7 @@ cd my-dapp-with-kadena-client
 npm init -y
 npm install -g typescript
 npm install --save @kadena/client
-npm install --save-dev @kadena/pactjs-cli
-npm install --save-dev ts-node
+npm install -g --save-dev @kadena/pactjs-cli ts-node
 ```
 
 # Contract based interaction using @kadena/client


### PR DESCRIPTION
pactjs-cli and ts-node must be installed globally

## Reason:

pactjs wouldn't run from the command line without the global flag.

## Changes made (preferably with images/screenshots):
- Add the -g flag for pactcli and ts-node
- moved ts-node to the pact-cli line because it has the same args, cuts down on commands to execute

## Check off the following:

- [ X] I have reviewed my changes and run the appropriate tests.
- [ ] I have have run `rush change` to add the appropriate change logs.
- [ X] I have added/edited docs.
- [ X] I have added tutorials.
- [ X] I have double checked and DEFINITELY added docs.

