### PR TITLE
[Docs] add texttransform option to typography components

### DIFF
--- a/common/changes/@kadena/react-components/feat-docs_textcomponents_2023-04-13-21-20.json
+++ b/common/changes/@kadena/react-components/feat-docs_textcomponents_2023-04-13-21-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/react-components",
+      "comment": "adding option to texttransform to the typography components",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/react-components"
+}

--- a/packages/apps/kadena-docs/src/components/Markdoc/Heading/Heading.tsx
+++ b/packages/apps/kadena-docs/src/components/Markdoc/Heading/Heading.tsx
@@ -1,18 +1,13 @@
 import { styled, SystemIcons } from '@kadena/react-components';
 
-import {
-  HeadingLevel1,
-  HeadingLevel2,
-  HeadingLevel3,
-  HeadingLevel4,
-  IHeadingLevelProps,
-} from '@/components';
-import { TagNameType } from '@/types/Layout';
+import { IHeadingLevelProps } from '@/components';
+import * as Headers from '@/components/Typography/Headers';
 import { createSlug } from '@/utils';
 import React, { FC } from 'react';
 
+type TagTypes = 1 | 2 | 3 | 4;
 interface IProp {
-  as: TagNameType;
+  as: TagTypes;
   children: string;
 }
 
@@ -34,19 +29,8 @@ const StyledLinkIcon = styled('a', {
   paddingLeft: '$3',
 });
 
-const chooseHeader = (as: string): FC<IHeadingLevelProps> => {
-  switch (as) {
-    case 'h1':
-      return HeadingLevel1;
-    case 'h2':
-      return HeadingLevel2;
-    case 'h3':
-      return HeadingLevel3;
-    case 'h4':
-      return HeadingLevel4;
-    default:
-      return HeadingLevel2;
-  }
+const chooseHeader = (as: TagTypes): FC<IHeadingLevelProps> => {
+  return Headers[`HeadingLevel${as}`];
 };
 
 export const TaggedHeading: FC<IProp> = ({ children, as }) => {

--- a/packages/apps/kadena-docs/src/components/Markdoc/Heading/Heading.tsx
+++ b/packages/apps/kadena-docs/src/components/Markdoc/Heading/Heading.tsx
@@ -1,5 +1,11 @@
-import { Heading, styled, SystemIcons } from '@kadena/react-components';
+import { styled, SystemIcons } from '@kadena/react-components';
 
+import {
+  HeadingLevel1,
+  HeadingLevel2,
+  HeadingLevel3,
+  HeadingLevel4,
+} from '@/components';
 import { TagNameType } from '@/types/Layout';
 import { createSlug } from '@/utils';
 import React, { FC } from 'react';
@@ -9,7 +15,8 @@ interface IProp {
   children: string;
 }
 
-const StyleHeader = styled(Heading, {
+const StyleHover = styled('span', {
+  background: 'green',
   a: {
     opacity: 0,
     transition: 'opacity .3s ease',
@@ -26,14 +33,33 @@ const StyledLinkIcon = styled('a', {
   paddingLeft: '$3',
 });
 
+const chooseHeader = (as: string): FC => {
+  switch (as) {
+    case 'h1':
+      return HeadingLevel1;
+    case 'h2':
+      return HeadingLevel2;
+    case 'h3':
+      return HeadingLevel3;
+    case 'h4':
+      return HeadingLevel4;
+    default:
+      return HeadingLevel2;
+  }
+};
+
 export const TaggedHeading: FC<IProp> = ({ children, as }) => {
   const slug = createSlug(children);
+  const Heading = chooseHeader(as);
+
   return (
-    <StyleHeader as={as}>
-      {children}
-      <StyledLinkIcon id={slug} href={`#${slug}`}>
-        <SystemIcons.Link />
-      </StyledLinkIcon>
-    </StyleHeader>
+    <StyleHover>
+      <Heading>
+        {children}
+        <StyledLinkIcon id={slug} href={`#${slug}`}>
+          <SystemIcons.Link />
+        </StyledLinkIcon>
+      </Heading>
+    </StyleHover>
   );
 };

--- a/packages/apps/kadena-docs/src/components/Markdoc/Heading/Heading.tsx
+++ b/packages/apps/kadena-docs/src/components/Markdoc/Heading/Heading.tsx
@@ -5,6 +5,7 @@ import {
   HeadingLevel2,
   HeadingLevel3,
   HeadingLevel4,
+  IHeadingLevelProps,
 } from '@/components';
 import { TagNameType } from '@/types/Layout';
 import { createSlug } from '@/utils';
@@ -33,7 +34,7 @@ const StyledLinkIcon = styled('a', {
   paddingLeft: '$3',
 });
 
-const chooseHeader = (as: string): FC => {
+const chooseHeader = (as: string): FC<IHeadingLevelProps> => {
   switch (as) {
     case 'h1':
       return HeadingLevel1;

--- a/packages/apps/kadena-docs/src/components/Markdoc/Paragraph/Paragraph.tsx
+++ b/packages/apps/kadena-docs/src/components/Markdoc/Paragraph/Paragraph.tsx
@@ -1,5 +1,4 @@
-import { Text } from '@kadena/react-components';
-
+import { BodyText } from '@/components/Typography';
 import React, { FC } from 'react';
 
 interface IProp {
@@ -7,5 +6,5 @@ interface IProp {
 }
 
 export const Paragraph: FC<IProp> = ({ children }) => {
-  return <Text as="p">{children}</Text>;
+  return <BodyText as="p">{children}</BodyText>;
 };

--- a/packages/apps/kadena-docs/src/components/Typography/BodyText.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/BodyText.tsx
@@ -1,0 +1,17 @@
+import { ITextProps, Text } from '@kadena/react-components';
+
+import React, { FC, ReactNode } from 'react';
+
+interface IProps {
+  children?: ReactNode;
+  as?: ITextProps['as'];
+  bold?: ITextProps['bold'];
+}
+
+export const BodyText: FC<IProps> = ({ children, as, bold }) => {
+  return (
+    <Text as={as} bold={bold}>
+      {children}
+    </Text>
+  );
+};

--- a/packages/apps/kadena-docs/src/components/Typography/Headers.ts
+++ b/packages/apps/kadena-docs/src/components/Typography/Headers.ts
@@ -1,0 +1,4 @@
+export { HeadingLevel1 } from './HeadingLevel1';
+export { HeadingLevel2 } from './HeadingLevel2';
+export { HeadingLevel3 } from './HeadingLevel3';
+export { HeadingLevel4 } from './HeadingLevel4';

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel1.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel1.tsx
@@ -1,8 +1,8 @@
-import { Heading, IHeadingProps } from '@kadena/react-components';
+import { Heading } from '@kadena/react-components';
 
 import { IHeadingLevelProps } from './types';
 
-import React, { FC, ReactNode } from 'react';
+import React, { FC } from 'react';
 
 export const HeadingLevel1: FC<IHeadingLevelProps> = ({
   children,

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel1.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel1.tsx
@@ -1,6 +1,6 @@
 import { Heading } from '@kadena/react-components';
 
-import { IHeadingLevelProps } from './types';
+import { IHeadingLevelProps } from './';
 
 import React, { FC } from 'react';
 

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel1.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel1.tsx
@@ -1,0 +1,16 @@
+import { Heading, IHeadingProps } from '@kadena/react-components';
+
+import { IHeadingLevelProps } from './types';
+
+import React, { FC, ReactNode } from 'react';
+
+export const HeadingLevel1: FC<IHeadingLevelProps> = ({
+  children,
+  bold = true,
+}) => {
+  return (
+    <Heading as="h1" variant="h1" bold={bold}>
+      {children}
+    </Heading>
+  );
+};

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel2.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel2.tsx
@@ -1,6 +1,6 @@
 import { Heading } from '@kadena/react-components';
 
-import { IHeadingLevelProps } from './types';
+import { IHeadingLevelProps } from './';
 
 import React, { FC } from 'react';
 

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel2.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel2.tsx
@@ -1,0 +1,16 @@
+import { Heading, IHeadingProps } from '@kadena/react-components';
+
+import React, { FC, ReactNode } from 'react';
+
+interface IProps {
+  children?: ReactNode;
+  bold?: IHeadingProps['bold'];
+}
+
+export const HeadingLevel2: FC<IProps> = ({ children, bold = true }) => {
+  return (
+    <Heading as="h2" variant="h2" bold={bold}>
+      {children}
+    </Heading>
+  );
+};

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel2.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel2.tsx
@@ -1,13 +1,13 @@
-import { Heading, IHeadingProps } from '@kadena/react-components';
+import { Heading } from '@kadena/react-components';
 
-import React, { FC, ReactNode } from 'react';
+import { IHeadingLevelProps } from './types';
 
-interface IProps {
-  children?: ReactNode;
-  bold?: IHeadingProps['bold'];
-}
+import React, { FC } from 'react';
 
-export const HeadingLevel2: FC<IProps> = ({ children, bold = true }) => {
+export const HeadingLevel2: FC<IHeadingLevelProps> = ({
+  children,
+  bold = true,
+}) => {
   return (
     <Heading as="h2" variant="h2" bold={bold}>
       {children}

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel3.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel3.tsx
@@ -1,0 +1,16 @@
+import { Heading, IHeadingProps } from '@kadena/react-components';
+
+import React, { FC, ReactNode } from 'react';
+
+interface IProps {
+  children?: ReactNode;
+  bold?: IHeadingProps['bold'];
+}
+
+export const HeadingLevel3: FC<IProps> = ({ children, bold = true }) => {
+  return (
+    <Heading as="h3" variant="h3" bold={bold}>
+      {children}
+    </Heading>
+  );
+};

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel3.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel3.tsx
@@ -1,6 +1,6 @@
 import { Heading } from '@kadena/react-components';
 
-import { IHeadingLevelProps } from './types';
+import { IHeadingLevelProps } from './';
 
 import React, { FC } from 'react';
 

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel3.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel3.tsx
@@ -1,13 +1,13 @@
-import { Heading, IHeadingProps } from '@kadena/react-components';
+import { Heading } from '@kadena/react-components';
 
-import React, { FC, ReactNode } from 'react';
+import { IHeadingLevelProps } from './types';
 
-interface IProps {
-  children?: ReactNode;
-  bold?: IHeadingProps['bold'];
-}
+import React, { FC } from 'react';
 
-export const HeadingLevel3: FC<IProps> = ({ children, bold = true }) => {
+export const HeadingLevel3: FC<IHeadingLevelProps> = ({
+  children,
+  bold = true,
+}) => {
   return (
     <Heading as="h3" variant="h3" bold={bold}>
       {children}

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel4.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel4.tsx
@@ -1,6 +1,6 @@
 import { Heading } from '@kadena/react-components';
 
-import { IHeadingLevelProps } from './types';
+import { IHeadingLevelProps } from './';
 
 import React, { FC } from 'react';
 

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel4.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel4.tsx
@@ -1,0 +1,16 @@
+import { Heading, IHeadingProps } from '@kadena/react-components';
+
+import React, { FC, ReactNode } from 'react';
+
+interface IProps {
+  children?: ReactNode;
+  bold?: IHeadingProps['bold'];
+}
+
+export const HeadingLevel4: FC<IProps> = ({ children, bold = true }) => {
+  return (
+    <Heading as="h4" variant="h4" bold={bold}>
+      {children}
+    </Heading>
+  );
+};

--- a/packages/apps/kadena-docs/src/components/Typography/HeadingLevel4.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/HeadingLevel4.tsx
@@ -1,13 +1,13 @@
-import { Heading, IHeadingProps } from '@kadena/react-components';
+import { Heading } from '@kadena/react-components';
 
-import React, { FC, ReactNode } from 'react';
+import { IHeadingLevelProps } from './types';
 
-interface IProps {
-  children?: ReactNode;
-  bold?: IHeadingProps['bold'];
-}
+import React, { FC } from 'react';
 
-export const HeadingLevel4: FC<IProps> = ({ children, bold = true }) => {
+export const HeadingLevel4: FC<IHeadingLevelProps> = ({
+  children,
+  bold = true,
+}) => {
   return (
     <Heading as="h4" variant="h4" bold={bold}>
       {children}

--- a/packages/apps/kadena-docs/src/components/Typography/SubBodyText.tsx
+++ b/packages/apps/kadena-docs/src/components/Typography/SubBodyText.tsx
@@ -1,0 +1,17 @@
+import { ITextProps, Text } from '@kadena/react-components';
+
+import React, { FC, ReactNode } from 'react';
+
+interface IProps {
+  children?: ReactNode;
+  as?: ITextProps['as'];
+  bold?: ITextProps['bold'];
+}
+
+export const SubBodyText: FC<IProps> = ({ children, as, bold }) => {
+  return (
+    <Text as={as} bold={bold} size="md">
+      {children}
+    </Text>
+  );
+};

--- a/packages/apps/kadena-docs/src/components/Typography/index.ts
+++ b/packages/apps/kadena-docs/src/components/Typography/index.ts
@@ -4,4 +4,4 @@ export { HeadingLevel3 } from './HeadingLevel3';
 export { HeadingLevel4 } from './HeadingLevel4';
 export { BodyText } from './BodyText';
 export { SubBodyText } from './SubBodyText';
-export { IHeadingLevelProps } from './types';
+export type { IHeadingLevelProps } from './types';

--- a/packages/apps/kadena-docs/src/components/Typography/index.ts
+++ b/packages/apps/kadena-docs/src/components/Typography/index.ts
@@ -1,7 +1,4 @@
-export { HeadingLevel1 } from './HeadingLevel1';
-export { HeadingLevel2 } from './HeadingLevel2';
-export { HeadingLevel3 } from './HeadingLevel3';
-export { HeadingLevel4 } from './HeadingLevel4';
+export * from './Headers';
 export { BodyText } from './BodyText';
 export { SubBodyText } from './SubBodyText';
 export type { IHeadingLevelProps } from './types';

--- a/packages/apps/kadena-docs/src/components/Typography/index.ts
+++ b/packages/apps/kadena-docs/src/components/Typography/index.ts
@@ -1,0 +1,7 @@
+export { HeadingLevel1 } from './HeadingLevel1';
+export { HeadingLevel2 } from './HeadingLevel2';
+export { HeadingLevel3 } from './HeadingLevel3';
+export { HeadingLevel4 } from './HeadingLevel4';
+export { BodyText } from './BodyText';
+export { SubBodyText } from './SubBodyText';
+export { IHeadingLevelProps } from './types';

--- a/packages/apps/kadena-docs/src/components/Typography/types.ts
+++ b/packages/apps/kadena-docs/src/components/Typography/types.ts
@@ -1,0 +1,8 @@
+import { IHeadingProps } from '@kadena/react-components';
+
+import { ReactNode } from 'react';
+
+export interface IHeadingLevelProps {
+  children?: ReactNode;
+  bold?: IHeadingProps['bold'];
+}

--- a/packages/apps/kadena-docs/src/components/index.ts
+++ b/packages/apps/kadena-docs/src/components/index.ts
@@ -2,3 +2,4 @@ export * from './DocsLogo';
 export * from './Footer';
 export * from './Header';
 export * from './Layout';
+export * from './Typography';

--- a/packages/apps/kadena-docs/src/markdoc/nodes/heading.markdoc.ts
+++ b/packages/apps/kadena-docs/src/markdoc/nodes/heading.markdoc.ts
@@ -21,7 +21,7 @@ const heading: Schema<Config, typeof TaggedHeading> = {
     return new Tag(
       // fix in the typing of MarkDoc.
       this.render as unknown as string,
-      { as: `h${attributes.level}` },
+      { as: attributes.level },
       children,
     );
   },

--- a/packages/apps/kadena-docs/src/pages/docs/pact/index.md
+++ b/packages/apps/kadena-docs/src/pages/docs/pact/index.md
@@ -4,9 +4,11 @@ description: How to get started with Markdoc
 layout: full
 ---
 
+# Pact
+
 ## Section 1
 
-Cookie dragée bear claw ice cream jelly beans fruitcake danish tootsie roll.
+Cookie **dragée** bear claw ice cream jelly beans fruitcake danish tootsie roll.
 Donut pastry tiramisu sesame snaps donut tootsie roll candy soufflé. Lollipop
 toffee ice cream jujubes cookie sugar plum croissant. Cookie toffee chocolate
 ice cream apple pie. Brownie gummies cupcake halvah sweet roll macaroon soufflé.

--- a/packages/libs/react-components/src/components/Typography/Heading.stories.tsx
+++ b/packages/libs/react-components/src/components/Typography/Heading.stories.tsx
@@ -1,5 +1,10 @@
 import { Heading } from './Heading';
-import { boldVariant, elementVariant, fontVariant } from './styles';
+import {
+  boldVariant,
+  elementVariant,
+  fontVariant,
+  transformVariant,
+} from './styles';
 
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
@@ -8,6 +13,9 @@ const meta: Meta<typeof Heading> = {
   title: 'Typography/Heading',
   component: Heading,
   argTypes: {
+    children: {
+      control: { type: 'text' },
+    },
     as: {
       control: { type: 'select' },
     },
@@ -23,6 +31,12 @@ const meta: Meta<typeof Heading> = {
       options: Object.keys(boldVariant) as (keyof typeof boldVariant)[],
       control: { type: 'boolean' },
     },
+    transform: {
+      options: Object.keys(
+        transformVariant,
+      ) as (keyof typeof transformVariant)[],
+      control: { type: 'radio' },
+    },
   },
 };
 
@@ -32,14 +46,22 @@ type Story = StoryObj<typeof Heading>;
 export const Primary: Story = {
   name: 'Heading',
   args: {
+    children: 'heading',
     as: 'h1',
     variant: undefined,
     font: 'main',
     bold: 'true',
+    transform: 'none',
   },
-  render: ({ font, bold, as, variant }) => (
-    <Heading font={font} bold={bold} as={as} variant={variant}>
-      Heading
+  render: ({ font, bold, as, variant, transform, children }) => (
+    <Heading
+      font={font}
+      bold={bold}
+      as={as}
+      variant={variant}
+      transform={transform}
+    >
+      {children}
     </Heading>
   ),
 };

--- a/packages/libs/react-components/src/components/Typography/Heading.tsx
+++ b/packages/libs/react-components/src/components/Typography/Heading.tsx
@@ -8,6 +8,7 @@ export interface IHeadingProps {
   variant?: VariantProps<typeof BaseText>['variant'];
   font?: VariantProps<typeof BaseText>['font'];
   bold?: VariantProps<typeof BaseText>['bold'];
+  transform?: VariantProps<typeof BaseText>['transform'];
   children: React.ReactNode;
 }
 
@@ -16,10 +17,17 @@ export const Heading: FC<IHeadingProps> = ({
   variant,
   font,
   bold,
+  transform,
   children,
 }) => {
   return (
-    <BaseText as={as} variant={variant ?? as} font={font} bold={bold}>
+    <BaseText
+      as={as}
+      variant={variant ?? as}
+      font={font}
+      bold={bold}
+      transform={transform}
+    >
       {children}
     </BaseText>
   );

--- a/packages/libs/react-components/src/components/Typography/Text.stories.tsx
+++ b/packages/libs/react-components/src/components/Typography/Text.stories.tsx
@@ -3,6 +3,7 @@ import {
   elementVariant,
   fontVariant,
   textSizeVariant,
+  transformVariant,
 } from './styles';
 import { Text } from './Text';
 
@@ -13,6 +14,9 @@ const meta: Meta<typeof Text> = {
   title: 'Typography/Text',
   component: Text,
   argTypes: {
+    children: {
+      control: { type: 'text' },
+    },
     as: {
       control: { type: 'select' },
     },
@@ -32,6 +36,12 @@ const meta: Meta<typeof Text> = {
       options: Object.keys(boldVariant) as (keyof typeof boldVariant)[],
       control: { type: 'boolean' },
     },
+    transform: {
+      options: Object.keys(
+        transformVariant,
+      ) as (keyof typeof transformVariant)[],
+      control: { type: 'radio' },
+    },
   },
 };
 
@@ -41,15 +51,24 @@ type Story = StoryObj<typeof Text>;
 export const Primary: Story = {
   name: 'Text',
   args: {
+    children: 'text',
     as: 'span',
     variant: undefined,
     size: 'lg',
     font: 'main',
     bold: 'false',
+    transform: 'none',
   },
-  render: ({ font, bold, size, as, variant }) => (
-    <Text font={font} bold={bold} size={size} as={as} variant={variant}>
-      Text
+  render: ({ font, bold, size, as, variant, transform, children }) => (
+    <Text
+      font={font}
+      bold={bold}
+      size={size}
+      as={as}
+      variant={variant}
+      transform={transform}
+    >
+      {children}
     </Text>
   ),
 };

--- a/packages/libs/react-components/src/components/Typography/Text.tsx
+++ b/packages/libs/react-components/src/components/Typography/Text.tsx
@@ -9,6 +9,7 @@ export interface ITextProps {
   font?: VariantProps<typeof BaseText>['font'];
   bold?: VariantProps<typeof BaseText>['bold'];
   size?: VariantProps<typeof StyledText>['size'];
+  transform?: VariantProps<typeof BaseText>['transform'];
   children: React.ReactNode;
 }
 
@@ -18,6 +19,7 @@ export const Text: FC<ITextProps> = ({
   font,
   bold,
   size,
+  transform,
   children,
 }) => {
   return (
@@ -27,6 +29,7 @@ export const Text: FC<ITextProps> = ({
       font={font}
       bold={bold}
       size={size}
+      transform={transform}
     >
       {children}
     </StyledText>

--- a/packages/libs/react-components/src/components/Typography/styles.ts
+++ b/packages/libs/react-components/src/components/Typography/styles.ts
@@ -79,9 +79,9 @@ export const elementVariant = {
       fontSize: '$lg',
     },
   },
-  p: { $$boldWeight: '$fontWeights$medium' },
-  span: { $$boldWeight: '$fontWeights$medium' },
-  code: { $$boldWeight: '$fontWeights$medium' },
+  p: { $$boldWeight: '$fontWeights$semiBold' },
+  span: { $$boldWeight: '$fontWeights$semiBold' },
+  code: { $$boldWeight: '$fontWeights$semiBold' },
 } as const;
 
 export const fontVariant = {

--- a/packages/libs/react-components/src/components/Typography/styles.ts
+++ b/packages/libs/react-components/src/components/Typography/styles.ts
@@ -114,6 +114,21 @@ export const textSizeVariant = {
   },
 };
 
+export const transformVariant = {
+  capitalize: {
+    textTransform: 'capitalize',
+  },
+  uppercase: {
+    textTransform: 'uppercase',
+  },
+  lowercase: {
+    textTransform: 'lowercase',
+  },
+  none: {
+    textTransform: 'none',
+  },
+};
+
 export const BaseText = styled('span', {
   fontWeight: '$regular',
   color: '$foreground',
@@ -124,12 +139,14 @@ export const BaseText = styled('span', {
     variant: elementVariant,
     font: fontVariant,
     bold: boldVariant,
+    transform: transformVariant,
   },
 
   defaultVariants: {
     variant: 'span',
     font: 'main',
     bold: 'false',
+    transform: 'none',
   },
 
   compoundVariants: [


### PR DESCRIPTION
Adding typography components to the docs.

## Reason:
This way we dont have to use the props everytime, which is error prone.
Just using the named components should make it easier to see what component / style you need to use

Closes https://app.asana.com/0/1204270938438101/1204388315302169/f



## Check off the following:

- [X] I have reviewed my changes and run the appropriate tests.
- [X] I have have run `rush change` to add the appropriate change logs.
- [X] I have added/edited  tests docs.
- [ ] I have added tutorials.
- [ ] I have double checked and DEFINITELY added docs.

