### PR TITLE
Graphql/UI fixes

### DIFF
--- a/packages/apps/graph-client/TODO
+++ b/packages/apps/graph-client/TODO
@@ -1,1 +1,3 @@
 [ ] Had to set `declaration: false` in tsconfig as a workaround for this: https://github.com/microsoft/TypeScript/issues/42873
+[ ] Importing @graphql-yoga/apollo-link from next is broken: https://github.com/dotansimha/graphql-yoga/issues/2194
+  - had to use require() and eslint-ignore it

--- a/packages/apps/graph-client/TODO
+++ b/packages/apps/graph-client/TODO
@@ -1,0 +1,1 @@
+[ ] Had to set `declaration: false` in tsconfig as a workaround for this: https://github.com/microsoft/TypeScript/issues/42873

--- a/packages/apps/graph-client/TODO
+++ b/packages/apps/graph-client/TODO
@@ -1,3 +1,4 @@
 [ ] Had to set `declaration: false` in tsconfig as a workaround for this: https://github.com/microsoft/TypeScript/issues/42873
 [ ] Importing @graphql-yoga/apollo-link from next is broken: https://github.com/dotansimha/graphql-yoga/issues/2194
   - had to use require() and eslint-ignore it
+[ ] Had to force the Component type in pages/_app.tsx to fix "Type 'React.ReactNode' is not assignable to type 'import("/home/tasinet/code/kadena.js/common/temp/node_modules/.pnpm/@types+react@18.0.26/node_modules/@types/react/index`).ReactNode'.`

--- a/packages/apps/graph-client/src/pages/_app.tsx
+++ b/packages/apps/graph-client/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import {
   NormalizedCacheObject,
 } from '@apollo/client';
 import type { AppProps } from 'next/app';
+import type { ComponentType } from 'react';
 import React from 'react';
 // next/apollo-link bug: https://github.com/dotansimha/graphql-yoga/issues/2194
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -21,9 +22,11 @@ const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function App({ Component, pageProps }: AppProps): JSX.Element {
+  // Fixes "Component' cannot be used as a JSX component."
+  const ReactComponent = Component as ComponentType;
   return (
     <ApolloProvider client={client}>
-      <Component {...pageProps} />
+      <ReactComponent {...pageProps} />
     </ApolloProvider>
   );
 }

--- a/packages/apps/graph-client/src/pages/_app.tsx
+++ b/packages/apps/graph-client/src/pages/_app.tsx
@@ -6,9 +6,11 @@ import {
   InMemoryCache,
   NormalizedCacheObject,
 } from '@apollo/client';
-import { YogaLink } from '@graphql-yoga/apollo-link';
 import type { AppProps } from 'next/app';
 import React from 'react';
+// next/apollo-link bug: https://github.com/dotansimha/graphql-yoga/issues/2194
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { YogaLink } = require('@graphql-yoga/apollo-link');
 
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
   link: new YogaLink({

--- a/packages/apps/graph-client/tsconfig.json
+++ b/packages/apps/graph-client/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "declaration": false, // fixes pnpm issue: https://github.com/microsoft/TypeScript/issues/42873
     "jsx": "preserve"
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
Temporary workarounds for 3 issues: 

- Stitches not working with rush/pnpm modules layout. `declarations: false` in tsconfig is the only thing that fixed it out of many suggestions in various issues: https://github.com/microsoft/TypeScript/issues/42873

- Importing @graphql-yoga/apollo-link from next is [broken](https://github.com/dotansimha/graphql-yoga/issues/2194) had to use require() and eslint-ignore it

- Had to force the Component type in pages/_app.tsx to fix `Type 'React.ReactNode' is not assignable to type 'import("/home/tasinet/code/kadena.js/common/temp/node_modules/.pnpm/@types+react@18.0.26/node_modules/@types/react/index).ReactNode'.`

These are meant to unblock you for the time being. I left a TODO with all 3 of these to re-examine later.