### PR TITLE
[@kadena/react-ui]: Changing token naming convention and lint cleanup

### DIFF
--- a/packages/libs/react-ui/src/components/Button/Button.css.ts
+++ b/packages/libs/react-ui/src/components/Button/Button.css.ts
@@ -10,13 +10,13 @@ export const container = style([
   sprinkles({
     display: 'flex',
     placeItems: 'center',
-    gap: 1,
-    borderRadius: 'sm',
+    gap: '$2',
+    borderRadius: '$sm',
     cursor: 'pointer',
-    paddingX: 4,
-    paddingY: 3,
+    paddingX: '$4',
+    paddingY: '$3',
     border: 'none',
-    fontSize: 'base',
+    fontSize: '$base',
   }),
   {
     transition: 'background-color 0.4s ease',
@@ -28,14 +28,14 @@ export const container = style([
     },
     ':focus-visible': {
       outlineOffset: '2px',
-      outlineWidth: vars.borderWidths.md,
+      outlineWidth: vars.borderWidths.$md,
       outlineStyle: 'solid',
       outlineColor: focusOutlineColor,
     },
     ':disabled': {
       opacity: 0.7,
-      background: vars.colors.neutral3,
-      color: vars.colors.neutral1,
+      background: vars.colors.$neutral3,
+      color: vars.colors.$neutral1,
       cursor: 'not-allowed',
     },
   },
@@ -53,14 +53,14 @@ export const colorVariants = styleVariants(colors, (color) => {
   return [
     container,
     sprinkles({
-      color: `${color}Surface`,
-      bg: `${color}Contrast`,
+      color: `$${color}Surface`,
+      bg: `$${color}Contrast`,
     }),
     {
       vars: {
-        [bgHoverColor]: vars.colors[`${color}HighContrast`],
-        [bgActiveColor]: vars.colors[`${color}Accent`],
-        [focusOutlineColor]: vars.colors[`${color}Accent`],
+        [bgHoverColor]: vars.colors[`$${color}HighContrast`],
+        [bgActiveColor]: vars.colors[`$${color}Accent`],
+        [focusOutlineColor]: vars.colors[`$${color}Accent`],
       },
     },
   ];

--- a/packages/libs/react-ui/src/components/Card/Card.css.ts
+++ b/packages/libs/react-ui/src/components/Card/Card.css.ts
@@ -4,15 +4,15 @@ import { style } from '@vanilla-extract/css';
 
 export const container = style([
   sprinkles({
-    background: 'neutral2',
-    color: 'neutral6',
+    background: '$neutral2',
+    color: '$neutral6',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'flex-start',
-    paddingX: 'lg',
-    paddingY: 'md',
-    borderRadius: 'sm',
-    marginY: 'md',
+    paddingX: '$lg',
+    paddingY: '$md',
+    borderRadius: '$sm',
+    marginY: '$md',
     border: 'none',
     width: 'max-content',
   }),
@@ -25,13 +25,13 @@ export const stackClass = style([
   {
     selectors: {
       '&:not(:last-child)': {
-        borderBottom: `1px solid ${vars.colors.neutral3}`,
+        borderBottom: `1px solid ${vars.colors.$neutral3}`,
       },
       '&:first-child': {
-        borderRadius: `${vars.radii.sm} ${vars.radii.sm} 0 0`,
+        borderRadius: `${vars.radii.$sm} ${vars.radii.$sm} 0 0`,
       },
       '&:last-child': {
-        borderRadius: `0 0 ${vars.radii.sm} ${vars.radii.sm}`,
+        borderRadius: `0 0 ${vars.radii.$sm} ${vars.radii.$sm}`,
       },
     },
   },

--- a/packages/libs/react-ui/src/components/Icons/IconWrapper.css.ts
+++ b/packages/libs/react-ui/src/components/Icons/IconWrapper.css.ts
@@ -4,12 +4,12 @@ import { style, styleVariants } from '@vanilla-extract/css';
 
 export const iconContainer = style([
   sprinkles({
-    color: 'foreground',
+    color: '$foreground',
   }),
 ]);
 
 export const sizeVariants = styleVariants({
-  sm: [iconContainer, sprinkles({ size: 4 })],
+  sm: [iconContainer, sprinkles({ size: '$4' })],
   md: [iconContainer, sprinkles({ size: 6 })],
   lg: [iconContainer, sprinkles({ size: 8 })],
   xl: [iconContainer, sprinkles({ size: 10 })],

--- a/packages/libs/react-ui/src/components/Icons/stories.css.ts
+++ b/packages/libs/react-ui/src/components/Icons/stories.css.ts
@@ -5,7 +5,7 @@ import { style } from '@vanilla-extract/css';
 export const gridContainer = style([
   sprinkles({
     display: 'grid',
-    gap: 'xl',
+    gap: '$xl',
   }),
   {
     gridTemplateColumns: 'repeat(3, 1fr)',
@@ -18,7 +18,7 @@ export const gridItem = style([
     flexDirection: 'row',
     justifyContent: 'flex-start',
     alignItems: 'center',
-    gap: 'xs',
-    padding: 'sm',
+    gap: '$xs',
+    padding: '$sm',
   }),
 ]);

--- a/packages/libs/react-ui/src/components/Stack/Stack.css.ts
+++ b/packages/libs/react-ui/src/components/Stack/Stack.css.ts
@@ -10,16 +10,16 @@ export const container = style([
 
 export const spacingClass = styleVariants({
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  '2xs': [sprinkles({ gap: '2xs' })],
-  xs: [sprinkles({ gap: 'xs' })],
-  sm: [sprinkles({ gap: 'sm' })],
-  md: [sprinkles({ gap: 'md' })],
-  lg: [sprinkles({ gap: 'lg' })],
-  xl: [sprinkles({ gap: 'xl' })],
+  '2xs': [sprinkles({ gap: '$2xs' })],
+  xs: [sprinkles({ gap: '$xs' })],
+  sm: [sprinkles({ gap: '$sm' })],
+  md: [sprinkles({ gap: '$md' })],
+  lg: [sprinkles({ gap: '$lg' })],
+  xl: [sprinkles({ gap: '$xl' })],
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  '2xl': [sprinkles({ gap: '2xl' })],
+  '2xl': [sprinkles({ gap: '$2xl' })],
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  '3xl': [sprinkles({ gap: '3xl' })],
+  '3xl': [sprinkles({ gap: '$3xl' })],
 });
 
 export const justifyContentClass = styleVariants({

--- a/packages/libs/react-ui/src/components/Typography/GradientText/GradientText.css.ts
+++ b/packages/libs/react-ui/src/components/Typography/GradientText/GradientText.css.ts
@@ -4,7 +4,7 @@ import { style } from '@vanilla-extract/css';
 
 export const gradientTextClass = style([
   sprinkles({
-    fontWeight: 'bold',
+    fontWeight: '$bold',
   }),
   {
     backgroundColor: 'inherit',

--- a/packages/libs/react-ui/src/components/Typography/Heading/Heading.css.ts
+++ b/packages/libs/react-ui/src/components/Typography/Heading/Heading.css.ts
@@ -13,68 +13,68 @@ export const elementVariants = {
   h1: [
     sprinkles({
       fontSize: {
-        xs: '5xl',
-        md: '7xl',
-        lg: '9xl',
-        xl: '10xl',
-        '2xl': '12xl',
+        xs: '$5xl',
+        md: '$7xl',
+        lg: '$9xl',
+        xl: '$10xl',
+        xxl: '$12xl',
       },
     }),
   ],
   h2: [
     sprinkles({
-      fontWeight: 'bold',
+      fontWeight: '$bold',
       fontSize: {
-        xs: '4xl',
-        lg: '6xl',
-        xl: '8xl',
-        '2xl': '9xl',
+        xs: '$4xl',
+        lg: '$6xl',
+        xl: '$8xl',
+        xxl: '$9xl',
       },
     }),
   ],
   h3: [
     sprinkles({
       fontSize: {
-        xs: '2xl',
-        lg: '4xl',
-        xl: '5xl',
-        '2xl': '6xl',
+        xs: '$2xl',
+        lg: '$4xl',
+        xl: '$5xl',
+        xxl: '$6xl',
       },
     }),
   ],
   h4: [
     sprinkles({
       fontSize: {
-        xs: 'xl',
-        lg: '2xl',
-        xl: '3xl',
-        '2xl': '4xl',
+        xs: '$xl',
+        lg: '$2xl',
+        xl: '$3xl',
+        xxl: '$4xl',
       },
     }),
   ],
   h5: [
     sprinkles({
       fontSize: {
-        xs: 'lg',
-        xl: 'xl',
-        '2xl': '4xl',
+        xs: '$lg',
+        xl: '$xl',
+        xxl: '$4xl',
       },
     }),
   ],
   h6: [
     sprinkles({
       fontSize: {
-        xs: 'base',
-        xl: 'md',
-        '2xl': 'lg',
+        xs: '$base',
+        xl: '$md',
+        xxl: '$lg',
       },
     }),
   ],
 };
 
 export const boldVariants = {
-  true: [sprinkles({ fontWeight: 'semiBold' })],
-  false: [sprinkles({ fontWeight: 'normal' })],
+  true: [sprinkles({ fontWeight: '$semiBold' })],
+  false: [sprinkles({ fontWeight: '$normal' })],
 };
 
 export const heading = recipe({
@@ -92,7 +92,7 @@ export const heading = recipe({
         variant: 'h1',
         bold: true,
       },
-      style: [sprinkles({ fontWeight: 'bold' })],
+      style: [sprinkles({ fontWeight: '$bold' })],
     },
     {
       variants: {
@@ -100,14 +100,14 @@ export const heading = recipe({
         variant: 'h1',
         bold: false,
       },
-      style: [sprinkles({ fontWeight: 'light' })],
+      style: [sprinkles({ fontWeight: '$light' })],
     },
     {
       variants: {
         variant: 'h2',
         bold: true,
       },
-      style: [sprinkles({ fontWeight: 'bold' })],
+      style: [sprinkles({ fontWeight: '$bold' })],
     },
     {
       variants: {
@@ -115,7 +115,7 @@ export const heading = recipe({
         variant: 'h2',
         bold: false,
       },
-      style: [sprinkles({ fontWeight: 'light' })],
+      style: [sprinkles({ fontWeight: '$light' })],
     },
   ],
 

--- a/packages/libs/react-ui/src/components/Typography/Text/Text.css.ts
+++ b/packages/libs/react-ui/src/components/Typography/Text/Text.css.ts
@@ -8,19 +8,19 @@ import {
 import { style, styleVariants } from '@vanilla-extract/css';
 
 export const elementVariant = styleVariants({
-  p: [sprinkles({ fontWeight: 'normal' })],
-  span: [sprinkles({ fontWeight: 'normal' })],
-  code: [sprinkles({ fontWeight: 'normal' })],
-  label: [sprinkles({ fontWeight: 'medium' })],
+  p: [sprinkles({ fontWeight: '$normal' })],
+  span: [sprinkles({ fontWeight: '$normal' })],
+  code: [sprinkles({ fontWeight: '$normal' })],
+  label: [sprinkles({ fontWeight: '$medium' })],
 });
 
 export const sizeVariant = styleVariants({
-  sm: [sprinkles({ fontSize: 'xs' })],
-  md: [sprinkles({ fontSize: 'sm' })],
-  lg: [sprinkles({ fontSize: 'base' })],
+  sm: [sprinkles({ fontSize: '$xs' })],
+  md: [sprinkles({ fontSize: '$sm' })],
+  lg: [sprinkles({ fontSize: '$base' })],
 });
 
 export const fontVariant = styleVariants(fontVariants);
 export const transformVariant = styleVariants(transformVariants);
 export const colorVariant = styleVariants(colorVariants);
-export const boldClass = style([sprinkles({ fontWeight: 'semiBold' })]);
+export const boldClass = style([sprinkles({ fontWeight: '$semiBold' })]);

--- a/packages/libs/react-ui/src/components/Typography/typography.css.ts
+++ b/packages/libs/react-ui/src/components/Typography/typography.css.ts
@@ -3,8 +3,8 @@ import { sprinkles } from '../../styles';
 import { ComplexStyleRule } from '@vanilla-extract/css';
 
 export const fontVariants: Record<string | number, ComplexStyleRule> = {
-  main: [sprinkles({ fontFamily: 'main' })],
-  mono: [sprinkles({ fontFamily: 'mono' })],
+  main: [sprinkles({ fontFamily: '$main' })],
+  mono: [sprinkles({ fontFamily: '$mono' })],
 };
 
 export const transformVariants: Record<string | number, ComplexStyleRule> = {
@@ -15,6 +15,6 @@ export const transformVariants: Record<string | number, ComplexStyleRule> = {
 };
 
 export const colorVariants: Record<string | number, ComplexStyleRule> = {
-  default: [sprinkles({ color: 'neutral4' })],
-  emphasize: [sprinkles({ color: 'neutral6' })],
+  default: [sprinkles({ color: '$neutral4' })],
+  emphasize: [sprinkles({ color: '$neutral6' })],
 };

--- a/packages/libs/react-ui/src/components/Typography/typography.css.ts
+++ b/packages/libs/react-ui/src/components/Typography/typography.css.ts
@@ -1,20 +1,20 @@
-/* eslint @kadena-dev/typedef-var: 0 */
-
 import { sprinkles } from '../../styles';
 
-export const fontVariants = {
+import { ComplexStyleRule } from '@vanilla-extract/css';
+
+export const fontVariants: Record<string | number, ComplexStyleRule> = {
   main: [sprinkles({ fontFamily: 'main' })],
   mono: [sprinkles({ fontFamily: 'mono' })],
 };
 
-export const transformVariants = {
+export const transformVariants: Record<string | number, ComplexStyleRule> = {
   uppercase: [sprinkles({ textTransform: 'uppercase' })],
   lowercase: [sprinkles({ textTransform: 'lowercase' })],
   capitalize: [sprinkles({ textTransform: 'capitalize' })],
   none: [sprinkles({ textTransform: 'none' })],
 };
 
-export const colorVariants = {
+export const colorVariants: Record<string | number, ComplexStyleRule> = {
   default: [sprinkles({ color: 'neutral4' })],
   emphasize: [sprinkles({ color: 'neutral6' })],
 };

--- a/packages/libs/react-ui/src/styles/global.css.ts
+++ b/packages/libs/react-ui/src/styles/global.css.ts
@@ -24,7 +24,7 @@ globalStyle('*', {
 */
 globalStyle('html, body', {
   height: '100%',
-  fontFamily: vars.fonts.main,
+  fontFamily: vars.fonts.$main,
 });
 
 /*
@@ -71,39 +71,39 @@ globalStyle('#root, #__next', {
 */
 globalStyle(':root', {
   vars: {
-    '--spacing-2xs': vars.sizes['1'],
-    '--spacing-xs': vars.sizes['2'],
-    '--spacing-sm': vars.sizes['3'],
-    '--spacing-md': vars.sizes['4'],
-    '--spacing-lg': vars.sizes['6'],
-    '--spacing-xl': vars.sizes['7'],
-    '--spacing-2xl': vars.sizes['9'],
-    '--spacing-3xl': vars.sizes['10'],
+    '--spacing-2xs': vars.sizes.$1,
+    '--spacing-xs': vars.sizes.$2,
+    '--spacing-sm': vars.sizes.$3,
+    '--spacing-md': vars.sizes.$4,
+    '--spacing-lg': vars.sizes.$6,
+    '--spacing-xl': vars.sizes.$7,
+    '--spacing-2xl': vars.sizes.$9,
+    '--spacing-3xl': vars.sizes.$10,
   },
   '@media': {
     [breakpoints.md]: {
       vars: {
-        '--spacing-3xl': vars.sizes['12'],
+        '--spacing-3xl': vars.sizes.$12,
       },
     },
     [breakpoints.lg]: {
       vars: {
-        '--spacing-2xl': vars.sizes['10'],
-        '--spacing-3xl': vars.sizes['15'],
+        '--spacing-2xl': vars.sizes.$10,
+        '--spacing-3xl': vars.sizes.$15,
       },
     },
     [breakpoints.xl]: {
       vars: {
-        '--spacing-xl': vars.sizes['8'],
-        '--spacing-2xl': vars.sizes['13'],
-        '--spacing-3xl': vars.sizes['20'],
+        '--spacing-xl': vars.sizes.$8,
+        '--spacing-2xl': vars.sizes.$13,
+        '--spacing-3xl': vars.sizes.$20,
       },
     },
-    [breakpoints['2xl']]: {
+    [breakpoints.xxl]: {
       vars: {
-        '--spacing-xl': vars.sizes['11'],
-        '--spacing-2xl': vars.sizes['17'],
-        '--spacing-3xl': vars.sizes['25'],
+        '--spacing-xl': vars.sizes.$11,
+        '--spacing-2xl': vars.sizes.$17,
+        '--spacing-3xl': vars.sizes.$25,
       },
     },
   },

--- a/packages/libs/react-ui/src/styles/sprinkles.css.ts
+++ b/packages/libs/react-ui/src/styles/sprinkles.css.ts
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/naming-convention: 0 */
-
 import { darkThemeClass, vars } from './themes.css';
 
 import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';

--- a/packages/libs/react-ui/src/styles/sprinkles.css.ts
+++ b/packages/libs/react-ui/src/styles/sprinkles.css.ts
@@ -1,16 +1,16 @@
-/* eslint @typescript-eslint/naming-convention: 0, @kadena-dev/typedef-var: 0 */
+/* eslint @typescript-eslint/naming-convention: 0 */
 
 import { darkThemeClass, vars } from './themes.css';
 
 import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';
 
-export const breakpoints = {
+export const breakpoints: Record<string, string> = {
   sm: `(min-width: ${640 / 16}rem)`,
   md: `(min-width: ${768 / 16}rem)`,
   lg: `(min-width: ${1024 / 16}rem)`,
   xl: `(min-width: ${1280 / 16}rem)`,
   '2xl': `(min-width: ${1536 / 16}rem)`,
-} as const;
+};
 
 const systemProperties = defineProperties({
   properties: {

--- a/packages/libs/react-ui/src/styles/sprinkles.css.ts
+++ b/packages/libs/react-ui/src/styles/sprinkles.css.ts
@@ -9,7 +9,7 @@ export const breakpoints: Record<string, string> = {
   md: `(min-width: ${768 / 16}rem)`,
   lg: `(min-width: ${1024 / 16}rem)`,
   xl: `(min-width: ${1280 / 16}rem)`,
-  '2xl': `(min-width: ${1536 / 16}rem)`,
+  xxl: `(min-width: ${1536 / 16}rem)`,
 };
 
 const systemProperties = defineProperties({
@@ -56,7 +56,7 @@ const responsiveProperties = defineProperties({
     md: { '@media': breakpoints.md },
     lg: { '@media': breakpoints.lg },
     xl: { '@media': breakpoints.xl },
-    '2xl': { '@media': breakpoints['2xl'] },
+    xxl: { '@media': breakpoints.xxl },
   },
   defaultCondition: 'xs',
   properties: {

--- a/packages/libs/react-ui/src/styles/themes.css.ts
+++ b/packages/libs/react-ui/src/styles/themes.css.ts
@@ -1,163 +1,162 @@
-/* eslint @typescript-eslint/naming-convention: 0 */
-
 import { createGlobalTheme, createTheme } from '@vanilla-extract/css';
 
 export const vars = createGlobalTheme(':root', {
   fonts: {
-    main: "'Haas Grotesk Display', -apple-system, sans-serif",
-    mono: "'Kadena Code', Menlo, monospace",
+    $main: "'Haas Grotesk Display', -apple-system, sans-serif",
+    $mono: "'Kadena Code', Menlo, monospace",
   },
   fontSizes: {
-    xs: '0.75rem', // 12px
-    sm: '0.875rem', // 14px
-    base: '1rem', // 16px
-    md: '1.123rem', // 18px
-    lg: '1.25rem', // 20px
-    xl: '1.5rem', // 24px
-    '2xl': '1.75rem', // 28px
-    '3xl': '2rem', // 32px
-    '4xl': '2.25rem', // 36px
-    '5xl': '2.5rem', // 40px
-    '6xl': '2.75rem', // 44px
-    '7xl': '3rem', // 48px
-    '8xl': '3.25rem', // 52px
-    '9xl': '3.75rem', // 60px
-    '10xl': '4.5rem', // 72px
-    '11xl': '5rem', // 80px
-    '12xl': '5.25rem', // 84px
+    $xs: '0.75rem', // 12px
+    $sm: '0.875rem', // 14px
+    $base: '1rem', // 16px
+    $md: '1.123rem', // 18px
+    $lg: '1.25rem', // 20px
+    $xl: '1.5rem', // 24px
+    $2xl: '1.75rem', // 28px
+    $3xl: '2rem', // 32px
+    $4xl: '2.25rem', // 36px
+    $5xl: '2.5rem', // 40px
+    $6xl: '2.75rem', // 44px
+    $7xl: '3rem', // 48px
+    $8xl: '3.25rem', // 52px
+    $9xl: '3.75rem', // 60px
+    $10xl: '4.5rem', // 72px
+    $11xl: '5rem', // 80px
+    $12xl: '5.25rem', // 84px
   },
   fontWeights: {
-    light: '300',
-    normal: '400',
-    medium: '500',
-    semiBold: '700',
-    bold: '900',
+    $light: '300',
+    $normal: '400',
+    $medium: '500',
+    $semiBold: '700',
+    $bold: '900',
   },
   radii: {
-    sm: '4px',
-    md: '6px',
-    lg: '8px',
-    round: '999rem',
+    $sm: '4px',
+    $md: '6px',
+    $lg: '8px',
+    $round: '999rem',
   },
   borderWidths: {
-    md: '2px',
+    $md: '2px',
   },
   shadows: {
     // TODO: Update to match design system
-    1: `0px 1px 2px 0 $colors$neutral3`,
+    $1: `0px 1px 2px 0 $colors$neutral3`,
   },
   sizes: {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     0: '0',
-    1: '0.25rem', // 4px
-    2: '0.5rem', // 8px
-    3: '0.75rem', // 12px
-    4: '1rem', // 16px
-    5: '1.25rem', // 20px
-    6: '1.5rem', // 24px
-    7: '1.75rem', // 28px
-    8: '2rem', // 32px
-    9: '2.25rem', // 36px
-    10: '2.5rem', // 40px
-    11: '2.75rem', // 44px
-    12: '3rem', // 48px
-    13: '3.25rem', // 52px
-    14: '3.5rem', // 56px
-    15: '3.75rem', // 60px
-    16: '4rem', // 64px
-    17: '4.25rem', // 68px
-    18: '4.5rem', // 72px
-    19: '4.75rem', // 76px
-    20: '5rem', // 80px
-    24: '6rem', // 96px
-    25: '6.25rem', // 100px
-    32: '8rem', // 128px
-    40: '10rem', // 160px
-    48: '12rem', // 192px
-    56: '14rem', // 224px
-    64: '16rem', // 256px
+    $1: '0.25rem', // 4px
+    $2: '0.5rem', // 8px
+    $3: '0.75rem', // 12px
+    $4: '1rem', // 16px
+    $5: '1.25rem', // 20px
+    $6: '1.5rem', // 24px
+    $7: '1.75rem', // 28px
+    $8: '2rem', // 32px
+    $9: '2.25rem', // 36px
+    $10: '2.5rem', // 40px
+    $11: '2.75rem', // 44px
+    $12: '3rem', // 48px
+    $13: '3.25rem', // 52px
+    $14: '3.5rem', // 56px
+    $15: '3.75rem', // 60px
+    $16: '4rem', // 64px
+    $17: '4.25rem', // 68px
+    $18: '4.5rem', // 72px
+    $19: '4.75rem', // 76px
+    $20: '5rem', // 80px
+    $24: '6rem', // 96px
+    $25: '6.25rem', // 100px
+    $32: '8rem', // 128px
+    $40: '10rem', // 160px
+    $48: '12rem', // 192px
+    $56: '14rem', // 224px
+    $64: '16rem', // 256px
 
-    '2xs': 'var(--spacing-2xs)',
-    xs: 'var(--spacing-xs)',
-    sm: 'var(--spacing-sm)',
-    md: 'var(--spacing-md)',
-    lg: 'var(--spacing-lg)',
-    xl: 'var(--spacing-xl)',
-    '2xl': 'var(--spacing-2xl)',
-    '3xl': 'var(--spacing-3xl)',
+    $2xs: 'var(--spacing-2xs)',
+    $xs: 'var(--spacing-xs)',
+    $sm: 'var(--spacing-sm)',
+    $md: 'var(--spacing-md)',
+    $lg: 'var(--spacing-lg)',
+    $xl: 'var(--spacing-xl)',
+    $2xl: 'var(--spacing-2xl)',
+    $3xl: 'var(--spacing-3xl)',
   },
   colors: {
-    foreground: '#050505',
-    background: '#FAFAFA',
+    $foreground: '#050505',
+    $background: '#FAFAFA',
 
-    neutral1: '#FAFAFA',
-    neutral2: '#F0F0F0',
-    neutral3: '#9EA1A6',
-    neutral4: '#474F52',
-    neutral5: '#1D1D1F',
-    neutral6: '#050505',
+    $neutral1: '#FAFAFA',
+    $neutral2: '#F0F0F0',
+    $neutral3: '#9EA1A6',
+    $neutral4: '#474F52',
+    $neutral5: '#1D1D1F',
+    $neutral6: '#050505',
 
-    primaryAccent: '#2997FF',
-    primarySurface: '#C2E1FF',
-    primaryContrast: '#00498F',
-    primaryHighContrast: '#002F5C',
+    $primaryAccent: '#2997FF',
+    $primarySurface: '#C2E1FF',
+    $primaryContrast: '#00498F',
+    $primaryHighContrast: '#002F5C',
 
-    secondaryAccent: '#ED098F',
-    secondarySurface: '#FDC4E5',
-    secondaryContrast: '#710444',
-    secondaryHighContrast: '#580335',
+    $secondaryAccent: '#ED098F',
+    $secondarySurface: '#FDC4E5',
+    $secondaryContrast: '#710444',
+    $secondaryHighContrast: '#580335',
 
-    positiveAccent: '#5EEA15',
-    positiveSurface: '#E5FFD8',
-    positiveContrast: '#194D00',
-    positiveHighContrast: '#113300',
+    $positiveAccent: '#5EEA15',
+    $positiveSurface: '#E5FFD8',
+    $positiveContrast: '#194D00',
+    $positiveHighContrast: '#113300',
 
-    warningAccent: '#FF9900',
-    warningSurface: '#FFE7C2',
-    warningContrast: '#704300',
-    warningHighContrast: '#3D2500',
+    $warningAccent: '#FF9900',
+    $warningSurface: '#FFE7C2',
+    $warningContrast: '#704300',
+    $warningHighContrast: '#3D2500',
 
-    negativeAccent: '#FF3338',
-    negativeSurface: '#FFDAD8',
-    negativeContrast: '#75000B',
-    negativeHighContrast: '#410006',
+    $negativeAccent: '#FF3338',
+    $negativeSurface: '#FFDAD8',
+    $negativeContrast: '#75000B',
+    $negativeHighContrast: '#410006',
   },
 });
 
 export const darkThemeClass = createTheme(vars.colors, {
-  foreground: '#FAFAFA',
-  background: '#050505',
+  $foreground: '#FAFAFA',
+  $background: '#050505',
 
-  neutral1: '#050505',
-  neutral2: '#1D1D1F',
-  neutral3: '#474F52',
-  neutral4: '#9EA1A6',
-  neutral5: '#F0F0F0',
-  neutral6: '#FAFAFA',
+  $neutral1: '#050505',
+  $neutral2: '#1D1D1F',
+  $neutral3: '#474F52',
+  $neutral4: '#9EA1A6',
+  $neutral5: '#F0F0F0',
+  $neutral6: '#FAFAFA',
 
-  primaryAccent: '#2997FF',
-  primarySurface: '#00498F',
-  primaryContrast: '#C2E1FF',
-  primaryHighContrast: '#DBEDFF',
+  $primaryAccent: '#2997FF',
+  $primarySurface: '#00498F',
+  $primaryContrast: '#C2E1FF',
+  $primaryHighContrast: '#DBEDFF',
 
-  secondaryAccent: '#ED098F',
-  secondarySurface: '#580335',
-  secondaryContrast: '#FB93D0',
-  secondaryHighContrast: '#FDC4E5',
+  $secondaryAccent: '#ED098F',
+  $secondarySurface: '#580335',
+  $secondaryContrast: '#FB93D0',
+  $secondaryHighContrast: '#FDC4E5',
 
-  positiveAccent: '#5EEA15',
-  positiveSurface: '#113300',
-  positiveContrast: '#CBFFB3',
-  positiveHighContrast: '#E5FFD8',
+  $positiveAccent: '#5EEA15',
+  $positiveSurface: '#113300',
+  $positiveContrast: '#CBFFB3',
+  $positiveHighContrast: '#E5FFD8',
 
-  warningAccent: '#FF9900',
-  warningSurface: '#3D2500',
-  warningContrast: '#FFC670',
-  warningHighContrast: '#FFE7C2',
+  $warningAccent: '#FF9900',
+  $warningSurface: '#3D2500',
+  $warningContrast: '#FFC670',
+  $warningHighContrast: '#FFE7C2',
 
-  negativeAccent: '#FF3338',
-  negativeSurface: '#410006',
-  negativeContrast: '#FFA8B0',
-  negativeHighContrast: '#FFDAD8',
+  $negativeAccent: '#FF3338',
+  $negativeSurface: '#410006',
+  $negativeContrast: '#FFA8B0',
+  $negativeHighContrast: '#FFDAD8',
 });
 
 export type ColorType =


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 
Can you please fill out the information below to save us time looking into your PR. 
Start with explaining the reasons for this change, and if applicable link to an issue.
And explain the changes you have made.
-->

## Reason:

This was prompted by the need to disable several lint errors. This includes: 
- Lint error cleanup for @kadena-dev/typevar-def
- And changing tokens to be prefixed with $ so that they don't trigger the typescript naming convention lint rule

Prefixing tokens with $
Advantages:
- It makes it more clear when you are assigning a custom variable
Disadvantages:
- There are still instances in which we need to disable the lint errors. For example when creating variants for a components spacing, we don't want to have to prefix the associated options with $ as well. 

Alternative: Disabling the `@typescript-eslint/naming-convention` lint rule in React projects

Curious to hear your thoughts and open to alternative suggestions!

## Check off the following:

- [x] I have reviewed my changes and run the appropriate tests.
- [x] I have have run `rush change` to add the appropriate change logs.
- [x] I have added/edited docs.
- [x] I have added tutorials.
- [x] I have double checked and DEFINITELY added docs.

