### PR TITLE
[apps/graph-client] Add recent blocks to UI

### DIFF
--- a/packages/apps/graph-client/src/pages/index.tsx
+++ b/packages/apps/graph-client/src/pages/index.tsx
@@ -1,4 +1,7 @@
-import { useGetBlocksSubscription } from '../__generated__/sdk';
+import {
+  useGetBlocksSubscription,
+  useGetRecentHeightsQuery,
+} from '../__generated__/sdk';
 import { ChainwebGraph } from '../components/chainweb';
 import { Text } from '../components/text';
 import { styled } from '../styles/stitches.config';
@@ -18,20 +21,32 @@ const StyledMain: any = styled('main', {
 });
 
 export default function Home(): JSX.Element {
-  const { loading, data } = useGetBlocksSubscription();
-  const previousData = usePrevious(data);
+  const { loading: loadingNewBlocks, data: newBlocks } =
+    useGetBlocksSubscription();
+  const { loading: loadingRecentBlocks, data: recentBlocks } =
+    useGetRecentHeightsQuery({ variables: { count: 3 } });
+  const previousNewBlocks = usePrevious(newBlocks);
+  const previousRecentBlocks = usePrevious(recentBlocks);
 
   const { allBlocks, addBlocks } = useParsedBlocks();
 
   useEffect(() => {
     if (
-      isEqual(previousData, data) === false &&
-      data?.newBlocks &&
-      data?.newBlocks?.length > 0
+      isEqual(previousNewBlocks, newBlocks) === false &&
+      newBlocks?.newBlocks &&
+      newBlocks?.newBlocks?.length > 0
     ) {
-      addBlocks(data?.newBlocks);
+      addBlocks(newBlocks?.newBlocks);
     }
-  }, [data]);
+
+    if (
+      isEqual(previousRecentBlocks, recentBlocks) === false &&
+      recentBlocks?.blocks &&
+      recentBlocks?.blocks?.length > 0
+    ) {
+      addBlocks(recentBlocks?.blocks);
+    }
+  }, [newBlocks, recentBlocks]);
 
   return (
     <div>
@@ -49,7 +64,11 @@ export default function Home(): JSX.Element {
         </Text>
 
         <div>
-          {loading ? 'Loading...' : <ChainwebGraph blocks={allBlocks} />}
+          {loadingRecentBlocks || loadingNewBlocks ? (
+            'Loading...'
+          ) : (
+            <ChainwebGraph blocks={allBlocks} />
+          )}
         </div>
       </StyledMain>
     </div>

--- a/packages/apps/graph-client/src/pages/index.tsx
+++ b/packages/apps/graph-client/src/pages/index.tsx
@@ -38,7 +38,9 @@ export default function Home(): JSX.Element {
     ) {
       addBlocks(newBlocks?.newBlocks);
     }
+  }, [newBlocks]);
 
+  useEffect(() => {
     if (
       isEqual(previousRecentBlocks, recentBlocks) === false &&
       recentBlocks?.blocks &&
@@ -46,7 +48,7 @@ export default function Home(): JSX.Element {
     ) {
       addBlocks(recentBlocks?.blocks);
     }
-  }, [newBlocks, recentBlocks]);
+  }, [recentBlocks]);
 
   return (
     <div>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 
Can you please fill out the information below to save us time looking into your PR. 
Start with explaining the reasons for this change, and if applicable link to an issue.
And explain the changes you have made.
-->

## Reason:

A new feature that allows users to retrieve recent blocks for a number of rows was released. This PR utilizes that functionality to fill in the some rows in the graph-client with blocks from before the new block subscription started so that there are no missing blocks in the starting rows 

## Changes made (preferably with images/screenshots):

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/9022549/212851697-4b2e4abd-415d-4f5d-8500-720d00b8145c.png">


