### PR TITLE
Simplify rush build + test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Rush CI (changelog, retest)
+name: Rush CI (changelog, build, test)
 # All pull requests, and
 # Workflow dispatch allows you to run this workflow manually from the Actions tab
 on:
@@ -59,10 +59,10 @@ jobs:
         run: |
           node common/scripts/install-run-rush.js install ${{ env.AFFECTED_OR_ALL }}
 
-      - name: Rush retest (install-run-rush)
+      - name: Rush build + test (install-run-rush)
         run: |
           node common/scripts/install-run-rush.js build --verbose ${{ env.AFFECTED_OR_ALL }}
-          node common/scripts/install-run-rush.js retest --verbose ${{ env.AFFECTED_OR_ALL }}
+          node common/scripts/install-run-rush.js test --verbose ${{ env.AFFECTED_OR_ALL }}
         env:
           # Prevent time-based browserslist update warning
           # See https://github.com/microsoft/rushstack/issues/2981

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,10 @@ jobs:
         run: node common/scripts/install-run-rush.js change --verify
       - name: Rush install (install-run-rush)
         run: node common/scripts/install-run-rush.js install
-      - name: Rush retest (install-run-rush)
-        run: node common/scripts/install-run-rush.js retest --verbose
+      - name: Rush test (install-run-rush)
+        run: |
+          node common/scripts/install-run-rush.js build --verbose
+          node common/scripts/install-run-rush.js test --verbose
         env:
           # Prevent time-based browserslist update warning
           # See https://github.com/microsoft/rushstack/issues/2981

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -45,16 +45,6 @@
     // },
 
     {
-      "commandKind": "phased",
-      "name": "retest",
-      "summary": "Rebuilds all projects and reruns their tests.",
-      // "phases": [],
-      "phases": ["_phase:build", "_phase:test"],
-      "enableParallelism": true,
-      "incremental": false
-    },
-
-    {
       "commandKind": "global",
       "name": "lint-staged",
       "summary": "Used by the pre-commit Git hook. This command invokes lint-staged to fix staged files.",
@@ -266,39 +256,7 @@
   /**
    * Adding support for phased builds: https://rushjs.io/pages/maintainer/phased_builds/
    */
-  "phases": [
-    {
-      /**
-       * The name of the phase. Note that this value must start with the \"_phase:\" prefix.
-       */
-      "name": "_phase:build",
-
-      /**
-       * The dependencies of this phase.
-       */
-      "dependencies": {
-        "upstream": ["_phase:build"]
-      },
-
-      /**
-       * Normally Rush requires that each project's package.json has a \"scripts\" entry matching the phase name. To disable this check, set \"ignoreMissingScript\" to true.
-       */
-      "ignoreMissingScript": true,
-
-      /**
-       * By default, Rush returns a nonzero exit code if errors or warnings occur during a command. If this option is set to \"true\", Rush will return a zero exit code if warnings occur during the execution of this phase.
-       */
-      "allowWarningsOnSuccess": false
-    },
-    {
-      "name": "_phase:test",
-      "dependencies": {
-        "self": ["_phase:build"]
-      },
-      "ignoreMissingScript": true,
-      "allowWarningsOnSuccess": false
-    }
-  ],
+  "phases": [],
 
   /**
    * Custom "parameters" introduce new parameters for specified Rush command-line commands.
@@ -310,8 +268,7 @@
       "shortName": "-u",
       "parameterKind": "flag",
       "description": "Update unit test snapshots for all projects",
-      "associatedCommands": ["test", "retest"],
-      "associatedPhases": ["_phase:test"]
+      "associatedCommands": ["test"]
     }
     // {
     //   /**

--- a/common/config/rush/experiments.json
+++ b/common/config/rush/experiments.json
@@ -40,5 +40,5 @@
    * If true, the phased commands feature is enabled. To use this feature, create a "phased" command
    * in common/config/rush/command-line.json.
    */
-  "phasedCommands": true
+  "phasedCommands": false
 }

--- a/packages/apps/graph/package.json
+++ b/packages/apps/graph/package.json
@@ -7,8 +7,6 @@
   "author": "",
   "main": "index.js",
   "scripts": {
-    "_phase:build": "npm run build",
-    "_phase:test": "npm run test",
     "build": "",
     "lint": "eslint ./src --ext .js,.ts --fix",
     "lint-staged": "lint-staged",

--- a/packages/apps/kadena-docs/package.json
+++ b/packages/apps/kadena-docs/package.json
@@ -5,8 +5,6 @@
     "7d": "npx 7d pinecone-create-index --index kda-docs --environment asia-northeast1-gcp",
     "7d:ingest": "npx 7d ingest --files 'src/pages/docs/**/*.md'  --files 'src/pages/docs/**/*.mdx' --namespace kda-docs",
     "7d:query": "npx 7d",
-    "_phase:build": "npm run build",
-    "_phase:test": "npm run test",
     "build": "npm run build:next",
     "build:next": "npm run createtree && next build",
     "createtree": "node ./src/scripts/getdocstree.mjs",

--- a/packages/apps/transfer/package.json
+++ b/packages/apps/transfer/package.json
@@ -3,8 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "_phase:build": "npm run build",
-    "_phase:test": "npm run test",
     "build": "npm run generate:icons && next build",
     "dev": "npm run generate:icons && next dev",
     "eject": "react-scripts eject",

--- a/packages/libs/bootstrap-lib/package.json
+++ b/packages/libs/bootstrap-lib/package.json
@@ -26,11 +26,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "_phase:build": "npm run build",
-    "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
     "lint": "eslint ./src --ext .js,.ts --fix",
-    "test": "rushx build && heft test --no-build"
+    "test": "heft test --no-build"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/packages/libs/chainweb-node-client/package.json
+++ b/packages/libs/chainweb-node-client/package.json
@@ -26,13 +26,11 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
     "generate:openapi-types": "echo 'openapi specs needs fixes' # openapi-typescript \"./openapi/*.json\" --output ./src/openapi",
     "postinstall": "npm run generate:openapi-types",
     "lint": "eslint ./src --ext .js,.ts --fix",
-    "test": "rushx build && heft test --no-build"
+    "test": "heft test --no-build"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/packages/libs/chainweb-stream-client/package.json
+++ b/packages/libs/chainweb-stream-client/package.json
@@ -26,11 +26,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
     "lint": "eslint ./src --ext .js,.ts --fix",
-    "test": "rushx build && heft test --no-build"
+    "test": "heft test --no-build"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/packages/libs/chainwebjs/package.json
+++ b/packages/libs/chainwebjs/package.json
@@ -44,13 +44,11 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
     "preinstall": "npx only-allow pnpm",
     "lint": "eslint ./src --ext .js,.ts --fix",
     "lint-staged": "lint-staged",
-    "test": "rushx build && heft test --no-build"
+    "test": "heft test --no-build"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/packages/libs/client/package.json
+++ b/packages/libs/client/package.json
@@ -11,8 +11,6 @@
   "main": "lib/index.js",
   "types": "dist/client.d.ts",
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "npm run test",
     "build": "heft build --clean",
     "dev:postinstall": "rushx pactjs:retrieve:contract; rushx pactjs:generate:contract",
     "lint": "eslint ./src --ext .js,.ts --fix",

--- a/packages/libs/cryptography-utils/package.json
+++ b/packages/libs/cryptography-utils/package.json
@@ -26,12 +26,10 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
     "lint": "eslint ./src --ext .js,.ts --fix",
     "lint-staged": "lint-staged",
-    "test": "rushx build && heft test --no-build"
+    "test": "heft test --no-build"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/packages/libs/kadena.js/package.json
+++ b/packages/libs/kadena.js/package.json
@@ -38,13 +38,11 @@
   ],
   "main": "lib/index.js",
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
     "build:prod": "webpack --mode=production",
     "lint": "eslint ./src --ext .js,.ts --fix",
     "serve-coverage": "python -m SimpleHTTPServer",
-    "test": "heft test"
+    "test": "heft test --no-build"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/packages/libs/pactjs-generator/package.json
+++ b/packages/libs/pactjs-generator/package.json
@@ -11,8 +11,6 @@
   "main": "lib/index.js",
   "types": "dist/pactjs-generator.d.ts",
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "npm run test",
     "prebuild": "npm run build:lexer && npm run build:grammar",
     "build": "heft build --clean",
     "build:lexer": "tsc src/lexer.ts",
@@ -24,7 +22,7 @@
     "lint": "eslint ./src --ext .js,.ts --fix",
     "lint-staged": "lint-staged",
     "start": "ts-node --transpile-only src/index.ts",
-    "test": "heft test"
+    "test": "heft test --no-build"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/packages/libs/pactjs-test-project/package.json
+++ b/packages/libs/pactjs-test-project/package.json
@@ -12,8 +12,6 @@
   "main": "lib/index.js",
   "types": "dist/pactjs-generator.d.ts",
   "scripts": {
-    "_phase:build": "npm run build",
-    "_phase:test": "npm run test",
     "prebuild": "npm run pactjs:generate:contract:file && npm run pactjs:generate:template",
     "build": "npm run prebuild && tsc --noEmit",
     "lint": "eslint ./src --ext .js,.ts --fix",

--- a/packages/libs/pactjs/package.json
+++ b/packages/libs/pactjs/package.json
@@ -26,11 +26,9 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "heft test --no-build",
     "build": "heft build --clean",
     "lint": "eslint ./src --ext .js,.ts --fix",
-    "test": "rushx build && heft test --no-build"
+    "test": "heft test --no-build"
   },
   "lint-staged": {
     "src/**/*.ts": [

--- a/packages/libs/react-components/config/rush-project.json
+++ b/packages/libs/react-components/config/rush-project.json
@@ -34,10 +34,6 @@
    */
   "operationSettings": [
     {
-      "operationName": "_phase:build",
-      "outputFolderNames": ["dist", "lib", "lib-commonjs", "temp", "types"]
-    },
-    {
       "operationName": "build",
       "outputFolderNames": ["dist", "lib", "lib-commonjs", "temp", "types"]
     }

--- a/packages/libs/react-components/package.json
+++ b/packages/libs/react-components/package.json
@@ -12,8 +12,6 @@
     "types"
   ],
   "scripts": {
-    "_phase:build": "npm run build",
-    "_phase:test": "npm run test",
     "build": "tsc -p ./tsconfig.esm.json & tsc -p ./tsconfig.cjs.json",
     "build:storybook": "storybook build",
     "build:test": "tsc & tsc -p ./tsconfig.esm.json",

--- a/packages/libs/react-ui/package.json
+++ b/packages/libs/react-ui/package.json
@@ -19,8 +19,6 @@
     "types"
   ],
   "scripts": {
-    "_phase:build": "npm run build",
-    "_phase:test": "npm run test",
     "build": "tsc & tsc -p ./tsconfig.cjs.json",
     "build:storybook": "storybook build",
     "build:test": "tsc --noEmit & tsc -p ./tsconfig.cjs.json --noEmit",

--- a/packages/libs/types/package.json
+++ b/packages/libs/types/package.json
@@ -26,8 +26,6 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "npm run test",
     "build": "heft build --clean",
     "lint": "eslint ./src --ext .js,.ts --fix",
     "test": "heft test --no-build"

--- a/packages/tools/cookbook/package.json
+++ b/packages/tools/cookbook/package.json
@@ -7,8 +7,6 @@
   "author": "",
   "main": "index.js",
   "scripts": {
-    "_phase:build": "npm run build",
-    "_phase:test": "npm run test",
     "build": "",
     "dev:postinstall": "mkdir -p ./contracts; rushx pactjs:retrieve:contract; rushx pactjs:generate:contract",
     "lint": "eslint ./src --ext .js,.ts --fix",

--- a/packages/tools/create-kadena-app/package.json
+++ b/packages/tools/create-kadena-app/package.json
@@ -12,12 +12,10 @@
     "create-kadena-app": "lib/index.js"
   },
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "npm run test",
     "build": "heft build --clean",
     "lint-staged": "lint-staged",
     "start": "ts-node --transpile-only src/index.ts",
-    "test": "rimraf test-* && heft test && cross-env NG_CLI_ANALYTICS=false ./scripts/generate-test.sh"
+    "test": "rimraf test-* && heft test --no-build && cross-env NG_CLI_ANALYTICS=false ./scripts/generate-test.sh"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [

--- a/packages/tools/eslint-config/package.json
+++ b/packages/tools/eslint-config/package.json
@@ -5,9 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "",
-    "_phase:build": "npm run build",
     "lint": "eslint ./mixins --ext .js,.ts --fix && npx eslint ./profile --ext .js,.ts --fix",
-    "_phase:test": "npm run test",
     "test": ""
   },
   "dependencies": {

--- a/packages/tools/eslint-plugin/package.json
+++ b/packages/tools/eslint-plugin/package.json
@@ -3,11 +3,9 @@
   "version": "0.0.3",
   "main": "src/index.js",
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "",
     "build": "heft build --clean",
     "lint-staged": "lint-staged",
-    "test": "heft test"
+    "test": "heft test --no-build"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [

--- a/packages/tools/heft-rig/package.json
+++ b/packages/tools/heft-rig/package.json
@@ -5,9 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "",
-    "test": "",
-    "_phase:build": "npm run build",
-    "_phase:test": "npm run test"
+    "test": ""
   },
   "peerDependencies": {
     "@rushstack/heft": "^0.46.1"

--- a/packages/tools/heft-rig/profiles/default/config/rush-project.json
+++ b/packages/tools/heft-rig/profiles/default/config/rush-project.json
@@ -1,10 +1,6 @@
 {
   "operationSettings": [
     {
-      "operationName": "_phase:build",
-      "outputFolderNames": ["dist", "lib", "lib-commonjs", "temp"]
-    },
-    {
       "operationName": "build",
       "outputFolderNames": ["dist", "lib", "lib-commonjs", "temp"]
     }

--- a/packages/tools/pactjs-cli/package.json
+++ b/packages/tools/pactjs-cli/package.json
@@ -12,11 +12,9 @@
     "pactjs": "lib/index.js"
   },
   "scripts": {
-    "_phase:build": "heft build --clean",
-    "_phase:test": "",
     "build": "heft build --clean",
     "lint-staged": "lint-staged",
-    "test": "heft test"
+    "test": "heft test --no-build"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx}": [

--- a/packages/tools/remark-plugins/package.json
+++ b/packages/tools/remark-plugins/package.json
@@ -5,8 +5,6 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "_phase:build": "npm run build",
-    "_phase:test": "npm run test",
     "lint": "eslint src",
     "build": "tsc",
     "test": ""

--- a/packages/tools/rush-fix-versions/package.json
+++ b/packages/tools/rush-fix-versions/package.json
@@ -5,8 +5,6 @@
   "main": "lib/index.js",
   "type": "module",
   "scripts": {
-    "_phase:build": "npm run build",
-    "_phase:test": "npm run test",
     "build": "heft build",
     "test": ""
   },


### PR DESCRIPTION
We're using an interesting feature of Rush, but with default values and slightly confusing scripts here and there. This simplifies/clarifies things a bit, as we're doing `rush build` and `rush test` separately already anyway in many cases.