### PR TITLE
ag/feat eslint relax react typedef var

### DIFF
--- a/common/changes/@kadena-dev/eslint-config/ag-feat-eslint-relax-react-typedef-var_2023-02-27-11-03.json
+++ b/common/changes/@kadena-dev/eslint-config/ag-feat-eslint-relax-react-typedef-var_2023-02-27-11-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/eslint-config",
+      "comment": "Move eslint-plugins from devDependencies to dependencies so consuming projects do not need to include them",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kadena-dev/eslint-config"
+}

--- a/common/changes/@kadena-dev/eslint-config/ag-feat-eslint-relax-react-typedef-var_2023-02-27-12-57.json
+++ b/common/changes/@kadena-dev/eslint-config/ag-feat-eslint-relax-react-typedef-var_2023-02-27-12-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/eslint-config",
+      "comment": "Disables @rushstack/typedev-var and adds @kadena-dev/typedev-var to the react config",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kadena-dev/eslint-config"
+}

--- a/common/changes/@kadena-dev/eslint-plugin/ag-feat-eslint-relax-react-typedef-var_2023-02-27-12-57.json
+++ b/common/changes/@kadena-dev/eslint-plugin/ag-feat-eslint-relax-react-typedef-var_2023-02-27-12-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/eslint-plugin",
+      "comment": "Adds typedev-var that allows implicit types when created from a function call",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kadena-dev/eslint-plugin"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -671,7 +671,6 @@ importers:
 
   ../../packages/tools/eslint-config:
     specifiers:
-      '@kadena-dev/eslint-config': workspace:*
       '@kadena-dev/eslint-plugin': workspace:*
       '@rushstack/eslint-config': ~2.6.2
       '@typescript-eslint/eslint-plugin': ^5.23.0
@@ -686,7 +685,6 @@ importers:
       eslint-plugin-react: 7.31.11_eslint@8.29.0
       eslint-plugin-simple-import-sort: 7.0.0_eslint@8.29.0
     devDependencies:
-      '@kadena-dev/eslint-config': 'link:'
       '@kadena-dev/eslint-plugin': link:../eslint-plugin
       '@rushstack/eslint-config': 2.6.2_eslint@8.29.0+typescript@4.6.4
       eslint: 8.29.0

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -682,14 +682,14 @@ importers:
       typescript: ~4.6.3
     dependencies:
       '@typescript-eslint/eslint-plugin': 5.46.0_eslint@8.29.0+typescript@4.6.4
+      eslint-plugin-import: 2.26.0_eslint@8.29.0
+      eslint-plugin-react: 7.31.11_eslint@8.29.0
+      eslint-plugin-simple-import-sort: 7.0.0_eslint@8.29.0
     devDependencies:
       '@kadena-dev/eslint-config': 'link:'
       '@kadena-dev/eslint-plugin': link:../eslint-plugin
       '@rushstack/eslint-config': 2.6.2_eslint@8.29.0+typescript@4.6.4
       eslint: 8.29.0
-      eslint-plugin-import: 2.26.0_eslint@8.29.0
-      eslint-plugin-react: 7.31.11_eslint@8.29.0
-      eslint-plugin-simple-import-sort: 7.0.0_eslint@8.29.0
       typescript: 4.6.4
 
   ../../packages/tools/eslint-plugin:
@@ -7028,7 +7028,6 @@ packages:
       eslint: '>=5.0.0'
     dependencies:
       eslint: 8.29.0
-    dev: true
 
   /eslint-plugin-tsdoc/0.2.17:
     resolution: {integrity: sha512-xRmVi7Zx44lOBuYqG8vzTXuL6IdGOeF9nHX17bjJ8+VE6fsxpdGem0/SBTmAwgYMKYB1WBkqRJVQ+n8GK041pA==}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -692,23 +692,21 @@ importers:
 
   ../../packages/tools/eslint-plugin:
     specifiers:
+      '@rushstack/eslint-plugin': ~0.11.0
       '@rushstack/heft': ~0.46.1
+      '@typescript-eslint/experimental-utils': ~5.53.0
       eslint: ^8.15.0
       eslint-module-utils: ^2.7.1
-      eslint-plugin-import: ^2.26.0
-      eslint-plugin-react: ~7.31.11
-      eslint-plugin-simple-import-sort: ~7.0.0
       is-core-module: ^2.8.0
       typescript: ~4.6.3
     dependencies:
+      '@typescript-eslint/experimental-utils': 5.53.0_eslint@8.29.0+typescript@4.6.4
       eslint-module-utils: 2.7.4_eslint@8.29.0
       is-core-module: 2.11.0
     devDependencies:
+      '@rushstack/eslint-plugin': 0.11.0_eslint@8.29.0+typescript@4.6.4
       '@rushstack/heft': 0.46.7
       eslint: 8.29.0
-      eslint-plugin-import: 2.26.0_eslint@8.29.0
-      eslint-plugin-react: 7.31.11_eslint@8.29.0
-      eslint-plugin-simple-import-sort: 7.0.0_eslint@8.29.0
       typescript: 4.6.4
 
   ../../packages/tools/heft-rig:
@@ -3485,6 +3483,19 @@ packages:
       - typescript
     dev: true
 
+  /@rushstack/eslint-plugin/0.11.0_eslint@8.29.0+typescript@4.6.4:
+    resolution: {integrity: sha512-e8eVBOgb/xkpkgFmPP+oifrqCLh8I5BFI/emB/nf5+WnuS4hsTHkgprCEiJuvkhJRypsWrbchkIda9/1YFadxg==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.2.4
+      '@typescript-eslint/experimental-utils': 5.38.1_eslint@8.29.0+typescript@4.6.4
+      eslint: 8.29.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@rushstack/eslint-plugin/0.9.1_eslint@8.29.0:
     resolution: {integrity: sha512-iMfRyk9FE1xdhuenIYwDEjJ67u7ygeFw/XBGJC2j4GHclznHWRfSGiwTeYZ66H74h7NkVTuTp8RYw/x2iDblOA==}
     peerDependencies:
@@ -4205,6 +4216,32 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/experimental-utils/5.38.1_eslint@8.29.0+typescript@4.6.4:
+    resolution: {integrity: sha512-Zv0EcU0iu64DiVG3pRZU0QYCgANO//U1fS3oEs3eqHD1eIVVcQsFd/T01ckaNbL2H2aCqRojY2xZuMAPcOArEA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@typescript-eslint/utils': 5.38.1_eslint@8.29.0+typescript@4.6.4
+      eslint: 8.29.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/experimental-utils/5.53.0_eslint@8.29.0+typescript@4.6.4:
+    resolution: {integrity: sha512-4SklZEwRn0jqkhtW+pPZpbKFXprwGneBndRM0TGzJu/LWdb9QV2hBgFIVU9AREo02BzqFvyG/ypd+xAW5YGhXw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@typescript-eslint/utils': 5.53.0_eslint@8.29.0+typescript@4.6.4
+      eslint: 8.29.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
   /@typescript-eslint/parser/4.33.0_eslint@8.29.0+typescript@4.6.4:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4340,12 +4377,28 @@ packages:
       '@typescript-eslint/visitor-keys': 5.20.0
     dev: true
 
+  /@typescript-eslint/scope-manager/5.38.1:
+    resolution: {integrity: sha512-BfRDq5RidVU3RbqApKmS7RFMtkyWMM50qWnDAkKgQiezRtLKsoyRKIvz1Ok5ilRWeD9IuHvaidaLxvGx/2eqTQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.38.1
+      '@typescript-eslint/visitor-keys': 5.38.1
+    dev: true
+
   /@typescript-eslint/scope-manager/5.46.0:
     resolution: {integrity: sha512-7wWBq9d/GbPiIM6SqPK9tfynNxVbfpihoY5cSFMer19OYUA3l4powA2uv0AV2eAZV6KoAh6lkzxv4PoxOLh1oA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.46.0
       '@typescript-eslint/visitor-keys': 5.46.0
+
+  /@typescript-eslint/scope-manager/5.53.0:
+    resolution: {integrity: sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.53.0
+      '@typescript-eslint/visitor-keys': 5.53.0
+    dev: false
 
   /@typescript-eslint/type-utils/5.20.0_eslint@8.29.0:
     resolution: {integrity: sha512-WxNrCwYB3N/m8ceyoGCgbLmuZwupvzN0rE8NBuwnl7APgjv24ZJIjkNzoFBXPRCGzLNkoU/WfanW0exvp/+3Iw==}
@@ -4432,9 +4485,19 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /@typescript-eslint/types/5.38.1:
+    resolution: {integrity: sha512-QTW1iHq1Tffp9lNfbfPm4WJabbvpyaehQ0SrvVK2yfV79SytD9XDVxqiPvdrv2LK7DGSFo91TB2FgWanbJAZXg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
   /@typescript-eslint/types/5.46.0:
     resolution: {integrity: sha512-wHWgQHFB+qh6bu0IAPAJCdeCdI0wwzZnnWThlmHNY01XJ9Z97oKqKOzWYpR2I83QmshhQJl6LDM9TqMiMwJBTw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  /@typescript-eslint/types/5.53.0:
+    resolution: {integrity: sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: false
 
   /@typescript-eslint/typescript-estree/4.33.0_typescript@4.6.4:
     resolution: {integrity: sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==}
@@ -4519,6 +4582,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree/5.38.1_typescript@4.6.4:
+    resolution: {integrity: sha512-99b5e/Enoe8fKMLdSuwrfH/C0EIbpUWmeEKHmQlGZb8msY33qn1KlkFww0z26o5Omx7EVjzVDCWEfrfCDHfE7g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.38.1
+      '@typescript-eslint/visitor-keys': 5.38.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.6.4
+      typescript: 4.6.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree/5.46.0_typescript@4.6.4:
     resolution: {integrity: sha512-kDLNn/tQP+Yp8Ro2dUpyyVV0Ksn2rmpPpB0/3MO874RNmXtypMwSeazjEN/Q6CTp8D7ExXAAekPEcCEB/vtJkw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4556,6 +4640,27 @@ packages:
       semver: 7.3.8
       tsutils: 3.21.0_typescript@4.9.4
       typescript: 4.9.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/typescript-estree/5.53.0_typescript@4.6.4:
+    resolution: {integrity: sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.53.0
+      '@typescript-eslint/visitor-keys': 5.53.0
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.6.4
+      typescript: 4.6.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4614,6 +4719,24 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils/5.38.1_eslint@8.29.0+typescript@4.6.4:
+    resolution: {integrity: sha512-oIuUiVxPBsndrN81oP8tXnFa/+EcZ03qLqPDfSZ5xIJVm7A9V0rlkQwwBOAGtrdN70ZKDlKv+l1BeT4eSFxwXA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@typescript-eslint/scope-manager': 5.38.1
+      '@typescript-eslint/types': 5.38.1
+      '@typescript-eslint/typescript-estree': 5.38.1_typescript@4.6.4
+      eslint: 8.29.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.29.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/utils/5.46.0_eslint@8.29.0+typescript@4.6.4:
     resolution: {integrity: sha512-4O+Ps1CRDw+D+R40JYh5GlKLQERXRKW5yIQoNDpmXPJ+C7kaPF9R7GWl+PxGgXjB3PQCqsaaZUpZ9dG4U6DO7g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4633,6 +4756,26 @@ packages:
       - supports-color
       - typescript
 
+  /@typescript-eslint/utils/5.53.0_eslint@8.29.0+typescript@4.6.4:
+    resolution: {integrity: sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.53.0
+      '@typescript-eslint/types': 5.53.0
+      '@typescript-eslint/typescript-estree': 5.53.0_typescript@4.6.4
+      eslint: 8.29.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.29.0
+      semver: 7.3.8
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: false
+
   /@typescript-eslint/visitor-keys/4.33.0:
     resolution: {integrity: sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==}
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
@@ -4649,12 +4792,28 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
+  /@typescript-eslint/visitor-keys/5.38.1:
+    resolution: {integrity: sha512-bSHr1rRxXt54+j2n4k54p4fj8AHJ49VDWtjpImOpzQj4qjAiOpPni+V1Tyajh19Api1i844F757cur8wH3YvOA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.38.1
+      eslint-visitor-keys: 3.3.0
+    dev: true
+
   /@typescript-eslint/visitor-keys/5.46.0:
     resolution: {integrity: sha512-E13gBoIXmaNhwjipuvQg1ByqSAu/GbEpP/qzFihugJ+MomtoJtFAJG/+2DRPByf57B863m0/q7Zt16V9ohhANw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.46.0
       eslint-visitor-keys: 3.3.0
+
+  /@typescript-eslint/visitor-keys/5.53.0:
+    resolution: {integrity: sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.53.0
+      eslint-visitor-keys: 3.3.0
+    dev: false
 
   /@webassemblyjs/ast/1.11.1:
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
@@ -7026,6 +7185,7 @@ packages:
       eslint: '>=5.0.0'
     dependencies:
       eslint: 8.29.0
+    dev: false
 
   /eslint-plugin-tsdoc/0.2.17:
     resolution: {integrity: sha512-xRmVi7Zx44lOBuYqG8vzTXuL6IdGOeF9nHX17bjJ8+VE6fsxpdGem0/SBTmAwgYMKYB1WBkqRJVQ+n8GK041pA==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "9986788fb2256446570a116513ae9ea8c6711582",
+  "pnpmShrinkwrapHash": "8b51c3306be744247c1cc774db6ac81749d2da63",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "8b51c3306be744247c1cc774db6ac81749d2da63",
+  "pnpmShrinkwrapHash": "1f2de684070dcf5b7b14a1c3aeb94b8165cbb8c9",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "ba8b267af803a5ec6df145e148a5a9f8ae2b3ba7",
+  "pnpmShrinkwrapHash": "9986788fb2256446570a116513ae9ea8c6711582",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/apps/explorer/.eslintrc.js
+++ b/packages/apps/explorer/.eslintrc.js
@@ -4,9 +4,8 @@ require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
   extends: [
+    'plugin:@next/next/recommended',
     '@kadena-dev/eslint-config/profile/react',
-    'eslint-config-next',
-    'eslint-config-prettier',
   ],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/apps/explorer/.eslintrc.js
+++ b/packages/apps/explorer/.eslintrc.js
@@ -3,9 +3,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: [
-    'plugin:@next/next/recommended',
-    '@kadena-dev/eslint-config/profile/react',
-  ],
+  extends: ['next/core-web-vitals', '@kadena-dev/eslint-config/profile/react'],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/apps/graph-client/.eslintrc.js
+++ b/packages/apps/graph-client/.eslintrc.js
@@ -2,9 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: [
-    'plugin:@next/next/recommended',
-    '@kadena-dev/eslint-config/profile/react',
-  ],
+  extends: ['next/core-web-vitals', '@kadena-dev/eslint-config/profile/react'],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/apps/graph-client/.eslintrc.js
+++ b/packages/apps/graph-client/.eslintrc.js
@@ -2,9 +2,9 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@kadena-dev/eslint-config/profile/react'],
+  extends: [
+    'plugin:@next/next/recommended',
+    '@kadena-dev/eslint-config/profile/react',
+  ],
   parserOptions: { tsconfigRootDir: __dirname },
-  rules: {
-    '@rushstack/typedef-var': 'off',
-  },
 };

--- a/packages/apps/graph/.eslintrc.js
+++ b/packages/apps/graph/.eslintrc.js
@@ -2,6 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['plugin:@next/next/recommended', '@kadena-dev/eslint-config/profile/lib'],
+  extends: ['@kadena-dev/eslint-config/profile/lib'],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/apps/graph/.eslintrc.js
+++ b/packages/apps/graph/.eslintrc.js
@@ -2,6 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@kadena-dev/eslint-config/profile/lib'],
+  extends: ['plugin:@next/next/recommended', '@kadena-dev/eslint-config/profile/lib'],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/tools/eslint-config/.eslintrc.js
+++ b/packages/tools/eslint-config/.eslintrc.js
@@ -2,6 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@kadena-dev/eslint-config/profile/lib'],
+  extends: ['./profile/lib'],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/tools/eslint-config/package.json
+++ b/packages/tools/eslint-config/package.json
@@ -11,16 +11,16 @@
     "test": ""
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.23.0"
+    "@typescript-eslint/eslint-plugin": "^5.23.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-react": "~7.31.11",
+    "eslint-plugin-simple-import-sort": "~7.0.0"
   },
   "devDependencies": {
     "@kadena-dev/eslint-config": "workspace:*",
     "@kadena-dev/eslint-plugin": "workspace:*",
     "@rushstack/eslint-config": "~2.6.2",
     "eslint": "^8.15.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-react": "~7.31.11",
-    "eslint-plugin-simple-import-sort": "~7.0.0",
     "typescript": "~4.6.3"
   }
 }

--- a/packages/tools/eslint-config/package.json
+++ b/packages/tools/eslint-config/package.json
@@ -17,7 +17,6 @@
     "eslint-plugin-simple-import-sort": "~7.0.0"
   },
   "devDependencies": {
-    "@kadena-dev/eslint-config": "workspace:*",
     "@kadena-dev/eslint-plugin": "workspace:*",
     "@rushstack/eslint-config": "~2.6.2",
     "eslint": "^8.15.0",

--- a/packages/tools/eslint-config/profile/react.js
+++ b/packages/tools/eslint-config/profile/react.js
@@ -2,6 +2,13 @@ module.exports = {
   root: true,
   extends: ['./lib', 'plugin:react/recommended'],
   plugins: ['import', 'simple-import-sort', 'react'],
+  rules: {
+    '@rushstack/typedef-var': 'off',
+    // @kadena-dev/typedef-var allows for inferred types in exported constants
+    //  when they are created by a function call.
+    //  e.g. This is allowed: `export const StyledButton = styled('button', {})`
+    '@kadena-dev/typedef-var': ['warn'],
+  },
   // rules: {
   //   '@typescript-eslint/explicit-function-return-type': {
   //     allowExpressions: true,

--- a/packages/tools/eslint-config/profile/react.js
+++ b/packages/tools/eslint-config/profile/react.js
@@ -7,8 +7,9 @@ module.exports = {
     // @kadena-dev/typedef-var allows for inferred types in exported constants
     //  when they are created by a function call.
     //  e.g. This is allowed: `export const StyledButton = styled('button', {})`
-    '@kadena-dev/typedef-var': ['warn'],
+    '@kadena-dev/typedef-var': 'warn',
   },
+
   // rules: {
   //   '@typescript-eslint/explicit-function-return-type': {
   //     allowExpressions: true,

--- a/packages/tools/eslint-plugin/package.json
+++ b/packages/tools/eslint-plugin/package.json
@@ -19,15 +19,14 @@
     ]
   },
   "dependencies": {
+    "@typescript-eslint/experimental-utils": "~5.53.0",
     "eslint-module-utils": "^2.7.1",
     "is-core-module": "^2.8.0"
   },
   "devDependencies": {
+    "@rushstack/eslint-plugin": "~0.11.0",
     "@rushstack/heft": "~0.46.1",
     "eslint": "^8.15.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-react": "~7.31.11",
-    "eslint-plugin-simple-import-sort": "~7.0.0",
     "typescript": "~4.6.3"
   }
 }

--- a/packages/tools/eslint-plugin/src/index.js
+++ b/packages/tools/eslint-plugin/src/index.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
     ['no-eslint-disable']: require('./rules/no-eslint-disable'),
+    ['typedef-var']: require('./rules/typedef-var'),
   },
 };

--- a/packages/tools/eslint-plugin/src/rules/typedef-var.js
+++ b/packages/tools/eslint-plugin/src/rules/typedef-var.js
@@ -1,6 +1,6 @@
 /* eslint-env es6 */
 const { rules } = require('@rushstack/eslint-plugin');
-const AST_NODE_TYPES = require('@typescript-eslint/experimental-utils');
+const { AST_NODE_TYPES } = require('@typescript-eslint/experimental-utils');
 
 const origTypedefVar = rules['typedef-var'];
 

--- a/packages/tools/eslint-plugin/src/rules/typedef-var.js
+++ b/packages/tools/eslint-plugin/src/rules/typedef-var.js
@@ -1,0 +1,119 @@
+/* eslint-env es6 */
+const { rules } = require('@rushstack/eslint-plugin');
+const AST_NODE_TYPES = require('@typescript-eslint/experimental-utils');
+
+const origTypedefVar = rules['typedef-var'];
+
+const typedefVar = {
+  ...origTypedefVar,
+  // We are overriding the behavior to allow for implicit typing of exported
+  //   variables that are created by calling a function
+  //  e.g. This is allowed: `export const StyledButton = styled('button', {})`
+  create: (context) => {
+    // This rule implements the variableDeclarationIgnoreFunction=true behavior from
+    function isVariableDeclarationIgnoreFunction(node) {
+      return (
+        node.type === AST_NODE_TYPES.FunctionExpression ||
+        node.type === AST_NODE_TYPES.ArrowFunctionExpression
+      );
+    }
+
+    function getNodeName(node) {
+      return node.type === AST_NODE_TYPES.Identifier ? node.name : undefined;
+    }
+
+    return {
+      VariableDeclarator(node) {
+        if (node.id.typeAnnotation) {
+          // An explicit type declaration was provided
+          return;
+        }
+
+        if (node.init?.type === 'CallExpression') {
+          // The variable is declared by a function call
+          return;
+        }
+
+        // These are @typescript-eslint/typedef exemptions
+        if (
+          node.id.type ===
+            AST_NODE_TYPES.ArrayPattern /* ArrayDestructuring */ ||
+          node.id.type ===
+            AST_NODE_TYPES.ObjectPattern /* ObjectDestructuring */ ||
+          (node.init && isVariableDeclarationIgnoreFunction(node.init))
+        ) {
+          return;
+        }
+
+        // Ignore this case:
+        //
+        //   for (const NODE of thing) { }
+        let current = node.parent;
+        while (current) {
+          switch (current.type) {
+            case AST_NODE_TYPES.VariableDeclaration:
+              // Keep looking upwards
+              current = current.parent;
+              break;
+            case AST_NODE_TYPES.ForOfStatement:
+            case AST_NODE_TYPES.ForInStatement:
+              // Stop traversing and don't report an error
+              return;
+            default:
+              // Stop traversing
+              current = undefined;
+              break;
+          }
+        }
+
+        // Is it a local variable?
+        current = node.parent;
+        while (current) {
+          switch (current.type) {
+            // function f() {
+            //   const NODE = 123;
+            // }
+            case AST_NODE_TYPES.FunctionDeclaration:
+
+            // class C {
+            //   public m(): void {
+            //     const NODE = 123;
+            //   }
+            // }
+            case AST_NODE_TYPES.MethodDefinition:
+
+            // let f = function() {
+            //   const NODE = 123;
+            // }
+            case AST_NODE_TYPES.FunctionExpression:
+
+            // let f = () => {
+            //   const NODE = 123;
+            // }
+            case AST_NODE_TYPES.ArrowFunctionExpression:
+              // Stop traversing and don't report an error
+              return;
+          }
+
+          current = current.parent;
+        }
+
+        const nodeName = getNodeName(node.id);
+        if (nodeName) {
+          context.report({
+            node,
+            messageId: 'expected-typedef-named',
+            data: { name: nodeName },
+          });
+        } else {
+          context.report({
+            node,
+            messageId: 'expected-typedef',
+          });
+        }
+      },
+    };
+  },
+};
+
+module.exports = typedefVar;

--- a/rush.json
+++ b/rush.json
@@ -532,7 +532,6 @@
     {
       "packageName": "@kadena-dev/eslint-config",
       "projectFolder": "packages/tools/eslint-config",
-      "cyclicDependencyProjects": ["@kadena-dev/eslint-config"],
       "tags": ["tools"],
       "shouldPublish": true
     },


### PR DESCRIPTION
- fix(eslint-config): move devDependencies to dependencies
- fix(eslint-config): remove @kadena/eslint-config from devDependencies
- feat(eslint-plugin): create new typedef-var to allow implicitly typed variables from function calls
