### PR TITLE
[docs] next prev navigation

### DIFF
--- a/packages/apps/kadena-docs/src/components/BottomPageSection/BottomPageSection.tsx
+++ b/packages/apps/kadena-docs/src/components/BottomPageSection/BottomPageSection.tsx
@@ -7,13 +7,13 @@ import { Wrapper } from './style';
 import React, { FC } from 'react';
 
 interface IProps {
-  filenameForEdit?: string;
+  editLink?: string;
 }
 
-export const BottomPageSection: FC<IProps> = ({ filenameForEdit }) => {
+export const BottomPageSection: FC<IProps> = ({ editLink }) => {
   return (
     <>
-      <EditPage filename={filenameForEdit} />
+      <EditPage editLink={editLink} />
       <Divider />
       <Wrapper>
         <div />

--- a/packages/apps/kadena-docs/src/components/BottomPageSection/BottomPageSection.tsx
+++ b/packages/apps/kadena-docs/src/components/BottomPageSection/BottomPageSection.tsx
@@ -1,19 +1,38 @@
-import { Divider } from '@kadena/react-components';
+import { Divider, Stack } from '@kadena/react-components';
 
 import { EditPage } from './components/EditPage';
 import { Subscribe } from './components/Subscribe';
 import { Wrapper } from './style';
 
+import { INavigation } from '@/types/Layout';
+import Link from 'next/link';
 import React, { FC } from 'react';
 
 interface IProps {
   editLink?: string;
+  navigation?: INavigation;
 }
 
-export const BottomPageSection: FC<IProps> = ({ editLink }) => {
+export const BottomPageSection: FC<IProps> = ({ editLink, navigation }) => {
   return (
     <>
-      <EditPage editLink={editLink} />
+      <Stack alignItems="center" justifyContent="space-between">
+        <EditPage editLink={editLink} />
+        {navigation?.previous !== undefined && (
+          <Link href={navigation?.previous.root}>
+            previous:
+            <br />
+            {navigation?.previous.title}
+          </Link>
+        )}
+        {navigation?.next !== undefined && (
+          <Link href={navigation?.next.root}>
+            next:
+            <br />
+            {navigation?.next.title}
+          </Link>
+        )}
+      </Stack>
       <Divider />
       <Wrapper>
         <div />

--- a/packages/apps/kadena-docs/src/components/BottomPageSection/components/EditPage.tsx
+++ b/packages/apps/kadena-docs/src/components/BottomPageSection/components/EditPage.tsx
@@ -3,17 +3,15 @@ import { Button } from '@kadena/react-components';
 import { FC } from 'react';
 
 interface IProps {
-  filename?: string;
+  editLink?: string;
 }
 
-const editRoot = process.env.NEXT_PUBLIC_GIT_EDIT_ROOT;
-
-export const EditPage: FC<IProps> = ({ filename }) => {
-  if (editRoot === null || filename === null) return null;
+export const EditPage: FC<IProps> = ({ editLink }) => {
+  if (Boolean(editLink) === null) return null;
   return (
     <Button
       as="a"
-      href={`${editRoot}${filename}`}
+      href={editLink}
       target="_blank"
       rel="noreferrer"
       title="Edit this page"

--- a/packages/apps/kadena-docs/src/components/Layout/Code/Code.tsx
+++ b/packages/apps/kadena-docs/src/components/Layout/Code/Code.tsx
@@ -11,13 +11,18 @@ import { BottomPageSection } from '@/components/BottomPageSection';
 import { ILayout } from '@/types/Layout';
 import React, { FC } from 'react';
 
-export const Code: FC<ILayout> = ({ children, isAsideOpen, editLink }) => {
+export const Code: FC<ILayout> = ({
+  children,
+  isAsideOpen,
+  editLink,
+  navigation,
+}) => {
   return (
     <>
       <Content id="maincontent">
         <Article>
           {children}
-          <BottomPageSection editLink={editLink} />
+          <BottomPageSection editLink={editLink} navigation={navigation} />
         </Article>
       </Content>
       <CodeBackground isOpen={isAsideOpen} />

--- a/packages/apps/kadena-docs/src/components/Layout/Code/Code.tsx
+++ b/packages/apps/kadena-docs/src/components/Layout/Code/Code.tsx
@@ -11,17 +11,13 @@ import { BottomPageSection } from '@/components/BottomPageSection';
 import { ILayout } from '@/types/Layout';
 import React, { FC } from 'react';
 
-export const Code: FC<ILayout> = ({
-  children,
-  isAsideOpen,
-  filenameForEdit,
-}) => {
+export const Code: FC<ILayout> = ({ children, isAsideOpen, editLink }) => {
   return (
     <>
       <Content id="maincontent">
         <Article>
           {children}
-          <BottomPageSection filenameForEdit={filenameForEdit} />
+          <BottomPageSection editLink={editLink} />
         </Article>
       </Content>
       <CodeBackground isOpen={isAsideOpen} />

--- a/packages/apps/kadena-docs/src/components/Layout/Full/Full.tsx
+++ b/packages/apps/kadena-docs/src/components/Layout/Full/Full.tsx
@@ -21,6 +21,7 @@ export const Full: FC<ILayout> = ({
   children,
   aSideMenuTree = [],
   editLink,
+  navigation,
 }) => {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
@@ -65,7 +66,7 @@ export const Full: FC<ILayout> = ({
       <Content id="maincontent">
         <Article ref={scrollRef}>
           {children}
-          <BottomPageSection editLink={editLink} />
+          <BottomPageSection editLink={editLink} navigation={navigation} />
         </Article>
       </Content>
       <AsideBackground />

--- a/packages/apps/kadena-docs/src/components/Layout/Full/Full.tsx
+++ b/packages/apps/kadena-docs/src/components/Layout/Full/Full.tsx
@@ -20,7 +20,7 @@ import React, { FC, useEffect, useRef, useState } from 'react';
 export const Full: FC<ILayout> = ({
   children,
   aSideMenuTree = [],
-  filenameForEdit,
+  editLink,
 }) => {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const router = useRouter();
@@ -65,7 +65,7 @@ export const Full: FC<ILayout> = ({
       <Content id="maincontent">
         <Article ref={scrollRef}>
           {children}
-          <BottomPageSection filenameForEdit={filenameForEdit} />
+          <BottomPageSection editLink={editLink} />
         </Article>
       </Content>
       <AsideBackground />

--- a/packages/apps/kadena-docs/src/components/Layout/components/Main/Main.tsx
+++ b/packages/apps/kadena-docs/src/components/Layout/components/Main/Main.tsx
@@ -19,6 +19,7 @@ export const Main: FC<IPageProps> = ({
     lastModifiedDate,
     icon: pageIcon,
     editLink,
+    navigation,
   },
   topDocs,
   aSideMenuTree,
@@ -90,6 +91,7 @@ export const Main: FC<IPageProps> = ({
           isAsideOpen={isAsideOpen}
           aSideMenuTree={aSideMenuTree}
           editLink={editLink}
+          navigation={navigation}
         >
           {isOneOfLayoutType(layoutType, 'full', 'code') && (
             <>

--- a/packages/apps/kadena-docs/src/components/Layout/components/Main/Main.tsx
+++ b/packages/apps/kadena-docs/src/components/Layout/components/Main/Main.tsx
@@ -18,7 +18,7 @@ export const Main: FC<IPageProps> = ({
     layout: layoutType,
     lastModifiedDate,
     icon: pageIcon,
-    filename: filenameForEdit = '',
+    editLink,
   },
   topDocs,
   aSideMenuTree,
@@ -89,7 +89,7 @@ export const Main: FC<IPageProps> = ({
         <Layout
           isAsideOpen={isAsideOpen}
           aSideMenuTree={aSideMenuTree}
-          filenameForEdit={filenameForEdit}
+          editLink={editLink}
         >
           {isOneOfLayoutType(layoutType, 'full', 'code') && (
             <>

--- a/packages/apps/kadena-docs/src/scripts/remarkFrontmatterToProps.js
+++ b/packages/apps/kadena-docs/src/scripts/remarkFrontmatterToProps.js
@@ -1,5 +1,7 @@
 import yaml from 'js-yaml';
 import fs from 'fs';
+import { getPathName } from './../utils/staticGeneration/checkSubTreeForActive.js';
+import { getData } from './../utils/staticGeneration/getData.js';
 
 const getFrontMatter = (node) => {
   const { type, value } = node;
@@ -38,6 +40,30 @@ const getFileNameInPackage = (file) => {
   return `/${newPath}`;
 };
 
+const flat = (acc, val) => {
+  const { children, ...newVal } = val;
+
+  return [
+    ...acc,
+    newVal,
+    children ? children.reduce(flat, []).flat() : undefined,
+  ];
+};
+/**
+ * create a navigation object with the next and previous link in the navigation json.
+ */
+const createNavigation = (file) => {
+  const path = getPathName(getFileName(file));
+  const flatData = getData().reduce(flat, []).flat();
+
+  const itemIdx = flatData.findIndex((i) => i.root === path);
+
+  return {
+    previous: flatData[itemIdx - 1] ?? undefined,
+    next: flatData[itemIdx + 1] ?? undefined,
+  };
+};
+
 const remarkFrontmatterToProps = () => {
   return async (tree, file) => {
     tree.children = tree.children.map((node) => {
@@ -53,6 +79,7 @@ const remarkFrontmatterToProps = () => {
               process.env.NEXT_PUBLIC_GIT_EDIT_ROOT +
               getFileNameInPackage(file),
             lastModifiedDate: getModifiedDate(getFileName(file)),
+            navigation: createNavigation(file),
           },
         },
       };

--- a/packages/apps/kadena-docs/src/scripts/remarkFrontmatterToProps.js
+++ b/packages/apps/kadena-docs/src/scripts/remarkFrontmatterToProps.js
@@ -49,7 +49,9 @@ const remarkFrontmatterToProps = () => {
         data: {
           frontmatter: {
             ...data,
-            filename: getFileNameInPackage(file),
+            editLink:
+              process.env.NEXT_PUBLIC_GIT_EDIT_ROOT +
+              getFileNameInPackage(file),
             lastModifiedDate: getModifiedDate(getFileName(file)),
           },
         },

--- a/packages/apps/kadena-docs/src/types/Layout.ts
+++ b/packages/apps/kadena-docs/src/types/Layout.ts
@@ -25,6 +25,10 @@ export interface IPageMeta {
   editLink: string;
   lastModifiedDate?: Date;
   icon?: ProductIconNames;
+  navigation: {
+    previous?: string;
+    next?: string;
+  };
 }
 export interface IMenuItem extends IPageMeta {
   root: string;

--- a/packages/apps/kadena-docs/src/types/Layout.ts
+++ b/packages/apps/kadena-docs/src/types/Layout.ts
@@ -14,6 +14,11 @@ export interface ISubHeaderElement {
   children: ISubHeaderElement[];
 }
 
+export interface INavigation {
+  previous?: IMenuItem;
+  next?: IMenuItem;
+}
+
 export interface IPageMeta {
   title: string; // title of the HEAD info
   subTitle?: string;
@@ -25,10 +30,7 @@ export interface IPageMeta {
   editLink: string;
   lastModifiedDate?: Date;
   icon?: ProductIconNames;
-  navigation: {
-    previous?: string;
-    next?: string;
-  };
+  navigation: INavigation;
 }
 export interface IMenuItem extends IPageMeta {
   root: string;
@@ -42,6 +44,7 @@ export interface ILayout {
   isAsideOpen?: boolean;
   aSideMenuTree?: ISubHeaderElement[];
   editLink?: string;
+  navigation?: INavigation;
 }
 
 export type LevelType = 1 | 2 | 3;

--- a/packages/apps/kadena-docs/src/types/Layout.ts
+++ b/packages/apps/kadena-docs/src/types/Layout.ts
@@ -22,7 +22,7 @@ export interface IPageMeta {
   label: string; // name of the pagdescription: string;
   layout: LayoutType;
   description: string;
-  filename: string;
+  editLink: string;
   lastModifiedDate?: Date;
   icon?: ProductIconNames;
 }
@@ -37,7 +37,7 @@ export interface ILayout {
   children?: ReactNode;
   isAsideOpen?: boolean;
   aSideMenuTree?: ISubHeaderElement[];
-  filenameForEdit?: string;
+  editLink?: string;
 }
 
 export type LevelType = 1 | 2 | 3;


### PR DESCRIPTION
## Reason:
as a user i want to easily navigate from page to page.
the next and previous button will get you to appropriate pages in the navigation.

There is no design implemented yet. just the functionality.
Designs are not ready yet

Closes [[issue link](https://app.asana.com/0/1204649083736950/1204691278957821/f)]

![image](https://github.com/kadena-community/kadena.js/assets/4015521/b4ac7f62-d624-4315-8361-3980a364d59e)

## Check off the following:

- [ ] I have reviewed my changes and run the appropriate tests.
- [ ] I have have run `rush change` to add the appropriate change logs.
- [ ] I have added/edited docs.
- [ ] I have added tutorials.
- [ ] I have double checked and DEFINITELY added docs.

