### PR TITLE
Add existing coc

### DIFF
--- a/packages/apps/kadena-docs/src/data/menu.mjs
+++ b/packages/apps/kadena-docs/src/data/menu.mjs
@@ -719,6 +719,18 @@ export const menuData = [
         "isActive": false
       },
       {
+        "children": [],
+        "root": "/docs/contribute/code-of-conduct",
+        "title": "Code of Conduct",
+        "description": "Kadena Code of Conduct (Draft 2022)",
+        "menu": "Code of Conduct",
+        "label": "Code of Conduct",
+        "order": 3,
+        "layout": "full",
+        "isMenuOpen": false,
+        "isActive": false
+      },
+      {
         "children": [
           {
             "children": [],

--- a/packages/apps/kadena-docs/src/data/menu.mjs
+++ b/packages/apps/kadena-docs/src/data/menu.mjs
@@ -719,18 +719,6 @@ export const menuData = [
         "isActive": false
       },
       {
-        "children": [],
-        "root": "/docs/contribute/code-of-conduct",
-        "title": "Code of Conduct",
-        "description": "Kadena Code of Conduct (Draft 2022)",
-        "menu": "Code of Conduct",
-        "label": "Code of Conduct",
-        "order": 3,
-        "layout": "full",
-        "isMenuOpen": false,
-        "isActive": false
-      },
-      {
         "children": [
           {
             "children": [],
@@ -955,6 +943,16 @@ export const menuData = [
     "description": "Home page",
     "layout": "landing",
     "icon": "PactLanguage",
+    "isMenuOpen": false,
+    "isActive": false
+  },
+  {
+    "children": [],
+    "root": "/docs/code-of-conduct",
+    "title": "Code of Conduct",
+    "description": "Kadena Code of Conduct",
+    "label": "Code of Conduct",
+    "layout": "normal",
     "isMenuOpen": false,
     "isActive": false
   }

--- a/packages/apps/kadena-docs/src/pages/docs/code-of-conduct.mdx
+++ b/packages/apps/kadena-docs/src/pages/docs/code-of-conduct.mdx
@@ -1,13 +1,11 @@
 ---
 title: Code of Conduct
-description: Kadena Code of Conduct (Draft 2022)
-menu: Code of Conduct
+description: Kadena Code of Conduct
 label: Code of Conduct
-order: 3
-layout: full
+layout: normal
 ---
 
-## Kadena Code of Conduct (Draft 2022)
+## Kadena Code of Conduct
 
 Kadena is committed to fostering a friendly, safe, and inclusive environment for
 all, regardless of sex, gender identity and expression, sexual orientation,

--- a/packages/apps/kadena-docs/src/pages/docs/contribute/code-of-conduct.mdx
+++ b/packages/apps/kadena-docs/src/pages/docs/contribute/code-of-conduct.mdx
@@ -99,7 +99,8 @@ intent and forgive as long as you earn their trust.
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is officially representing Kadena in public spaces. This includes
 (but is not limited to) the Discord server, IRL Kadena events, and collaborative
-platforms utilized for Kadena projects like Notion, Google Docs, and Slack.
+platforms utilized for Kadena projects like GitHub, Notion, Google Docs, and
+Slack.
 
 The Kadena Code of Conduct applies equally to all members of the community,
 including staff.

--- a/packages/apps/kadena-docs/src/pages/docs/contribute/code-of-conduct.mdx
+++ b/packages/apps/kadena-docs/src/pages/docs/contribute/code-of-conduct.mdx
@@ -1,0 +1,111 @@
+---
+title: Code of Conduct
+description: Kadena Code of Conduct (Draft 2022)
+menu: Code of Conduct
+label: Code of Conduct
+order: 3
+layout: full
+---
+
+## Kadena Code of Conduct (Draft 2022)
+
+Kadena is committed to fostering a friendly, safe, and inclusive environment for
+all, regardless of sex, gender identity and expression, sexual orientation,
+disability, mental illness, neuro(a)typicality, physical appearance, race,
+ethnicity, religion, nationality, age, or level of experience.
+
+Kadena upholds these values within its own workplace and when it engages with
+third parties. Community members are expected to abide by the same standards.
+
+To that end, Kadena intends for our social channels to be a safe and welcoming
+environment that fosters open dialogue and the free expression of ideas, free of
+harassment, discrimination, and hostile conduct. Further, as extensions of
+Kadena, community members represent Kadena's brand and image, thus sharing a
+responsibility to create and maintain an environment for the benefit of all.
+
+The intention of this document is to set our expectations of community members
+and to promote consistency in behavior across all levels of the Kadena
+community. This is a living document that will be used to guide all activities
+and decision making.
+
+### Expected Behavior
+
+Avoid using overtly sexual aliases or other nicknames that might detract from a
+friendly, safe and welcoming environment for all. Respect that people have
+differences of opinion and that every design or implementation choice carries a
+trade-off and numerous costs. There is seldom a right answer. Aim to provide
+constructive criticism, and be able to recommend solid ideas. Inversely, we
+encourage you to gratefully accept constructive criticism. Use welcoming and
+inclusive language. We will exclude you from interaction if you insult, demean,
+or harass anyone. Private harassment is unacceptable. No matter who you are, if
+you feel you have been or are being harassed or made uncomfortable by a
+community member, please contact our Moderation team immediately. Use members'
+preferred pronouns.
+
+### Unacceptable Behavior
+
+Violence, threats of violence or violent language directed against another
+person. Sexist, racist, homophobic, transphobic, ableist or otherwise
+discriminatory jokes and language. Posting or displaying sexually explicit or
+violent material. Posting or threatening to post other people's personally
+identifying information ("doxing"). Personal insults, particularly those related
+to gender, sexual orientation, race, religion, or disability. Inappropriate
+photography or recording. Inappropriate physical contact. You should have
+someone's consent before touching them. Unwelcome sexual attention. This
+includes, sexualized comments or jokes; inappropriate touching, groping, and
+unwelcomed sexual advances. Deliberate intimidation, stalking or following
+(online or in person). Advocating for, or encouraging, any of the above
+behavior. Sustained disruption of community events, including talks and
+presentations.
+
+### Moderation
+
+These are the policies for upholding our community's standards of conduct.
+
+Remarks that violate the Kadena standards of conduct, including hateful,
+hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is
+allowed, but never targeting another user, and never in a hateful manner.)
+Remarks that moderators find inappropriate, whether listed in the code of
+conduct or not, are also not allowed. Moderators will first respond to such
+remarks with a warning. If the warning is unheeded, the user will be “kicked,”
+i.e., kicked out of the communication channel to cool off. If the user comes
+back and continues to make trouble, they will be banned, i.e., indefinitely
+excluded. Moderators may choose at their discretion to un-ban the user if it was
+a first offense and they offer the offended party a genuine apology. If a
+moderator bans someone and you think it was unjustified, please take it up with
+that moderator, or with a different moderator, in private. Complaints about bans
+in-channel are not allowed. Moderators are held to a higher standard than other
+community members. If a moderator creates an inappropriate situation, they
+should expect less leeway than others.
+
+In the Kadena community we strive to go the extra step to look out for each
+other. Don't just aim to be technically unimpeachable, try to be your best self.
+In particular, avoid flirting with offensive or sensitive issues, particularly
+if they're off-topic; this all too often leads to unnecessary fights, hurt
+feelings, and damaged trust; worse, it can drive people away from the community
+entirely.
+
+And if someone takes issue with something you said or did, resist the urge to be
+defensive. Just stop doing what it was they complained about and apologize. Even
+if you feel you were misinterpreted or unfairly accused, chances are good there
+was something you could've communicated better — remember that it's your
+responsibility to make your fellow community Members comfortable. Everyone wants
+to get along and we are all here first and foremost because we want to talk
+about cool technology. You will find that people will be eager to assume good
+intent and forgive as long as you earn their trust.
+
+### Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing Kadena in public spaces. This includes
+(but is not limited to) the Discord server, IRL Kadena events, and collaborative
+platforms utilized for Kadena projects like Notion, Google Docs, and Slack.
+
+The Kadena Code of Conduct applies equally to all members of the community,
+including staff.
+
+### Attribution
+
+This code of conduct document draws from the following projects: Friends with
+Benefits Code of Conduct, Rust's Code of Conduct, Stumptown Syndicate's Code of
+Conduct, and Python's Discord Code of Conduct.

--- a/packages/apps/kadena-docs/src/pages/docs/contribute/code-of-conduct.mdx
+++ b/packages/apps/kadena-docs/src/pages/docs/contribute/code-of-conduct.mdx
@@ -89,10 +89,20 @@ And if someone takes issue with something you said or did, resist the urge to be
 defensive. Just stop doing what it was they complained about and apologize. Even
 if you feel you were misinterpreted or unfairly accused, chances are good there
 was something you could've communicated better — remember that it's your
-responsibility to make your fellow community Members comfortable. Everyone wants
+responsibility to make your fellow community members comfortable. Everyone wants
 to get along and we are all here first and foremost because we want to talk
 about cool technology. You will find that people will be eager to assume good
 intent and forgive as long as you earn their trust.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[report@kadena.io][1]. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
 ### Scope
 
@@ -108,10 +118,11 @@ including staff.
 ### Attribution
 
 This code of conduct document draws from the following projects: [Friends with
-Benefits Code of Conduct][1], [Rust's Code of Conduct][2], [Stumptown
-Syndicate's Code of Conduct][3], and [Python's Discord Code of Conduct][4].
+Benefits Code of Conduct][2], [Rust's Code of Conduct][3], [Stumptown
+Syndicate's Code of Conduct][4], and [Python's Discord Code of Conduct][5].
 
-[1]: https://github.com/friends-with-benefits/codeofconduct/blob/main/code.md
-[2]: https://foundation.rust-lang.org/policies/code-of-conduct/
-[3]: https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md
-[4]: https://www.pythondiscord.com/pages/code-of-conduct/
+[1]: mailto:report@kadena.io
+[2]: https://github.com/friends-with-benefits/codeofconduct/blob/main/code.md
+[3]: https://foundation.rust-lang.org/policies/code-of-conduct/
+[4]: https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md
+[5]: https://www.pythondiscord.com/pages/code-of-conduct/

--- a/packages/apps/kadena-docs/src/pages/docs/contribute/code-of-conduct.mdx
+++ b/packages/apps/kadena-docs/src/pages/docs/contribute/code-of-conduct.mdx
@@ -106,6 +106,11 @@ including staff.
 
 ### Attribution
 
-This code of conduct document draws from the following projects: Friends with
-Benefits Code of Conduct, Rust's Code of Conduct, Stumptown Syndicate's Code of
-Conduct, and Python's Discord Code of Conduct.
+This code of conduct document draws from the following projects: [Friends with
+Benefits Code of Conduct][1], [Rust's Code of Conduct][2], [Stumptown
+Syndicate's Code of Conduct][3], and [Python's Discord Code of Conduct][4].
+
+[1]: https://github.com/friends-with-benefits/codeofconduct/blob/main/code.md
+[2]: https://foundation.rust-lang.org/policies/code-of-conduct/
+[3]: https://github.com/stumpsyn/policies/blob/master/citizen_code_of_conduct.md
+[4]: https://www.pythondiscord.com/pages/code-of-conduct/


### PR DESCRIPTION
Supersedes #350. I'm not seeing significant missing elements in comparison, except for a generic contact option (see below). So I'll close that one.

This is a copy of the draft at https://docs.google.com/document/d/1SU9OKkobYpq0R5vDK1MeYxiz8RpXxYmaceF3UMtzjXQ

- [x] Do we need HR or legal to review?
- [x] This misses contact options (i.e. email address). The original draft targeted Discord, where you can PM a moderator. GitHub (and other platforms) don't have that option.