### PR TITLE
[@kadena/cookbook] transfer-create using private key

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -711,6 +711,7 @@ importers:
       '@kadena/chainweb-node-client': workspace:*
       '@kadena/client': workspace:*
       '@kadena/pactjs-cli': workspace:*
+      '@kadena/types': workspace:*
       '@rushstack/eslint-config': ~2.6.2
       '@rushstack/heft': ~0.46.1
       '@types/heft-jest': ~1.0.3
@@ -725,6 +726,7 @@ importers:
       '@kadena-dev/eslint-plugin': link:../eslint-plugin
       '@kadena-dev/heft-rig': link:../heft-rig
       '@kadena/pactjs-cli': link:../pactjs-cli
+      '@kadena/types': link:../../libs/types
       '@rushstack/eslint-config': 2.6.2_eslint@8.41.0
       '@rushstack/heft': 0.46.7
       '@types/heft-jest': 1.0.3

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "f858c3936ab5850fb958a271c4ee4b5d20c99b12",
+  "pnpmShrinkwrapHash": "4d536fa4bc13a3841da524c54afff2b7fc03be0d",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/tools/cookbook/package.json
+++ b/packages/tools/cookbook/package.json
@@ -34,6 +34,7 @@
     "@kadena-dev/eslint-plugin": "workspace:*",
     "@kadena-dev/heft-rig": "workspace:*",
     "@kadena/pactjs-cli": "workspace:*",
+    "@kadena/types": "workspace:*",
     "@rushstack/eslint-config": "~2.6.2",
     "@rushstack/heft": "~0.46.1",
     "@types/heft-jest": "~1.0.3",

--- a/packages/tools/cookbook/src/accounts/transfer-create-with-chainweaver.ts
+++ b/packages/tools/cookbook/src/accounts/transfer-create-with-chainweaver.ts
@@ -1,9 +1,10 @@
 import { Pact, signWithChainweaver } from '@kadena/client';
+import { IPactDecimal } from '@kadena/types';
 
 import { accountKey } from '../utils/account-key';
 import { apiHost } from '../utils/api-host';
 
-const HELP: string = `Usage example: \n\nts-node transfer-create.js k:{senderPublicKey} k:{receiverPublicKey} amount`;
+const HELP: string = `Usage example: \n\nts-node transfer-create.js k:{senderPublicKey} k:{receiverPublicKey} {amount}`;
 const NETWORK_ID: 'testnet04' | 'mainnet01' | 'development' | undefined =
   'testnet04';
 const API_HOST: string = apiHost('1', 'testnet.', NETWORK_ID);
@@ -36,15 +37,17 @@ async function transferCreate(
     },
   };
 
-  const transactionBuilder = await Pact.modules.coin['transfer-create'](
+  const pactDecimal: IPactDecimal = { decimal: `${amount}` };
+
+  const transactionBuilder = Pact.modules.coin['transfer-create'](
     sender,
     receiver,
     () => '(read-keyset "ks")',
-    amount,
+    pactDecimal,
   )
     .addData(guardData)
     .addCap('coin.GAS', senderPublicKey)
-    .addCap('coin.TRANSFER', senderPublicKey, sender, receiver, amount)
+    .addCap('coin.TRANSFER', senderPublicKey, sender, receiver, pactDecimal)
     .setMeta({ sender }, NETWORK_ID);
 
   await signWithChainweaver(transactionBuilder);

--- a/packages/tools/cookbook/src/accounts/transfer-create-with-private-key.ts
+++ b/packages/tools/cookbook/src/accounts/transfer-create-with-private-key.ts
@@ -1,0 +1,86 @@
+import { PactCommand } from '@kadena/client';
+import { sign } from '@kadena/cryptography-utils';
+
+import { accountKey } from '../utils/account-key';
+import { apiHost } from '../utils/api-host';
+
+const HELP: string = `Usage example: \n\nts-node transfer-create.js k:{senderPublicKey} {senderPrivateKey} k:{receiverPublicKey} {amount}`;
+const NETWORK_ID: 'testnet04' | 'mainnet01' | 'development' | undefined =
+  'testnet04';
+const API_HOST: string = apiHost('1', 'testnet.', NETWORK_ID);
+
+if (process.argv.length !== 6) {
+  console.info(HELP);
+  process.exit(1);
+}
+
+const [sender, senderPrivateKey, receiver, transferAmount] =
+  process.argv.slice(2);
+
+/**
+ * Create a new KDA account and transfer funds to it
+ *
+ * @param sender - Account sending coins
+ * @param senderPrivateKey - Private key of the account sending the coins
+ * @param receiver - Account being created and receiving coins
+ * @param amount - Amount of coins transferred to the new account
+ * @return
+ */
+async function transferCreate(
+  sender: string,
+  senderPrivateKey: string,
+  receiver: string,
+  amount: number,
+): Promise<void> {
+  const senderPublicKey = accountKey(sender);
+  const guardData: Record<string, unknown> = {
+    ks: {
+      keys: [accountKey(receiver)],
+      pred: 'keys-all',
+    },
+  };
+
+  const pactDecimal = { decimal: `${amount}` };
+
+  const transactionBuilder = new PactCommand();
+  transactionBuilder.code = `(coin.transfer "${sender}" "${receiver}" ${amount})`;
+  transactionBuilder
+    .addData(guardData)
+    .addCap('coin.GAS', senderPublicKey)
+    .addCap('coin.TRANSFER', senderPublicKey, sender, receiver, pactDecimal)
+    .setMeta({ chainId: '1', sender }, NETWORK_ID);
+
+  const cmd = transactionBuilder.createCommand();
+
+  const sig = sign(cmd.cmd, {
+    publicKey: senderPublicKey,
+    secretKey: senderPrivateKey,
+  });
+
+  if (sig.sig === undefined) {
+    throw new Error('Failed to sign transaction');
+  }
+
+  transactionBuilder.addSignatures({ pubKey: senderPublicKey, sig: sig.sig });
+
+  await transactionBuilder.send(API_HOST);
+
+  const pollResult = await transactionBuilder.pollUntil(API_HOST, {
+    onPoll: async (transaction, pollRequest): Promise<void> => {
+      console.log(
+        `Polling ${transaction.requestKey}.\nStatus: ${transaction.status}`,
+      );
+      console.log(await pollRequest);
+    },
+  });
+
+  console.log('Polling Completed.');
+  console.log(pollResult);
+}
+
+transferCreate(
+  sender,
+  senderPrivateKey,
+  receiver,
+  Number(transferAmount),
+).catch(console.error);


### PR DESCRIPTION
Adds an example on how to create a `transfer-create` transaction and sign it with a private key.

Usage:
`ts-node transfer-create.js k:{senderPublicKey} k:{receiverPublicKey} {amount}`

