### PR TITLE
[@kadena/client] Fixes types

### DIFF
--- a/common/changes/@kadena/client/fix-types_2023-05-23-12-45.json
+++ b/common/changes/@kadena/client/fix-types_2023-05-23-12-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "Fix type for addCap, add requestKey to IPactCommand",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -116,6 +116,8 @@ export interface IPactCommand {
     // (undocumented)
     publicMeta: IPublicMeta;
     // (undocumented)
+    requestKey?: string;
+    // (undocumented)
     signers: {
         pubKey: string;
         caps: {
@@ -233,7 +235,7 @@ export const Pact: IPact;
 // @alpha
 export class PactCommand implements IPactCommand, ICommandBuilder<Record<string, unknown>> {
     constructor();
-    addCap<T extends Array<PactValue> = Array<PactValue>>(capability: string, signer: string, ...args: T[]): this;
+    addCap<T extends Array<PactValue> = Array<PactValue>>(capability: string, signer: string, ...args: T): this;
     // (undocumented)
     addData(data: IPactCommand['data']): this;
     // (undocumented)

--- a/packages/libs/client/src/interfaces/IPactCommand.ts
+++ b/packages/libs/client/src/interfaces/IPactCommand.ts
@@ -18,6 +18,7 @@ export interface IPactCommand {
   }[];
   type: string;
   sigs: (ISignatureJson | undefined)[];
+  requestKey?: string;
 }
 
 /**

--- a/packages/libs/client/src/pact.ts
+++ b/packages/libs/client/src/pact.ts
@@ -270,7 +270,7 @@ export class PactCommand
   public addCap<T extends Array<PactValue> = Array<PactValue>>(
     capability: string,
     signer: string,
-    ...args: T[]
+    ...args: T
   ): this {
     this._unfinalizeTransaction();
 


### PR DESCRIPTION
- Fixes the type for addCap when building a transaction without generating types for the module first.
- Adds the requestKey to IPactCommand