### PR TITLE
[Docs] Add lastmodified date to the page

### DIFF
--- a/packages/apps/kadena-docs/src/components/LastModifiedDate/LastModifiedDate.tsx
+++ b/packages/apps/kadena-docs/src/components/LastModifiedDate/LastModifiedDate.tsx
@@ -1,0 +1,19 @@
+import { Stack, Text } from '@kadena/react-components';
+
+import { formatISODate } from '@/utils/dates';
+import React, { FC } from 'react';
+
+interface IProps {
+  time: number;
+}
+
+export const LastModifiedDate: FC<IProps> = ({ time }) => {
+  const dateString = formatISODate(new Date(time));
+  return (
+    <Stack justifyContent="flex-end">
+      <Text size="sm">
+        Last updated <time dateTime={dateString}>{dateString}</time>
+      </Text>
+    </Stack>
+  );
+};

--- a/packages/apps/kadena-docs/src/components/LastModifiedDate/index.ts
+++ b/packages/apps/kadena-docs/src/components/LastModifiedDate/index.ts
@@ -1,0 +1,1 @@
+export { LastModifiedDate } from './LastModifiedDate';

--- a/packages/apps/kadena-docs/src/components/Layout/components/Main/Main.tsx
+++ b/packages/apps/kadena-docs/src/components/Layout/components/Main/Main.tsx
@@ -2,6 +2,7 @@ import { HomeHeader } from '../../Landing/components';
 import { SideMenu } from '../SideMenu';
 import { Footer, Header, Menu, MenuBack, Template, TitleHeader } from '../';
 
+import { LastModifiedDate } from '@/components';
 import { Breadcrumbs } from '@/components/Breadcrumbs';
 import { ITopDoc } from '@/data/getTopDocs';
 import { IMenuItem, IPageMeta, ISubHeaderElement } from '@/types/Layout';
@@ -25,6 +26,7 @@ export const Main: FC<IProps> = ({
     subTitle = '',
     description = '',
     layout: layoutType,
+    lastModifiedDate,
   },
   topDocs,
   aSideMenuTree,
@@ -94,7 +96,10 @@ export const Main: FC<IProps> = ({
         </Menu>
         <Layout isAsideOpen={isAsideOpen} aSideMenuTree={aSideMenuTree}>
           {isOneOfLayoutType(layoutType, 'full', 'code') && (
-            <Breadcrumbs menuItems={leftMenuTree} />
+            <>
+              <Breadcrumbs menuItems={leftMenuTree} />
+              <LastModifiedDate time={lastModifiedDate} />
+            </>
           )}
           {children}
         </Layout>

--- a/packages/apps/kadena-docs/src/components/index.ts
+++ b/packages/apps/kadena-docs/src/components/index.ts
@@ -5,3 +5,4 @@ export * from './Breadcrumbs';
 export * from './BrowseSection';
 export * from './LinkList';
 export * from './Analytics';
+export * from './LastModifiedDate';

--- a/packages/apps/kadena-docs/src/scripts/remarkFrontmatterToProps.js
+++ b/packages/apps/kadena-docs/src/scripts/remarkFrontmatterToProps.js
@@ -1,4 +1,5 @@
 import yaml from 'js-yaml';
+import fs from 'fs';
 
 const getFrontMatter = (node) => {
   const { type, value } = node;
@@ -8,8 +9,19 @@ const getFrontMatter = (node) => {
   }
 };
 
+const getModifiedDate = (file) => {
+  const stats = fs.statSync(file);
+  if (!stats.isFile()) return;
+  return stats.mtimeMs;
+};
+
+const getFileName = (file) => {
+  if (file.history.length === 0) return '';
+  return file.history[0];
+};
+
 const remarkFrontmatterToProps = () => {
-  return async (tree) => {
+  return async (tree, file) => {
     tree.children = tree.children.map((node) => {
       const data = getFrontMatter(node);
       if (!data) return node;
@@ -17,7 +29,10 @@ const remarkFrontmatterToProps = () => {
       return {
         type: 'props',
         data: {
-          frontmatter: data,
+          frontmatter: {
+            ...data,
+            lastModifiedDate: getModifiedDate(getFileName(file)),
+          },
         },
       };
     });

--- a/packages/apps/kadena-docs/src/types/Layout.ts
+++ b/packages/apps/kadena-docs/src/types/Layout.ts
@@ -21,6 +21,7 @@ export interface IPageMeta {
   label: string; // name of the pagdescription: string;
   layout: LayoutType;
   description: string;
+  lastModifiedDate: number;
 }
 export interface IMenuItem extends IPageMeta {
   root: string;


### PR DESCRIPTION
## Reason:
As a user I want to see what was the last moment the document was updated, so that I get the feeling that the file is up to date

Closes [[issue link](https://app.asana.com/0/1204526868335507/1204645223098991/f)]

## Changes made (preferably with images/screenshots):
![image](https://github.com/kadena-community/kadena.js/assets/4015521/e6fbc56a-4aad-438b-8b69-9e3ea0047109)


## Check off the following:

- [X] I have reviewed my changes and run the appropriate tests.
- [X] I have have run `rush change` to add the appropriate change logs.
- [ ] I have added/edited docs.
- [ ] I have added tutorials.
- [ ] I have double checked and DEFINITELY added docs.

