### PR TITLE
Added .npmrc to our .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ jspm_packages/
 *.tgz
 
 # Optional config for 'rush publish'
+.npmrc
 .npmrc-publish
 
 # Yarn Integrity file


### PR DESCRIPTION
Title says it all - `.npmrc` was not in .gitignore, this adds it.