### PR TITLE
[Docs] add codeowners to docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 /packages/apps/explorer                         @alber70g @randynamic @ggobugi27
 /packages/apps/graph                            @alber70g @randynamic @ggobugi27
 /packages/apps/graph-client                     @alber70g @randynamic @ggobugi27 @eileenmguo
-/packages/apps/kadena-docs                      @sstraatemans
+/packages/apps/kadena-docs                      @eileenmguo @sstraatemans @isaozler @ash-vd
 
 /packages/libs/bootstrap-lib                    @alber70g @randynamic @ggobugi27
 /packages/libs/chainweb-node-client             @alber70g @randynamic @ggobugi27


### PR DESCRIPTION
## Reason: At the moment I'm the only one who is owner.
So hard to get PR reviews. The people added are Frontend devs from the react component lib

## Check off the following:

- [X] I have reviewed my changes and run the appropriate tests.
- [X] I have have run `rush change` to add the appropriate change logs.
- [ ] I have added/edited docs.
- [ ] I have added tutorials.
- [ ] I have double checked and DEFINITELY added docs.

