### PR TITLE
chore: use node 16 or 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        NodeVersion: [14, 16]
+        NodeVersion: [16, 18]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/rush.json
+++ b/rush.json
@@ -124,7 +124,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=12.13.0 <13.0.0 || >=14.15.0 <15.0.0 || >=16.13.0 <17.0.0",
+  "nodeSupportedVersionRange": ">=16.13.0 <17.0.0 || >=18.12.0 <19.0.0",
 
   /**
    * Odd-numbered major versions of Node.js are experimental.  Even-numbered releases


### PR DESCRIPTION
Node 14 is no longer supported and is causing build failures. To fix this, I suggest updating to the two latest LTS versions of Node.

