### PR TITLE
Fix: Added stub test script to remark-plugins to fix `rush test` error

### DIFF
--- a/packages/tools/remark-plugins/package.json
+++ b/packages/tools/remark-plugins/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "lint": "eslint src",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "echo \"No tests yet.\""
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
This duplicates the fix in https://github.com/kadena-community/kadena.js/pull/400/files but the line is identical so it should not conflict