### PR TITLE
chore(pactjs-generator): Merge generated capability types

### DIFF
--- a/common/changes/@kadena/pactjs-cli/feat-merge-capabilities_2022-12-22-07-52.json
+++ b/common/changes/@kadena/pactjs-cli/feat-merge-capabilities_2022-12-22-07-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-cli",
+      "comment": "Adds option to choose custom interface for caps",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kadena/pactjs-cli"
+}

--- a/common/changes/@kadena/pactjs-generator/feat-merge-capabilities_2022-12-21-14-18.json
+++ b/common/changes/@kadena/pactjs-generator/feat-merge-capabilities_2022-12-21-14-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-generator",
+      "comment": "Merge generated types for capabilities across modules ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kadena/pactjs-generator"
+}

--- a/packages/libs/pactjs-generator/etc/pactjs-generator.api.md
+++ b/packages/libs/pactjs-generator/etc/pactjs-generator.api.md
@@ -33,7 +33,7 @@ export class FileContractDefinition implements IContractDefinition {
 // Warning: (ae-forgotten-export) The symbol "ModuleName" needs to be exported by the entry point index.d.ts
 //
 // @alpha (undocumented)
-export function generateDts(modules: Output): Map<ModuleName, string>;
+export function generateDts(modules: Output, capsInterfaceName?: string): Map<ModuleName, string>;
 
 // @alpha (undocumented)
 export function generateTemplates(templates: {

--- a/packages/libs/pactjs-generator/src/contract/generation/generator.ts
+++ b/packages/libs/pactjs-generator/src/contract/generation/generator.ts
@@ -22,18 +22,6 @@ const mapType = (name: string | 'undefined'): string => {
 
 type ModuleName = string;
 
-function capitalize([first, ...rest]: string): string {
-  return first.toUpperCase() + rest.join('');
-}
-
-function camelCase(name: string[]): string {
-  return name.map(capitalize).join('');
-}
-
-function stripDashesAndCamelCase(name: string): string {
-  return camelCase(name.split('-'));
-}
-
 function generateModuleName(module: Module): string {
   if (module.namespace.length === 0) {
     return module.name;
@@ -56,11 +44,13 @@ export function generateDts(modules: Output): Map<ModuleName, string> {
 import type { ICommandBuilder, IPactCommand } from '@kadena/client';
 
 declare module '@kadena/client' {
-  export type I${stripDashesAndCamelCase(module.name)}Caps = {
+  export interface ICapabilities {
     ${Object.keys(module.defcaps)
       .map((defcapName) => {
         const defcap: Defcap = module.defcaps[defcapName];
-        return `"${module.name}.${defcapName}": [ ${Object.keys(defcap.args)
+        return `"${generateModuleName(module)}.${defcapName}": [ ${Object.keys(
+          defcap.args,
+        )
           .map((argName) => {
             const defcapArg: Arg = defcap.args[argName];
             return `${argName.replace(/-/g, '')}: ${mapType(defcapArg.type)}`;
@@ -81,9 +71,7 @@ declare module '@kadena/client' {
                  argDef.type,
                )}`;
              })
-             .join(', ')}) => ICommandBuilder<I${stripDashesAndCamelCase(
-             module.name,
-           )}Caps> & IPactCommand`;
+             .join(', ')}) => ICommandBuilder<ICapabilities> & IPactCommand`;
          })
          .join(',\n')}
     }

--- a/packages/libs/pactjs-generator/src/contract/generation/generator.ts
+++ b/packages/libs/pactjs-generator/src/contract/generation/generator.ts
@@ -33,7 +33,10 @@ function generateModuleName(module: Module): string {
 /**
  * @alpha
  */
-export function generateDts(modules: Output): Map<ModuleName, string> {
+export function generateDts(
+  modules: Output,
+  capsInterfaceName: string = 'ICapabilities',
+): Map<ModuleName, string> {
   const moduleDtss: Map<ModuleName, string> = new Map<ModuleName, string>();
   for (const ModuleName in modules) {
     if (Object.prototype.hasOwnProperty.call(modules, ModuleName)) {
@@ -44,7 +47,7 @@ export function generateDts(modules: Output): Map<ModuleName, string> {
 import type { ICommandBuilder, IPactCommand } from '@kadena/client';
 
 declare module '@kadena/client' {
-  export interface ICapabilities {
+  export interface ${capsInterfaceName} {
     ${Object.keys(module.defcaps)
       .map((defcapName) => {
         const defcap: Defcap = module.defcaps[defcapName];
@@ -71,7 +74,9 @@ declare module '@kadena/client' {
                  argDef.type,
                )}`;
              })
-             .join(', ')}) => ICommandBuilder<ICapabilities> & IPactCommand`;
+             .join(
+               ', ',
+             )}) => ICommandBuilder<${capsInterfaceName}> & IPactCommand`;
          })
          .join(',\n')}
     }

--- a/packages/libs/pactjs-generator/src/contract/generation/tests/generator.test.ts
+++ b/packages/libs/pactjs-generator/src/contract/generation/tests/generator.test.ts
@@ -141,36 +141,74 @@ declare module '@kadena/client' {
         .join(' ');
     expect(dTs).toBe(expected);
   });
-});
 
-it('creates a typescript definition with DEFCAPS from a namespaced contract', () => {
-  const contract: string = `(namespace 'free-namespace)
+  it('creates a typescript definition with DEFCAPS from a namespaced contract', () => {
+    const contract: string = `(namespace 'free-namespace)
     (module the-free-module
     (defun transfer:string (from:string to:string amount:decimal))
     (defcap GAS ())
     (defcap TRANSFER (sender:string receiver:string amount:decimal))
   )`;
-  const parsedContract = new StringContractDefinition(contract);
-  const dTs = generateDts(parsedContract.modulesWithFunctions)
-    .get('the-free-module')!
-    .split(/[\s\n]/)
-    .filter((x) => x !== '')
-    .join(' ');
-  const expected =
-    `import type { ICommandBuilder, IPactCommand } from '@kadena/client';
-declare module '@kadena/client' {
-export interface ICapabilities {
-  "free-namespace.the-free-module.GAS": [ ],
-  "free-namespace.the-free-module.TRANSFER": [ sender: string, receiver: string, amount: number ]
-}
-export interface IPactModules {
-  "free-namespace.the-free-module": {
-    "transfer": (from: string, to: string, amount: number) => ICommandBuilder<ICapabilities> & IPactCommand
-  }
-}
-}`
+    const parsedContract = new StringContractDefinition(contract);
+    const dTs = generateDts(parsedContract.modulesWithFunctions)
+      .get('the-free-module')!
       .split(/[\s\n]/)
       .filter((x) => x !== '')
       .join(' ');
-  expect(dTs).toBe(expected);
+    const expected =
+      `import type { ICommandBuilder, IPactCommand } from '@kadena/client';
+declare module '@kadena/client' {
+  export interface ICapabilities {
+    "free-namespace.the-free-module.GAS": [ ],
+    "free-namespace.the-free-module.TRANSFER": [ sender: string, receiver: string, amount: number ]
+  }
+  export interface IPactModules {
+    "free-namespace.the-free-module": {
+      "transfer": (from: string, to: string, amount: number) => ICommandBuilder<ICapabilities> & IPactCommand
+    }
+  }
+}`
+        .split(/[\s\n]/)
+        .filter((x) => x !== '')
+        .join(' ');
+    expect(dTs).toBe(expected);
+  });
+
+  it('creates a typescript definition with a custom interface name', () => {
+    const contract: string = `(namespace 'free-namespace)
+    (module the-free-module
+    (defun transfer:string (from:string to:string amount:decimal))
+    (defcap GAS ())
+    (defcap TRANSFER (sender:string receiver:string amount:decimal)))`;
+
+    const parsedContract = new StringContractDefinition(contract);
+
+    const dTs = generateDts(
+      parsedContract.modulesWithFunctions,
+      'IMyInterfaceName',
+    )
+      .get('the-free-module')!
+      .split(/[\s\n]/)
+      .filter((x) => x !== '')
+      .join(' ');
+
+    const expected =
+      `import type { ICommandBuilder, IPactCommand } from '@kadena/client';
+declare module '@kadena/client' {
+  export interface IMyInterfaceName {
+    "free-namespace.the-free-module.GAS": [ ],
+    "free-namespace.the-free-module.TRANSFER": [ sender: string, receiver: string, amount: number ]
+  }
+  export interface IPactModules {
+    "free-namespace.the-free-module": {
+      "transfer": (from: string, to: string, amount: number) => ICommandBuilder<IMyInterfaceName> & IPactCommand
+    }
+  }
+}`
+        .split(/[\s\n]/)
+        .filter((x) => x !== '')
+        .join(' ');
+
+    expect(dTs).toBe(expected);
+  });
 });

--- a/packages/libs/pactjs-generator/src/contract/generation/tests/generator.test.ts
+++ b/packages/libs/pactjs-generator/src/contract/generation/tests/generator.test.ts
@@ -15,10 +15,10 @@ describe('generator', () => {
     const expected =
       `import type { ICommandBuilder, IPactCommand } from '@kadena/client';
 declare module '@kadena/client' {
-  export type ICoinCaps = { }
+  export interface ICapabilities { }
   export interface IPactModules {
     "coin": {
-      "transfer": (from: string, to: string, amount: number) => ICommandBuilder<ICoinCaps> & IPactCommand
+      "transfer": (from: string, to: string, amount: number) => ICommandBuilder<ICapabilities> & IPactCommand
     }
   }
 }`
@@ -43,13 +43,13 @@ declare module '@kadena/client' {
     const expected =
       `import type { ICommandBuilder, IPactCommand } from '@kadena/client';
 declare module '@kadena/client' {
-  export type ICoinCaps = {
+  export interface ICapabilities {
     "coin.GAS": [ ],
     "coin.TRANSFER": [ sender: string, receiver: string, amount: number ]
   }
   export interface IPactModules {
     "coin": {
-      "transfer": (from: string, to: string, amount: number) => ICommandBuilder<ICoinCaps> & IPactCommand
+      "transfer": (from: string, to: string, amount: number) => ICommandBuilder<ICapabilities> & IPactCommand
     }
   }
 }`
@@ -74,11 +74,11 @@ declare module '@kadena/client' {
     const expected =
       `import type { ICommandBuilder, IPactCommand } from '@kadena/client';
 declare module '@kadena/client' {
-  export type IModuleWithDashesCaps = {
+  export interface ICapabilities {
   }
   export interface IPactModules {
     "module-with-dashes": {
-      "transfer": (from: string, to: string, amount: any) => ICommandBuilder<IModuleWithDashesCaps> & IPactCommand
+      "transfer": (from: string, to: string, amount: any) => ICommandBuilder<ICapabilities> & IPactCommand
     }
   }
 }`
@@ -129,10 +129,10 @@ declare module '@kadena/client' {
     const expected =
       `import type { ICommandBuilder, IPactCommand } from '@kadena/client';
 declare module '@kadena/client' {
-  export type ITheFreeModuleCaps = { }
+  export interface ICapabilities { }
   export interface IPactModules {
     "free-namespace.the-free-module": {
-      "transfer": (from: string, to: string, amount: number) => ICommandBuilder<ITheFreeModuleCaps> & IPactCommand
+      "transfer": (from: string, to: string, amount: number) => ICommandBuilder<ICapabilities> & IPactCommand
     }
   }
 }`
@@ -141,4 +141,36 @@ declare module '@kadena/client' {
         .join(' ');
     expect(dTs).toBe(expected);
   });
+});
+
+it('creates a typescript definition with DEFCAPS from a namespaced contract', () => {
+  const contract: string = `(namespace 'free-namespace)
+    (module the-free-module
+    (defun transfer:string (from:string to:string amount:decimal))
+    (defcap GAS ())
+    (defcap TRANSFER (sender:string receiver:string amount:decimal))
+  )`;
+  const parsedContract = new StringContractDefinition(contract);
+  const dTs = generateDts(parsedContract.modulesWithFunctions)
+    .get('the-free-module')!
+    .split(/[\s\n]/)
+    .filter((x) => x !== '')
+    .join(' ');
+  const expected =
+    `import type { ICommandBuilder, IPactCommand } from '@kadena/client';
+declare module '@kadena/client' {
+export interface ICapabilities {
+  "free-namespace.the-free-module.GAS": [ ],
+  "free-namespace.the-free-module.TRANSFER": [ sender: string, receiver: string, amount: number ]
+}
+export interface IPactModules {
+  "free-namespace.the-free-module": {
+    "transfer": (from: string, to: string, amount: number) => ICommandBuilder<ICapabilities> & IPactCommand
+  }
+}
+}`
+      .split(/[\s\n]/)
+      .filter((x) => x !== '')
+      .join(' ');
+  expect(dTs).toBe(expected);
 });

--- a/packages/tools/pactjs-cli/src/contract-generate/index.ts
+++ b/packages/tools/pactjs-cli/src/contract-generate/index.ts
@@ -12,6 +12,7 @@ const TARGET_PACKAGE: '.kadena/pactjs-generated' =
 interface IContractGenerateOptions {
   file: string;
   clean: boolean;
+  capsInterface: string | undefined;
 }
 
 const shallowFindFile = (path: string, file: string): string | undefined => {
@@ -56,6 +57,7 @@ const generate =
     );
     const moduleDtss: Map<string, string> = generateDts(
       pactModule.modulesWithFunctions,
+      args.capsInterface,
     );
 
     // walk up in file tree from process.cwd() to get the package.json
@@ -162,6 +164,11 @@ export function contractGenerateCommand(
     .command('contract-generate')
     .description('Generate client based on a contract')
     .option('-c, --clean', 'Clean existing generated files')
+    .option(
+      '-i, --caps-interface',
+      'Custom name for the interface of the caps. ' +
+        'Can be used to create a type definition with a limited set of capabilities.',
+    )
     .option('-f, --file <file>', 'Generate d.ts from Pact contract file')
     .action((args: IContractGenerateOptions) => {
       generate(program, version)(args);


### PR DESCRIPTION
## Reason:

Merge generated types for capabilities across modules so you can also have access to types for capabilities defined in other modules   

Closes https://github.com/kadena-community/kadena.js/issues/137


## Check off the following:

- [X] I have reviewed my changes and run the appropriate tests.
- [X] I have have run `rush change` to add the appropriate change logs.
- [X] I have added/edited docs.
- [X] I have added tutorials.
- [X] I have double checked and DEFINITELY added docs.

