### PR TITLE
[@kadena/react-ui]: Importing global styles

### DIFF
--- a/packages/libs/react-ui/.storybook/preview.ts
+++ b/packages/libs/react-ui/.storybook/preview.ts
@@ -1,7 +1,6 @@
 import { darkThemeClass } from '../src/styles';
 import type { Preview } from '@storybook/react';
 import { themes } from '@storybook/theming';
-import '../src/styles/global.css';
 
 const preview: Preview = {
   parameters: {

--- a/packages/libs/react-ui/src/index.ts
+++ b/packages/libs/react-ui/src/index.ts
@@ -1,3 +1,5 @@
+import './styles/global.css';
+
 export {
   IButtonProps,
   Button,


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 
Can you please fill out the information below to save us time looking into your PR. 
Start with explaining the reasons for this change, and if applicable link to an issue.
And explain the changes you have made.
-->

## Reason:

We need to be able to import global styles to the consuming application. The common way of importing it via a path to the file within the package wasn't working in this case so I thought of the following options:
- Add creating a global styles file as part of the setup instructions on the readme
- Importing the global styles file in the index file

Went the the later approach although I don't know if there are any repercussions to this strategy. I think this is fine for now, but let me know if you have any other ideas!


## Check off the following:

- [ ] I have reviewed my changes and run the appropriate tests.
- [ ] I have have run `rush change` to add the appropriate change logs.
- [ ] I have added/edited docs.
- [ ] I have added tutorials.
- [ ] I have double checked and DEFINITELY added docs.

