### PR TITLE
chore(nextjs): remove the unnecessary proptypes rule from eslint config

### DIFF
--- a/common/changes/@kadena-dev/eslint-config/fix-remove_proptypesrule_2023-06-16-07-29.json
+++ b/common/changes/@kadena-dev/eslint-config/fix-remove_proptypesrule_2023-06-16-07-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/eslint-config",
+      "comment": "remove the unnecessary proptypes rule from eslint config",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kadena-dev/eslint-config"
+}

--- a/packages/tools/eslint-config/profile/next.js
+++ b/packages/tools/eslint-config/profile/next.js
@@ -2,7 +2,4 @@ module.exports = {
   root: true,
   extends: ['./react', 'next/core-web-vitals'],
   plugins: ['import', 'simple-import-sort'],
-  rules: {
-    'react/prop-types': 'off',
-  },
 };


### PR DESCRIPTION
## Check off the following:

- [X] I have reviewed my changes and run the appropriate tests.
- [X] I have have run `rush change` to add the appropriate change logs.
- [ ] I have added/edited docs.
- [ ] I have added tutorials.
- [ ] I have double checked and DEFINITELY added docs.

