### PR TITLE
fix(@kadena/react-components): adding skipLibCheck to fix incorrect @types/react version resolution

### DIFF
--- a/common/changes/@kadena/react-components/fix-react-components-build_2023-04-25-17-17.json
+++ b/common/changes/@kadena/react-components/fix-react-components-build_2023-04-25-17-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/react-components",
+      "comment": "fix @types/react version mismatch issue",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/react-components"
+}

--- a/packages/libs/react-components/tsconfig.cjs.json
+++ b/packages/libs/react-components/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.esm.json",
   "compilerOptions": {
     "module": "CommonJS",
+    "skipLibCheck": true,
     "outDir": "dist/cjs"
   }
 }

--- a/packages/libs/react-components/tsconfig.json
+++ b/packages/libs/react-components/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "./node_modules/@kadena-dev/heft-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
-    "types": ["heft-jest"],
-    "skipLibCheck": true
+    "types": ["heft-jest"]
   },
   "include": ["src/**/*"]
 }

--- a/packages/libs/react-components/tsconfig.json
+++ b/packages/libs/react-components/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "./node_modules/@kadena-dev/heft-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
-    "types": ["heft-jest"]
+    "types": ["heft-jest"],
+    "skipLibCheck": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 
Can you please fill out the information below to save us time looking into your PR. 
Start with explaining the reasons for this change, and if applicable link to an issue.
And explain the changes you have made.
-->

Attempt to fix build issue with react-components

Issue has to do with @types/react confusion - v18 used in react-components but v17 is resolved by typescript somehow

~removing skipLibCheck fixed this locally~ edit: incorrect