### PR TITLE
Propose to start using ADRs with an ADR and add a template

### DIFF
--- a/docs/decisions/0001-use-adr.md
+++ b/docs/decisions/0001-use-adr.md
@@ -1,0 +1,34 @@
+# Use ADRs
+
+Date: 2023-06-02
+
+Status: proposed
+
+## Context
+
+Sometimes we have requirements or make decisions in our architecture that
+deserve to be recorded properly. This is a format to do this. It also motivates
+to add more background information such as reasoning and considered alternatives
+(which isn't always appropriate or interesting in regular documentation).
+
+## Decision
+
+Record decisions in this repository using [the template][1].
+
+## Consequences
+
+We, our collaborators and our successors will have a better understanding of why
+things are the way they are, and make better decisions as a consequence.
+
+## Resources
+
+- [Documenting Architecture Decisions][2]
+- [Architecture decision record (ADR) examples for software planning, IT
+  leadership, and template documentation][3]
+- [The Markdown template for this ADR][4]
+
+[1]: ./0000-template.md
+[2]: https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions
+[3]: https://github.com/joelparkerhenderson/architecture-decision-record
+[4]:
+  https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md

--- a/docs/decisions/_template.md
+++ b/docs/decisions/_template.md
@@ -1,0 +1,17 @@
+# Title
+
+Date: YYYY-MM-DD
+
+Status: proposed | rejected | accepted | deprecated | ... | superseded by ...
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?


### PR DESCRIPTION
My feeling is that we have a need and desire to write down reasoning and decisions for all sorts of (architectural) decisions, for example:

- Why are we using monorepos and related tooling?
- What environments and browsers do we want to support for our packages/apps?
- Why and how are we using tools like TypeScript and ESLint etc.?
- How do we want to write cross-OS scripts?
- Let's use `@kadena/client` as entry point for common use cases
- ...
- ...

This is a proposal to start recording such decisions.

An example can be seen in the Remix repository: https://github.com/remix-run/remix/tree/main/decisions. Do you know of others?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204735333828872