### PR TITLE
Simplify CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,33 +1,23 @@
 # About code owners: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-*                                               @alber70g @randynamic @ggobugi27
+/*.*                                            @alber70g
+/*.md                                           @webpro
+/common                                         @alber70g
+/packages/apps/graph                            @alber70g
 
-/common                                         @alber70g @randynamic @ggobugi27
-
-/packages/apps/graph                            @alber70g @randynamic @ggobugi27
-/packages/apps/graph-client                     @alber70g @randynamic @ggobugi27 @eileenmguo
-/packages/apps/kadena-docs                      @eileenmguo @sstraatemans @isaozler @ash-vd
-/packages/apps/kadena-transfer                  @MRVDH @KristinaSpasevska @nil-amrutlal-dept @rezaerami
-
-/packages/libs/bootstrap-lib                    @alber70g @randynamic @ggobugi27
-/packages/libs/chainweb-node-client             @alber70g @randynamic @ggobugi27
 /packages/libs/chainweb-stream-client           @Takadenoshi
-/packages/libs/chainwebjs                       @alber70g @randynamic @ggobugi27
-/packages/libs/client                           @alber70g @randynamic @ggobugi27 @ash-vd
-/packages/libs/cryptography-utils               @alber70g @randynamic @ggobugi27
-/packages/libs/kadena.js                        @ash-vd @alber70g
-/packages/libs/cryptography-utils               @alber70g @randynamic @ggobugi27
-/packages/libs/pactjs                           @alber70g @randynamic @ggobugi27 @ash-vd
-/packages/libs/pactjs-generator                 @alber70g @randynamic @ggobugi27
-/packages/libs/pactjs-test-project              @alber70g @randynamic @ggobugi27
-/packages/libs/react-components                 @eileenmguo @sstraatemans @isaozler
-/packages/libs/types                            @alber70g @randynamic @ggobugi27
-/packages/libs/react-ui                         @eileenmguo @sstraatemans @isaozler
 
-/packages/tools/cookbook                        @eileenmguo @ash-vd
+/packages/libs/bootstrap-lib                    @alber70g
+/packages/libs/client                           @alber70g
+/packages/libs/kadena.js                        @alber70g
+/packages/libs/pactjs-generator                 @alber70g
+/packages/libs/types                            @alber70g
+/packages/tools/pactjs-cli                      @alber70g
+
 /packages/tools/create-kadena-app               @jermaine150
-/packages/tools/eslint-config                   @alber70g @randynamic @ggobugi27
-/packages/tools/eslint-plugin                   @alber70g @randynamic @ggobugi27
-/packages/tools/heft-rig                        @alber70g @randynamic @ggobugi27
-/packages/tools/integration-tests               @alber70g @randynamic @ggobugi27
-/packages/tools/pactjs-cli                      @alber70g @randynamic @ggobugi27 @ash-vd
+/packages/tools/eslint-config                   @alber70g
+/packages/tools/eslint-plugin                   @alber70g
+/packages/tools/heft-rig                        @alber70g
+/packages/tools/integration-tests               @ggobugi27
+/packages/tools/remark-plugins                  @webpro
+/packages/tools/rush-fix-versions               @alber70g


### PR DESCRIPTION
Not so long ago we had a simple `CODEOWNERS` file, it looked something like this:

```
* @alber70g @Randynamic @ggobugi27 
```

That wasn't great when their availability is limited, they don't have the in-depth knowledge to review/approve something, etc. So a few weeks ago I went ahead and created basically what we currently in the master branch. It seems to work fine, but some of us think we can do with less targeted ownership. This PR depicts this idea, and comes with the message that we can take responsibility and request reviews and approvals from the people we think are best suited to do so.

With this new setup, lots of files do no longer have code ownership. There are still folders/packages that have one owner. This means that changes touching them require their approval. Overall, it should be easier to get PRs through.

The required number of approvals is always 2. It is up to you to chase more if that's appropriate for the changes made.

If you think you should own certain folder(s) or file(s), then you can tell us now; or later in another PR.