### PR TITLE
Run CI for all pull requests, not just those against master.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: Rush CI (changelog, retest)
-on:
-  pull_request:
-    branches: ['master']
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+# All pull requests, and
+# Workflow dispatch allows you to run this workflow manually from the Actions tab
+on: [pull_request, workflow_dispatch]
 jobs:
   build:
     name: ${{ matrix.os }} - Node.js v${{ matrix.NodeVersion }}


### PR DESCRIPTION
Since we are going to be using feature branches as PR bases for large changes, I am changing the CI action to run for all pull request branches.