### PR TITLE
Run CI pipeline after merges to/in master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
 name: Rush CI (changelog, retest)
 # All pull requests, and
 # Workflow dispatch allows you to run this workflow manually from the Actions tab
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
 jobs:
   build:
     name: ${{ matrix.os }} - Node.js v${{ matrix.NodeVersion }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+env:
+  AFFECTED_OR_ALL: |
+    ${{ github.ref_name == 'master' && '' || format('--to git:origin/{0}', github.base_ref)  }}
+
 jobs:
   build:
     name: ${{ matrix.os }} - Node.js v${{ matrix.NodeVersion }}
@@ -46,22 +50,24 @@ jobs:
           key: cache-pnpm-${{ runner.os }}
 
       - name: List impacted packages
+        if: github.ref_name != 'master'
         run: |
-          node common/scripts/install-run-rush.js list --to git:origin/${{ github.base_ref }}
+          node common/scripts/install-run-rush.js list ${{ env.AFFECTED_OR_ALL }}
 
       - name: Rush install (install-run-rush)
         run: |
-          node common/scripts/install-run-rush.js install --to git:origin/${{ github.base_ref }}
+          node common/scripts/install-run-rush.js install ${{ env.AFFECTED_OR_ALL }}
 
       - name: Rush retest (install-run-rush)
         run: |
-          node common/scripts/install-run-rush.js build --verbose --to git:origin/${{ github.base_ref }}
-          node common/scripts/install-run-rush.js retest --verbose --to git:origin/${{ github.base_ref }}
+          node common/scripts/install-run-rush.js build --verbose ${{ env.AFFECTED_OR_ALL }}
+          node common/scripts/install-run-rush.js retest --verbose ${{ env.AFFECTED_OR_ALL }}
         env:
           # Prevent time-based browserslist update warning
           # See https://github.com/microsoft/rushstack/issues/2981
           BROWSERSLIST_IGNORE_OLD_DATA: 1
 
       - name: Rush verify Change Logs (install-run-rush)
+        if: github.ref_name != 'master'
         run: |
           node common/scripts/install-run-rush.js change --verify --target-branch origin/${{ github.base_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,5 @@
 name: Rush release (version --bump, publish)
 on:
-  push:
-    branches: ['master']
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 jobs:
@@ -40,7 +38,8 @@ jobs:
       #   run: node common/scripts/install-run-rush.js version --bump --target-branch master --ignore-git-hooks
 
       - name: Rush publish (install-run-rush)
-        run: node common/scripts/install-run-rush.js publish --apply --publish --include-all --add-commit-details --set-access-level public --target-branch master
+        run: |
+          node common/scripts/install-run-rush.js publish --apply --publish --include-all --add-commit-details --set-access-level public --target-branch master
       # - name: Rush test (rush-lib)
       #   run: node apps/rush/lib/start-dev.js test --verbose --production --timeline
       #   env:


### PR DESCRIPTION
This disables the release pipeline, which we aren't using and is very red. Can still be ran manually.

Activating the CI pipeline this way shows master is in a good state.

~**NOTE:** Needs work. just realized this may not do much as it runs things based on changes with... `master` 🤦~