### PR TITLE
pactjs-cli unit test, windows compatibility

### DIFF
--- a/common/changes/@kadena/pactjs-cli/fix-pact-cli-test_2023-05-15-09-00.json
+++ b/common/changes/@kadena/pactjs-cli/fix-pact-cli-test_2023-05-15-09-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-cli",
+      "comment": "use nodejs path util to make path-like strings for cross OS compability",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs-cli"
+}

--- a/packages/tools/pactjs-cli/src/retrieve-contract/tests/retrieve-contract.test.ts
+++ b/packages/tools/pactjs-cli/src/retrieve-contract/tests/retrieve-contract.test.ts
@@ -1,10 +1,10 @@
 jest.mock('fs');
 jest.mock('../../utils/retrieveContractFromChain');
-const path = require('path');
 
 import { retrieveContractFromChain } from '../../utils/retrieveContractFromChain';
 
 import { writeFileSync } from 'fs';
+import path from 'path';
 
 const mockedWriteFileSync = writeFileSync as jest.MockedFunction<
   typeof writeFileSync

--- a/packages/tools/pactjs-cli/src/retrieve-contract/tests/retrieve-contract.test.ts
+++ b/packages/tools/pactjs-cli/src/retrieve-contract/tests/retrieve-contract.test.ts
@@ -1,5 +1,6 @@
 jest.mock('fs');
 jest.mock('../../utils/retrieveContractFromChain');
+const path = require('path');
 
 import { retrieveContractFromChain } from '../../utils/retrieveContractFromChain';
 
@@ -63,7 +64,7 @@ describe('retrieve-contract', () => {
     await createAndRunProgram();
 
     expect(mockedWriteFileSync.mock.calls[0][0]).toContain(
-      '/some/path/to/contract.pact',
+      path.join('some', 'path', 'to', 'contract.pact'),
     );
     expect(mockedWriteFileSync.mock.calls[0][1]).toEqual('some code');
   });


### PR DESCRIPTION
## Reason:

pactjs-cli unit test is failing on Windows. because Windows use "\" for paths.

## Changes made (preferably with images/screenshots):
used nodejs path util to make paths compatible by OS

## Check off the following:

- [x] I have reviewed my changes and run the appropriate tests.
- [x] I have have run `rush change` to add the appropriate change logs.
- [ ] I have added/edited docs.
- [ ] I have added tutorials.
- [ ] I have double checked and DEFINITELY added docs.

