### PR TITLE
Fix usage of `repository` and `npx` in package.json

### DIFF
--- a/common/changes/@kadena-dev/eslint-config/feat-fix-packagejson-fields_2023-05-22-10-49.json
+++ b/common/changes/@kadena-dev/eslint-config/feat-fix-packagejson-fields_2023-05-22-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/eslint-config",
+      "comment": "Fix usage of `repository` and `npx` in package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena-dev/eslint-config"
+}

--- a/common/changes/@kadena/chainweb-node-client/feat-fix-packagejson-fields_2023-05-22-10-49.json
+++ b/common/changes/@kadena/chainweb-node-client/feat-fix-packagejson-fields_2023-05-22-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-node-client",
+      "comment": "Fix usage of `repository` and `npx` in package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainweb-node-client"
+}

--- a/common/changes/@kadena/chainweb-stream-client/feat-fix-packagejson-fields_2023-05-22-10-49.json
+++ b/common/changes/@kadena/chainweb-stream-client/feat-fix-packagejson-fields_2023-05-22-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-stream-client",
+      "comment": "Fix usage of `repository` and `npx` in package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainweb-stream-client"
+}

--- a/common/changes/@kadena/chainwebjs/feat-fix-packagejson-fields_2023-05-22-10-49.json
+++ b/common/changes/@kadena/chainwebjs/feat-fix-packagejson-fields_2023-05-22-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainwebjs",
+      "comment": "Fix usage of `repository` and `npx` in package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainwebjs"
+}

--- a/common/changes/@kadena/client/feat-fix-packagejson-fields_2023-05-22-10-49.json
+++ b/common/changes/@kadena/client/feat-fix-packagejson-fields_2023-05-22-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "Fix usage of `repository` and `npx` in package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/common/changes/@kadena/cryptography-utils/feat-fix-packagejson-fields_2023-05-22-10-49.json
+++ b/common/changes/@kadena/cryptography-utils/feat-fix-packagejson-fields_2023-05-22-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/cryptography-utils",
+      "comment": "Fix usage of `repository` and `npx` in package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/cryptography-utils"
+}

--- a/common/changes/@kadena/pactjs-cli/feat-fix-packagejson-fields_2023-05-22-10-49.json
+++ b/common/changes/@kadena/pactjs-cli/feat-fix-packagejson-fields_2023-05-22-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-cli",
+      "comment": "Fix usage of `repository` and `npx` in package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs-cli"
+}

--- a/common/changes/@kadena/pactjs-generator/feat-fix-packagejson-fields_2023-05-22-10-49.json
+++ b/common/changes/@kadena/pactjs-generator/feat-fix-packagejson-fields_2023-05-22-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-generator",
+      "comment": "Fix usage of `repository` and `npx` in package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs-generator"
+}

--- a/common/changes/@kadena/pactjs/feat-fix-packagejson-fields_2023-05-22-10-49.json
+++ b/common/changes/@kadena/pactjs/feat-fix-packagejson-fields_2023-05-22-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs",
+      "comment": "Fix usage of `repository` and `npx` in package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs"
+}

--- a/common/changes/@kadena/react-components/feat-fix-packagejson-fields_2023-05-22-10-49.json
+++ b/common/changes/@kadena/react-components/feat-fix-packagejson-fields_2023-05-22-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/react-components",
+      "comment": "Fix usage of `repository` and `npx` in package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/react-components"
+}

--- a/common/changes/@kadena/types/feat-fix-packagejson-fields_2023-05-22-10-49.json
+++ b/common/changes/@kadena/types/feat-fix-packagejson-fields_2023-05-22-10-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/types",
+      "comment": "Fix usage of `repository` and `npx` in package.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/types"
+}

--- a/packages/apps/graph/package.json
+++ b/packages/apps/graph/package.json
@@ -10,7 +10,7 @@
     "_phase:build": "npm run build",
     "_phase:test": "npm run test",
     "build": "",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "lint-staged": "lint-staged",
     "prisma:generate": "prisma generate",
     "prisma:pull": "prisma db pull",

--- a/packages/apps/kadena-docs/package.json
+++ b/packages/apps/kadena-docs/package.json
@@ -12,7 +12,7 @@
     "cypress:open": "percy exec -- cypress open",
     "cypress:run": "percy exec -- cypress run",
     "dev": "next dev",
-    "lint": "npx eslint ./src --ext .js,.ts,.jsx,.tsx --fix",
+    "lint": "eslint ./src --ext .js,.ts,.jsx,.tsx --fix",
     "lint-staged": "lint-staged",
     "start": "next start",
     "storybook": "storybook dev -p 6006",

--- a/packages/libs/bootstrap-lib/package.json
+++ b/packages/libs/bootstrap-lib/package.json
@@ -5,7 +5,8 @@
   "keywords": [],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/libs/bootstrap-lib"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/libs/bootstrap-lib"
   },
   "license": "ISC",
   "contributors": [
@@ -28,7 +29,7 @@
     "_phase:build": "npm run build",
     "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "test": "rushx build && heft test --no-build"
   },
   "lint-staged": {

--- a/packages/libs/chainweb-node-client/package.json
+++ b/packages/libs/chainweb-node-client/package.json
@@ -5,7 +5,8 @@
   "keywords": [],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/libs/chainweb-node-client"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/libs/chainweb-node-client"
   },
   "license": "ISC",
   "contributors": [
@@ -30,7 +31,7 @@
     "build": "heft build --clean",
     "generate:openapi-types": "echo 'openapi specs needs fixes' # openapi-typescript \"./openapi/*.json\" --output ./src/openapi",
     "postinstall": "npm run generate:openapi-types",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "test": "rushx build && heft test --no-build"
   },
   "lint-staged": {

--- a/packages/libs/chainweb-stream-client/package.json
+++ b/packages/libs/chainweb-stream-client/package.json
@@ -5,7 +5,8 @@
   "keywords": [],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/libs/chainweb-stream-client"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/libs/chainweb-stream-client"
   },
   "license": "ISC",
   "contributors": [
@@ -28,7 +29,7 @@
     "_phase:build": "heft build --clean",
     "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "test": "rushx build && heft test --no-build"
   },
   "lint-staged": {

--- a/packages/libs/chainwebjs/package.json
+++ b/packages/libs/chainwebjs/package.json
@@ -16,7 +16,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/libs/chainwebjs"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/libs/chainwebjs"
   },
   "license": "MIT",
   "author": "Lars Kuhtz <lars@kadena.io>",
@@ -46,8 +47,8 @@
     "_phase:build": "heft build --clean",
     "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
-    "preinstall": "npx only-allow pnpm",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "preinstall": "only-allow pnpm",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "lint-staged": "lint-staged",
     "test": "rushx build && heft test --no-build"
   },

--- a/packages/libs/chainwebjs/package.json
+++ b/packages/libs/chainwebjs/package.json
@@ -47,7 +47,7 @@
     "_phase:build": "heft build --clean",
     "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
-    "preinstall": "only-allow pnpm",
+    "preinstall": "npx only-allow pnpm",
     "lint": "eslint ./src --ext .js,.ts --fix",
     "lint-staged": "lint-staged",
     "test": "rushx build && heft test --no-build"

--- a/packages/libs/client/package.json
+++ b/packages/libs/client/package.json
@@ -4,7 +4,8 @@
   "description": "Core library for building Pact expressions to send to the blockchain in js. Makes use of .kadena/pactjs-generated",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/libs/client"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/libs/client"
   },
   "license": "MIT",
   "main": "lib/index.js",
@@ -14,7 +15,7 @@
     "_phase:test": "npm run test",
     "build": "heft build --clean",
     "dev:postinstall": "rushx pactjs:retrieve:contract; rushx pactjs:generate:contract",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "lint-staged": "lint-staged",
     "pactjs:generate:contract": "pactjs contract-generate --file contracts/coin.contract.pact",
     "pactjs:retrieve:contract": "pactjs retrieve-contract --out contracts/coin.contract.pact --module coin",

--- a/packages/libs/cryptography-utils/package.json
+++ b/packages/libs/cryptography-utils/package.json
@@ -5,7 +5,8 @@
   "keywords": [],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/libs/cryptography-utils"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/libs/cryptography-utils"
   },
   "license": "ISC",
   "contributors": [
@@ -28,7 +29,7 @@
     "_phase:build": "heft build --clean",
     "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "lint-staged": "lint-staged",
     "test": "rushx build && heft test --no-build"
   },

--- a/packages/libs/kadena.js/package.json
+++ b/packages/libs/kadena.js/package.json
@@ -14,7 +14,8 @@
   "homepage": "tbd",
   "repository": {
     "type": "git",
-    "url": "git://github.com/kadena-io/kadena.js.git"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/libs/kadena.js"
   },
   "license": "MIT",
   "author": "Randynamic",
@@ -41,7 +42,7 @@
     "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
     "build:prod": "webpack --mode=production",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "serve-coverage": "python -m SimpleHTTPServer",
     "test": "heft test"
   },

--- a/packages/libs/pactjs-generator/package.json
+++ b/packages/libs/pactjs-generator/package.json
@@ -4,7 +4,8 @@
   "description": "Generates TypeScript definitions of Pact contracts, for use in @kadena/pactjs",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/libs/pactjs-generator"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/libs/pactjs-generator"
   },
   "license": "MIT",
   "main": "lib/index.js",
@@ -20,7 +21,7 @@
     "build:grammar:watch": "chokidar src/lexer.js src/grammar.ne src/tests/test.contract.pact -c \"rushx build:grammar\"",
     "test:grammar:watch": "heft test -w -t grammar --disable-code-coverage",
     "util:lexer-grammar:watch": "concurrently --kill-others npm:build:*:watch # npm:test:grammar:watch",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "lint-staged": "lint-staged",
     "start": "ts-node --transpile-only src/index.ts",
     "test": "heft test"

--- a/packages/libs/pactjs-test-project/package.json
+++ b/packages/libs/pactjs-test-project/package.json
@@ -5,7 +5,8 @@
   "description": "Test project to verify pactjs-cli and pactjs-generator",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/libs/pactjs-test-project"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/libs/pactjs-test-project"
   },
   "license": "MIT",
   "main": "lib/index.js",
@@ -15,7 +16,7 @@
     "_phase:test": "npm run test",
     "prebuild": "npm run pactjs:generate:contract:file && npm run pactjs:generate:template",
     "build": "npm run prebuild && tsc --noEmit",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "lint-staged": "lint-staged",
     "pactjs:generate:contract:file": "pactjs contract-generate --file src/example-contract/coin.contract.pact && pactjs contract-generate --file src/example-contract/marmalade.module.pact",
     "pactjs:generate:contract:chain": "pactjs contract-generate --contract coin --api https://api.chainweb.com/chainweb/0.0/mainnet01/chain/0/pact;",

--- a/packages/libs/pactjs/package.json
+++ b/packages/libs/pactjs/package.json
@@ -5,7 +5,8 @@
   "keywords": [],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/libs/pactjs"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/libs/pactjs"
   },
   "license": "ISC",
   "contributors": [
@@ -28,7 +29,7 @@
     "_phase:build": "heft build --clean",
     "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "test": "rushx build && heft test --no-build"
   },
   "lint-staged": {

--- a/packages/libs/react-components/package.json
+++ b/packages/libs/react-components/package.json
@@ -17,7 +17,7 @@
     "build": "tsc -p ./tsconfig.esm.json & tsc -p ./tsconfig.cjs.json",
     "build:storybook": "storybook build",
     "build:test": "tsc & tsc -p ./tsconfig.esm.json",
-    "lint": "npx eslint ./src --ext .js,.ts,.tsx --fix",
+    "lint": "eslint ./src --ext .js,.ts,.tsx --fix",
     "storybook": "storybook dev -p 6006",
     "test": "rushx build:test && heft test"
   },

--- a/packages/libs/types/package.json
+++ b/packages/libs/types/package.json
@@ -5,7 +5,8 @@
   "keywords": [],
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/libs/types"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/libs/types"
   },
   "license": "ISC",
   "contributors": [
@@ -28,7 +29,7 @@
     "_phase:build": "heft build --clean",
     "_phase:test": "npm run test",
     "build": "heft build --clean",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "test": "heft test --no-build"
   },
   "lint-staged": {

--- a/packages/tools/cookbook/package.json
+++ b/packages/tools/cookbook/package.json
@@ -11,7 +11,7 @@
     "_phase:test": "npm run test",
     "build": "",
     "dev:postinstall": "mkdir -p ./contracts; rushx pactjs:retrieve:contract; rushx pactjs:generate:contract",
-    "lint": "npx eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "pactjs:generate:contract": "pactjs contract-generate --file contracts/coin.contract.pact",
     "pactjs:retrieve:contract": "pactjs retrieve-contract --out contracts/coin.contract.pact --module coin",
     "test": ""

--- a/packages/tools/create-kadena-app/package.json
+++ b/packages/tools/create-kadena-app/package.json
@@ -4,7 +4,8 @@
   "description": "create-kadena-app CLI tool to create a starter project with @kadena/client integration",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/tools/create-kadena-app"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/tools/create-kadena-app"
   },
   "license": "ISC",
   "bin": {

--- a/packages/tools/create-kadena-app/templates/angular/package.json
+++ b/packages/tools/create-kadena-app/templates/angular/package.json
@@ -4,7 +4,8 @@
   "description": "Angular starter project with @kadena/client integration",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/tools/create-kadena-app"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/tools/create-kadena-app/templates/angular"
   },
   "license": "ISC",
   "scripts": {

--- a/packages/tools/create-kadena-app/templates/nextjs/package.json
+++ b/packages/tools/create-kadena-app/templates/nextjs/package.json
@@ -4,7 +4,8 @@
   "description": "Nextjs starter project with @kadena/client integration",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/tools/create-kadena-app"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/tools/create-kadena-app/templates/nextjs"
   },
   "license": "ISC",
   "scripts": {

--- a/packages/tools/create-kadena-app/templates/vuejs/package.json
+++ b/packages/tools/create-kadena-app/templates/vuejs/package.json
@@ -4,7 +4,8 @@
   "description": "Vuejs starter project with @kadena/client integration",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/tools/create-kadena-app"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/tools/create-kadena-app/templates/vuejs"
   },
   "license": "ISC",
   "scripts": {

--- a/packages/tools/eslint-config/package.json
+++ b/packages/tools/eslint-config/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "",
     "_phase:build": "npm run build",
-    "lint": "npx eslint ./mixins --ext .js,.ts --fix && npx eslint ./profile --ext .js,.ts --fix",
+    "lint": "eslint ./mixins --ext .js,.ts --fix && npx eslint ./profile --ext .js,.ts --fix",
     "_phase:test": "npm run test",
     "test": ""
   },

--- a/packages/tools/integration-tests/package.json
+++ b/packages/tools/integration-tests/package.json
@@ -22,7 +22,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "heft build --clean",
-    "lint": "npx eslint src --ext .js,.ts --fix",
+    "lint": "eslint src --ext .js,.ts --fix",
     "precommit": "pnpm run test --silent",
     "start:pact": "rm -Rf ./log && mkdir log && pact --serve src/tests/pact-server.conf",
     "test": "",

--- a/packages/tools/pactjs-cli/package.json
+++ b/packages/tools/pactjs-cli/package.json
@@ -4,7 +4,8 @@
   "description": "CLI tool accompanying @kadena/pactjs-core and @kadena/pactjs-client to generate TypeScript definitions and Pact client",
   "repository": {
     "type": "git",
-    "url": "https://github.com/kadena-community/kadena.js/tree/master/packages/tools/pactjs-cli"
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/tools/pactjs-cli"
   },
   "license": "MIT",
   "bin": {


### PR DESCRIPTION
The `repository` field did originally not support `directories`, but now we can add them, which is in this PR (also see https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository).

Since package managers should add `bin` directory to the path automatically, there's no need to put `npx` in between when running scripts.