### PR TITLE
Format generated test file

### DIFF
--- a/packages/apps/kadena-docs/next-env.d.ts
+++ b/packages/apps/kadena-docs/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/libs/pactjs-test-project/package.json
+++ b/packages/libs/pactjs-test-project/package.json
@@ -21,6 +21,7 @@
     "pactjs:generate:contract:file": "pactjs contract-generate --file src/example-contract/coin.contract.pact && pactjs contract-generate --file src/example-contract/marmalade.module.pact",
     "pactjs:generate:contract:chain": "pactjs contract-generate --contract coin --api https://api.chainweb.com/chainweb/0.0/mainnet01/chain/0/pact;",
     "pactjs:generate:template": "pactjs template-generate --clean --file src/example-templates/tx-templates --out src/example-templates/generated-tx-templates",
+    "postpactjs:generate:template": "prettier --write -u src/example-templates/generated-tx-templates",
     "test": ""
   },
   "lint-staged": {


### PR DESCRIPTION
See https://github.com/kadena-community/kadena.js/pull/291#discussion_r1211732301

This is a quick fix so the generated file is reformatted according to our Prettier config. Ideally we would do it directly in code but that would require more changes and adding the dependency, but this is a test project so I didn't bother.

It's kinda weird that we have to take into account that Rush does not execute `npm run pre[task]` or `npm run post[task]` but in this case we can take advantage of it.