### PR TITLE
Adds a postinstall script for graph-client

### DIFF
--- a/packages/apps/graph-client/package.json
+++ b/packages/apps/graph-client/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "dev": "concurrently --kill-others \"npm:next:dev\" \"npm:start:graph\" \"sleep 3; rushx generate:sdk\"",
     "generate:sdk": "graphql-codegen --config codegen-sdk.yml -w",
+    "postinstall": "graphql-codegen --config codegen-sdk.yml",
     "lint": "next lint",
     "lint-staged": "lint-staged",
     "next:dev": "next dev",


### PR DESCRIPTION
Runs `graphql-codegen` as `postinstall` for `graph-client`, which wasn't done before. This ensures that we can build the `graph-client` properly.