### PR TITLE
feat(@kadena/ui): Add Button Component

### DIFF
--- a/common/changes/@kadena/react-components/feat-button-component_2023-04-18-13-03.json
+++ b/common/changes/@kadena/react-components/feat-button-component_2023-04-18-13-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/react-components",
+      "comment": "Added base button component",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@kadena/react-components"
+}

--- a/packages/libs/react-components/src/components/Button/Button.stories.tsx
+++ b/packages/libs/react-components/src/components/Button/Button.stories.tsx
@@ -1,0 +1,72 @@
+import { SystemIcons } from './../../';
+import { Button, IButtonProps } from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+const meta: Meta<
+  {
+    selectIcon: keyof typeof SystemIcons;
+    text: string;
+  } & IButtonProps
+> = {
+  title: 'Button',
+  argTypes: {
+    onClick: { action: 'clicked' },
+    selectIcon: {
+      options: Object.keys(SystemIcons),
+      control: {
+        type: 'select',
+      },
+    },
+    title: {
+      control: {
+        type: 'text',
+      },
+    },
+    text: {
+      control: {
+        type: 'text',
+      },
+    },
+    disabled: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<
+  {
+    text: string;
+    selectIcon: keyof typeof SystemIcons;
+  } & IButtonProps
+>;
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/react/api/csf
+ * to learn how to use render functions.
+ */
+
+export const Primary: Story = {
+  name: 'Button',
+  args: {
+    selectIcon: undefined,
+    title: 'test title',
+    disabled: false,
+    text: 'Click me',
+  },
+  render: ({ selectIcon, onClick, title, disabled, text }) => {
+    const Icon = SystemIcons[selectIcon];
+    return (
+      <>
+        <Button title={title} onClick={onClick} icon={Icon} disabled={disabled}>
+          {text}
+        </Button>
+      </>
+    );
+  },
+};

--- a/packages/libs/react-components/src/components/Button/Button.tsx
+++ b/packages/libs/react-components/src/components/Button/Button.tsx
@@ -1,0 +1,42 @@
+import { SystemIcons } from '../Icons';
+
+import { StyledButton } from './styles';
+
+import React, { FC } from 'react';
+
+export interface IButtonProps
+  extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'as' | 'disabled'> {
+  as?: 'button' | 'a';
+  icon?: typeof SystemIcons[keyof typeof SystemIcons];
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  href?: string;
+  children: React.ReactNode;
+  title: string;
+  disabled?: boolean;
+}
+
+export const Button: FC<IButtonProps> = ({
+  as = 'button',
+  icon,
+  onClick,
+  href,
+  color = 'transparent',
+  children,
+  ...props
+}) => {
+  const Icon = icon;
+  const ariaLabel = props['aria-label'] ?? props.title;
+
+  return (
+    <StyledButton
+      {...props}
+      as={as}
+      onClick={as === 'button' ? onClick : undefined}
+      href={as === 'a' ? href : undefined}
+      aria-label={ariaLabel}
+    >
+      {children}
+      {Icon && <Icon size="md" />}
+    </StyledButton>
+  );
+};

--- a/packages/libs/react-components/src/components/Button/Button.tsx
+++ b/packages/libs/react-components/src/components/Button/Button.tsx
@@ -20,7 +20,6 @@ export const Button: FC<IButtonProps> = ({
   icon,
   onClick,
   href,
-  color = 'transparent',
   children,
   ...props
 }) => {

--- a/packages/libs/react-components/src/components/Button/index.ts
+++ b/packages/libs/react-components/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export { Button, IButtonProps } from './Button';

--- a/packages/libs/react-components/src/components/Button/styles.ts
+++ b/packages/libs/react-components/src/components/Button/styles.ts
@@ -11,8 +11,6 @@ export const styleVariant = {
     $$bgHoverColor: '$colors$primaryHighContrast',
     $$focusOutlineColor: '$colors$primaryHighContrast',
     $$disabledBackgroundColor: '$colors$neutral3',
-
-    $$tempColor: '$colors$tempBlue',
   },
 } as const;
 
@@ -36,15 +34,14 @@ export const StyledButton = styled('button', {
   },
   '&:active': {
     opacity: '0.8',
-    // backgroundColor: '$$tempColor',
   },
   '&:focus-visible': {
     outlineOffset: '2px',
     outline: '2px solid $$focusOutlineColor',
   },
   '&:disabled': {
-    background: '$$disabledBackgroundColor',
     opacity: 0.7,
+    background: '$$disabledBackgroundColor',
     color: '$$inverseColor',
     cursor: 'not-allowed',
   },

--- a/packages/libs/react-components/src/components/Button/styles.ts
+++ b/packages/libs/react-components/src/components/Button/styles.ts
@@ -1,0 +1,59 @@
+/* eslint @kadena-dev/typedef-var: 0 */
+// TODO: Remove this when this issue is resolved: https://github.com/kadena-community/kadena.js/issues/201
+
+import { styled } from '../../styles';
+
+export const styleVariant = {
+  primaryFilled: {
+    $$color: '$colors$neutral1',
+    $$inverseColor: '$colors$neutral6',
+    $$bgColor: '$colors$primaryContrast',
+    $$bgHoverColor: '$colors$primaryHighContrast',
+    $$focusOutlineColor: '$colors$primaryHighContrast',
+    $$disabledBackgroundColor: '$colors$neutral3',
+
+    $$tempColor: '$colors$tempBlue',
+  },
+} as const;
+
+export const StyledButton = styled('button', {
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '$1',
+  transition: 'background-color 0.1s ease, color 0.1s ease',
+  borderRadius: '$sm',
+  cursor: 'pointer',
+  border: 0,
+  px: '$4',
+  py: '$3',
+  fontWeight: '$semiBold',
+  color: '$$color',
+  backgroundColor: '$$bgColor',
+  '&:hover': {
+    backgroundColor: '$$bgHoverColor',
+  },
+  '&:active': {
+    opacity: '0.8',
+    // backgroundColor: '$$tempColor',
+  },
+  '&:focus-visible': {
+    outlineOffset: '2px',
+    outline: '2px solid $$focusOutlineColor',
+  },
+  '&:disabled': {
+    background: '$$disabledBackgroundColor',
+    opacity: 0.7,
+    color: '$$inverseColor',
+    cursor: 'not-allowed',
+  },
+
+  variants: {
+    variant: styleVariant,
+  },
+
+  defaultVariants: {
+    variant: 'primaryFilled',
+  },
+});

--- a/packages/libs/react-components/src/components/IconButton/IconButton.stories.tsx
+++ b/packages/libs/react-components/src/components/IconButton/IconButton.stories.tsx
@@ -1,5 +1,5 @@
 import { SystemIcons } from './../../';
-import { IconButton, IIConButtonProps } from '.';
+import { IconButton, IIconButtonProps } from '.';
 
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
@@ -9,7 +9,7 @@ const meta: Meta<
     title: string;
     selectIcon: keyof typeof SystemIcons;
     color: string;
-  } & IIConButtonProps
+  } & IIconButtonProps
 > = {
   title: 'IconButton',
   argTypes: {
@@ -39,7 +39,7 @@ type Story = StoryObj<
     title: string;
     selectIcon: keyof typeof SystemIcons;
     color: string;
-  } & IIConButtonProps
+  } & IIconButtonProps
 >;
 
 /*

--- a/packages/libs/react-components/src/components/IconButton/IconButton.tsx
+++ b/packages/libs/react-components/src/components/IconButton/IconButton.tsx
@@ -6,8 +6,10 @@ import React, { FC } from 'react';
 
 export interface IIconButtonProps
   extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'color'> {
+  as?: 'button' | 'a';
   icon: typeof SystemIcons[keyof typeof SystemIcons];
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+  href?: string;
   title: string;
   color?: PropertyValue<'backgroundColor', typeof config>;
 }
@@ -30,8 +32,10 @@ const Button = styled('button', {
 });
 
 export const IconButton: FC<IIconButtonProps> = ({
+  as = 'button',
   icon,
   onClick,
+  href,
   color = 'transparent',
   ...props
 }) => {
@@ -40,8 +44,10 @@ export const IconButton: FC<IIconButtonProps> = ({
 
   return (
     <Button
-      onClick={onClick}
       {...props}
+      as={as}
+      href={as === 'a' ? href : undefined}
+      onClick={as === 'button' ? onClick : undefined}
       aria-label={ariaLabel}
       css={{ backgroundColor: color }}
     >

--- a/packages/libs/react-components/src/components/IconButton/IconButton.tsx
+++ b/packages/libs/react-components/src/components/IconButton/IconButton.tsx
@@ -4,7 +4,7 @@ import { SystemIcons } from '../Icons';
 import { PropertyValue } from '@stitches/react';
 import React, { FC } from 'react';
 
-export interface IIConButtonProps
+export interface IIconButtonProps
   extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'color'> {
   icon: typeof SystemIcons[keyof typeof SystemIcons];
   onClick: React.MouseEventHandler<HTMLButtonElement>;
@@ -29,7 +29,7 @@ const Button = styled('button', {
   },
 });
 
-export const IconButton: FC<IIConButtonProps> = ({
+export const IconButton: FC<IIconButtonProps> = ({
   icon,
   onClick,
   color = 'transparent',

--- a/packages/libs/react-components/src/components/IconButton/index.ts
+++ b/packages/libs/react-components/src/components/IconButton/index.ts
@@ -1,1 +1,1 @@
-export { IconButton, IIConButtonProps } from './IconButton';
+export { IconButton, IIconButtonProps } from './IconButton';

--- a/packages/libs/react-components/src/index.ts
+++ b/packages/libs/react-components/src/index.ts
@@ -1,6 +1,7 @@
 export { Stack, IStackProps } from './components/Stack/Stack';
 export { Grid, IGridContainerProps, IGridItemProps } from './components/Grid';
-export { IconButton, IIConButtonProps } from './components/IconButton';
+export { IconButton, IIconButtonProps } from './components/IconButton';
+export { Button, IButtonProps } from './components/Button';
 export { SystemIcons } from './components/Icons';
 export {
   Heading,

--- a/packages/libs/react-components/src/styles/baseGlobalStyles.ts
+++ b/packages/libs/react-components/src/styles/baseGlobalStyles.ts
@@ -47,13 +47,13 @@ export const baseGlobalStyles: Record<string, unknown> = {
     7. Remove built-in form typography styles
   */
   'input, button, textarea, select': {
-    font: 'inherit',
+    fontFamily: '$main',
   },
 
   /*
     8. Avoid text overflows
   */
-  'p, h1, h2, h3, h4, h5, h6': {
+  'span, p, h1, h2, h3, h4, h5, h6': {
     fontFamily: '$main',
     overflowWrap: 'break-word',
   },

--- a/packages/libs/react-components/src/styles/colors/index.ts
+++ b/packages/libs/react-components/src/styles/colors/index.ts
@@ -4,9 +4,7 @@ import { neutral } from './neutral';
 export const colors = {
   ...neutral,
 
-  tempBlue: '#8FC8FF',
-
-  neutral1: '#FAFAFA', // TODO: neutral colors should be updated to use extended neutral color palette
+  neutral1: '#FAFAFA',
   neutral2: '#F0F0F0',
   neutral3: '#9EA1A6',
   neutral4: '#474F52',
@@ -21,9 +19,11 @@ export const colors = {
   secondaryAccent: '#ED098F',
   secondarySurface: '#FDC4E5',
   secondaryContrast: '#8A0553',
+
   successAccent: '#5EEA15',
   successSurface: '#E5FFD8',
   successContrast: '#113300',
+
   errorAccent: '#FF3338',
   errorSurface: '#FFDAD8',
   errorContrast: '#410006',
@@ -31,8 +31,6 @@ export const colors = {
 
 export const colorsDark = {
   ...neutral,
-
-  tempBlue: '#0C5269',
 
   neutral1: '#050505',
   neutral2: '#1D1D1F',
@@ -49,9 +47,11 @@ export const colorsDark = {
   secondaryAccent: '#ED098F',
   secondarySurface: '#8A0553',
   secondaryContrast: '#FDC4E5', // TODO: Replace this with highlighter color
+
   successAccent: '#5EEA15',
   successSurface: '#113300',
   successContrast: '#E5FFD8',
+
   errorAccent: '#FF3338',
   errorSurface: '#410006',
   errorContrast: '#FFDAD8',

--- a/packages/libs/react-components/src/styles/colors/index.ts
+++ b/packages/libs/react-components/src/styles/colors/index.ts
@@ -1,8 +1,12 @@
 /* eslint @kadena-dev/typedef-var: 0 */
-// TODO: Update to match design system
+import { neutral } from './neutral';
 
 export const colors = {
-  neutral1: '#FAFAFA',
+  ...neutral,
+
+  tempBlue: '#8FC8FF',
+
+  neutral1: '#FAFAFA', // TODO: neutral colors should be updated to use extended neutral color palette
   neutral2: '#F0F0F0',
   neutral3: '#9EA1A6',
   neutral4: '#474F52',
@@ -11,8 +15,12 @@ export const colors = {
 
   primaryAccent: '#2997FF',
   primarySurface: '#C2E1FF',
+  primaryContrast: '#00498F',
+  primaryHighContrast: '#002F5C',
+
   secondaryAccent: '#ED098F',
   secondarySurface: '#FDC4E5',
+  secondaryContrast: '#8A0553',
   successAccent: '#5EEA15',
   successSurface: '#E5FFD8',
   successContrast: '#113300',
@@ -22,6 +30,10 @@ export const colors = {
 } as const;
 
 export const colorsDark = {
+  ...neutral,
+
+  tempBlue: '#0C5269',
+
   neutral1: '#050505',
   neutral2: '#1D1D1F',
   neutral3: '#474F52',
@@ -31,8 +43,12 @@ export const colorsDark = {
 
   primaryAccent: '#2997FF',
   primarySurface: '#00498F',
+  primaryContrast: '#27B7E6',
+  primaryHighContrast: '#B1E5F6',
+
   secondaryAccent: '#ED098F',
   secondarySurface: '#8A0553',
+  secondaryContrast: '#FDC4E5', // TODO: Replace this with highlighter color
   successAccent: '#5EEA15',
   successSurface: '#113300',
   successContrast: '#E5FFD8',

--- a/packages/libs/react-components/src/styles/colors/neutral.ts
+++ b/packages/libs/react-components/src/styles/colors/neutral.ts
@@ -1,17 +1,7 @@
 /* eslint @kadena-dev/typedef-var: 0 */
 
+// TODO: Replace with correct color scales
 export const neutral = {
   neutral000: '#000000',
-  neutral010: '#191C1D',
-  neutral020: '#2E3132',
-  neutral030: '#444748',
-  neutral040: '#5C5F5F',
-  neutral050: '#747878',
-  neutral060: '#8E9192',
-  neutral070: '#A9ACAC',
-  neutral080: '#C4C7C7',
-  neutral090: '#E1E3E3',
-  neutral095: '#F1F3F3',
-  neutral099: '#FBFCFC',
   neutral100: '#FFFFFF',
 } as const;

--- a/packages/libs/react-components/src/styles/colors/neutral.ts
+++ b/packages/libs/react-components/src/styles/colors/neutral.ts
@@ -1,0 +1,17 @@
+/* eslint @kadena-dev/typedef-var: 0 */
+
+export const neutral = {
+  neutral000: '#000000',
+  neutral010: '#191C1D',
+  neutral020: '#2E3132',
+  neutral030: '#444748',
+  neutral040: '#5C5F5F',
+  neutral050: '#747878',
+  neutral060: '#8E9192',
+  neutral070: '#A9ACAC',
+  neutral080: '#C4C7C7',
+  neutral090: '#E1E3E3',
+  neutral095: '#F1F3F3',
+  neutral099: '#FBFCFC',
+  neutral100: '#FFFFFF',
+} as const;

--- a/packages/libs/react-components/src/styles/stitches.config.ts
+++ b/packages/libs/react-components/src/styles/stitches.config.ts
@@ -71,8 +71,8 @@ export const {
       foreground: '$colors$neutral6',
     },
     fonts: {
-      main: 'Haas Grotesk Display, -apple-system, sans-serif',
-      mono: 'Kadena Code, Menlo, monospace',
+      main: "'Haas Grotesk Display', -apple-system, sans-serif",
+      mono: "'Kadena Code', Menlo, monospace",
     },
     fontSizes: {
       xs: '0.75rem', // 12px


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 
Can you please fill out the information below to save us time looking into your PR. 
Start with explaining the reasons for this change, and if applicable link to an issue.
And explain the changes you have made.
-->

Created a Button component that accepts children and an icon which is aligned to the right 
- Currently it only has one style variant which is `primaryFilled`, but it is setup so that all of the colors can be updated via named local tokens
- The button component can also be used as a link when passed `as='a'` and an href.
- I also added another theme dependant color called `primaryHighContrast` for the interactive states for the button. We can add these to the other colors when they are chosen
- Additionally I added a `neutral` color scale that only includes black and white as place holders for now, but it acts as a placeholder for the full neutral color scale when it is available which allows us to use a token to choose the same color regardless of the active theme


## Changes made (preferably with images/screenshots):

## Check off the following:

- [x] I have reviewed my changes and run the appropriate tests.
- [x] I have have run `rush change` to add the appropriate change logs.
- [ ] I have added/edited docs.
- [ ] I have added tutorials.
- [ ] I have double checked and DEFINITELY added docs.

