### PR TITLE
feat(@kadena/ui): Add design system defined spacing to component library

### DIFF
--- a/common/changes/@kadena/react-components/feat-design-system-spacing_2023-03-31-09-33.json
+++ b/common/changes/@kadena/react-components/feat-design-system-spacing_2023-03-31-09-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/react-components",
+      "comment": "Added design system defined spacing tokens",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kadena/react-components"
+}

--- a/packages/libs/react-components/src/components/Stack/Stack.tsx
+++ b/packages/libs/react-components/src/components/Stack/Stack.tsx
@@ -57,57 +57,30 @@ const FlexContainer = styled('div', {
     spacing: {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       '2xs': {
-        gap: '$1',
+        gap: '$2xs',
       },
       xs: {
-        gap: '$2',
+        gap: '$xs',
       },
       sm: {
         gap: '$3',
       },
       md: {
-        gap: '$4',
+        gap: '$md',
       },
       lg: {
-        gap: '$6',
+        gap: '$lg',
       },
       xl: {
-        gap: '$7',
-        '@xl': {
-          gap: '$8',
-        },
-        '@2xl': {
-          gap: '$11',
-        },
+        gap: '$xl',
       },
       // eslint-disable-next-line @typescript-eslint/naming-convention
       '2xl': {
-        gap: '$9',
-        '@lg': {
-          gap: '$10',
-        },
-        '@xl': {
-          gap: '$13',
-        },
-        '@2xl': {
-          gap: '$17',
-        },
+        gap: '$2xl',
       },
       // eslint-disable-next-line @typescript-eslint/naming-convention
       '3xl': {
-        gap: '$10',
-        '@md': {
-          gap: '$12',
-        },
-        '@lg': {
-          gap: '$15',
-        },
-        '@xl': {
-          gap: '$15',
-        },
-        '@2xl': {
-          gap: '$25',
-        },
+        gap: '$3xl',
       },
     },
   },

--- a/packages/libs/react-components/src/styles/baseGlobalStyles.ts
+++ b/packages/libs/react-components/src/styles/baseGlobalStyles.ts
@@ -66,6 +66,38 @@ export const baseGlobalStyles: Record<string, unknown> = {
   /*
     Kadena Design System
   */
+
+  // Spacing
+  ':root': {
+    '$spacing-2xs': '$sizes$1',
+    '$spacing-xs': '$sizes$2',
+    '$spacing-sm': '$sizes$3',
+    '$spacing-md': '$sizes$4',
+    '$spacing-lg': '$sizes$6',
+    '$spacing-xl': '$sizes$7',
+    '$spacing-2xl': '$sizes$9',
+    '$spacing-3xl': '$sizes$10',
+
+    '@md': {
+      '$spacing-3xl': '$sizes$12',
+    },
+    '@lg': {
+      '$spacing-2xl': '$sizes$10',
+      '$spacing-3xl': '$sizes$15',
+    },
+    '@xl': {
+      '$spacing-xl': '$sizes$8',
+      '$spacing-2xl': '$sizes$13',
+      '$spacing-3xl': '$sizes$20',
+    },
+    '@2xl': {
+      '$spacing-xl': '$sizes$11',
+      '$spacing-2xl': '$sizes$17',
+      '$spacing-3xl': '$sizes$25',
+    },
+  },
+
+  // Typography
   h1: {
     fontSize: '$5xl',
     '@md': {

--- a/packages/libs/react-components/src/styles/stitches.config.ts
+++ b/packages/libs/react-components/src/styles/stitches.config.ts
@@ -33,6 +33,15 @@ const sizes: Record<string, string> = {
   48: '12rem', // 192px
   56: '14rem', // 224px
   64: '16rem', // 256px
+  // NOTE: These are defined in global styles and vary in size depending on breakpoints
+  '2xs': 'var(--spacing-2xs)',
+  xs: 'var(--spacing-xs)',
+  sm: 'var(--spacing-sm)',
+  md: 'var(--spacing-md)',
+  lg: 'var(--spacing-lg)',
+  xl: 'var(--spacing-xl)',
+  '2xl': 'var(--spacing-2xl)',
+  '3xl': 'var(--spacing-3xl)',
 };
 
 export const {

--- a/packages/libs/react-components/src/styles/stitches.config.ts
+++ b/packages/libs/react-components/src/styles/stitches.config.ts
@@ -33,7 +33,6 @@ const sizes: Record<string, string> = {
   48: '12rem', // 192px
   56: '14rem', // 224px
   64: '16rem', // 256px
-
   // NOTE: These are defined in global styles and vary in size depending on breakpoints
   // See: https://github.com/stitchesjs/stitches/discussions/284
   '2xs': 'var(--spacing-2xs)',

--- a/packages/libs/react-components/src/styles/stitches.config.ts
+++ b/packages/libs/react-components/src/styles/stitches.config.ts
@@ -33,7 +33,9 @@ const sizes: Record<string, string> = {
   48: '12rem', // 192px
   56: '14rem', // 224px
   64: '16rem', // 256px
+
   // NOTE: These are defined in global styles and vary in size depending on breakpoints
+  // See: https://github.com/stitchesjs/stitches/discussions/284
   '2xs': 'var(--spacing-2xs)',
   xs: 'var(--spacing-xs)',
   sm: 'var(--spacing-sm)',


### PR DESCRIPTION
## Reason:

We were not able to access design system defined spacing outside of the stack component since it depends on breakpoints. This workaround allows us to assign tokens that change depending on the breakpoint. 

## Changes made (preferably with images/screenshots):

Defined new variables in the global styles that change depending on breakpoints and referenced those variables when defining the theme tokens. This means that they should be accessible as any other space token

## Check off the following:

- [x] I have reviewed my changes and run the appropriate tests.
- [x] I have have run `rush change` to add the appropriate change logs.
- [ ] I have added/edited docs.
- [ ] I have added tutorials.
- [ ] I have double checked and DEFINITELY added docs.

