### PR TITLE
Update README.md

### DIFF
--- a/packages/libs/client/README.md
+++ b/packages/libs/client/README.md
@@ -148,7 +148,7 @@ The log shows what has happened. Inside the `node_modules` directory, a new
 package has been created: `.kadena/pactjs-generated`. This package is referenced by
 `@kadena/client` to give you type information.
 
-> **NOTE:** do not forget to add this `"types": [".kadena/pactjs-generated"],` to compilerOptions
+> **NOTE:** do not forget to add this `"types": [".kadena/pactjs-generated"],` to `compilerOptions`
 > in `tsconfig.json`. Otherwise this will not work
 
 # Building a simple transaction from the contract

--- a/packages/libs/client/README.md
+++ b/packages/libs/client/README.md
@@ -145,11 +145,11 @@ pactjs contract-generate --file "./contracts/coin.module.pact"
 ````
 
 The log shows what has happened. Inside the `node_modules` directory, a new
-package has been created: `.kadena/generated`. This package is referenced by
+package has been created: `.kadena/pactjs-generated`. This package is referenced by
 `@kadena/client` to give you type information.
 
-> **NOTE:** do not forget to add this `"types": [".kadena/generated"],` to your
-> `tsconfig.json`. Otherwise this will not work
+> **NOTE:** do not forget to add this `"types": [".kadena/pactjs-generated"],` to compilerOptions
+> in `tsconfig.json`. Otherwise this will not work
 
 # Building a simple transaction from the contract
 


### PR DESCRIPTION
path to ".kadena/pactjs-generated" corrected

## Reason:

the path to the pactjs generated folder needed correction because it couldn't find it at the specified location. Probably this has been changed recently.

## Check off the following:

- [ X] I have reviewed my changes and run the appropriate tests.
- [ ] I have have run `rush change` to add the appropriate change logs.
- [ X] I have added/edited docs.
- [ ] I have added tutorials.
- [X ] I have double checked and DEFINITELY added docs.

