### PR TITLE
fix(pactjs-cli) : append the export to index.d.ts if it's not already there

### DIFF
--- a/common/changes/@kadena/pactjs-cli/patch-1_2023-05-08-07-29.json
+++ b/common/changes/@kadena/pactjs-cli/patch-1_2023-05-08-07-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-cli",
+      "comment": "append the export to index.d.ts if it's not already there",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kadena/pactjs-cli"
+}

--- a/packages/tools/pactjs-cli/src/contract-generate/generate.ts
+++ b/packages/tools/pactjs-cli/src/contract-generate/generate.ts
@@ -141,7 +141,10 @@ export const generate =
       if (existsSync(indexPath)) {
         console.log(`Appending to existing file ${indexPath}`);
         const indexDts: string = readFileSync(indexPath, 'utf8');
-        writeFileSync(indexPath, indexDts + exportStatement);
+        // Append the export to the file if it's not already there.
+        if (!indexDts.includes(exportStatement)) {
+          writeFileSync(indexPath, indexDts + exportStatement);
+        }
       } else {
         console.log(`Writing to new file ${indexPath}`);
         writeFileSync(indexPath, exportStatement);

--- a/packages/tools/pactjs-cli/src/contract-generate/generate.ts
+++ b/packages/tools/pactjs-cli/src/contract-generate/generate.ts
@@ -143,7 +143,9 @@ export const generate =
         const indexDts: string = readFileSync(indexPath, 'utf8');
         // Append the export to the file if it's not already there.
         if (!indexDts.includes(exportStatement)) {
-          writeFileSync(indexPath, indexDts + exportStatement);
+          const separator = indexDts.endsWith('\n') ? '' : '\n';
+          const newIndexDts = [indexDts, exportStatement].join(separator);
+          writeFileSync(indexPath, newIndexDts);
         }
       } else {
         console.log(`Writing to new file ${indexPath}`);


### PR DESCRIPTION
## Reason:

contract-generate adds the export type to the index file even if the export is already there.  it happens if we run the script on a file twice. 
it can happen where a user updates the contract and wants to ensure the types are also updated.


## Changes made (preferably with images/screenshots):

## Check off the following:

- [x] I have reviewed my changes and run the appropriate tests.
- [x] I have have run `rush change` to add the appropriate change logs.
- [ ] I have added/edited docs.
- [ ] I have added tutorials.
- [ ] I have double checked and DEFINITELY added docs.

