### PR TITLE
Allow warnings in test and lint commands

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -20,7 +20,7 @@
       "enableParallelism": true,
       "ignoreDependencyOrder": false,
       "ignoreMissingScript": false,
-      "allowWarningsInSuccessfulBuild": false,
+      "allowWarningsInSuccessfulBuild": true,
       // default: false. Changed to true as it should not need to run when nothing has changed
       "incremental": true,
       "watchForChanges": false,
@@ -37,7 +37,7 @@
     //   "enableParallelism": true,
     //   "ignoreDependencyOrder": false,
     //   "ignoreMissingScript": false,
-    //   "allowWarningsInSuccessfulBuild": false,
+    //   "allowWarningsInSuccessfulBuild": true,
     //   // default: false. Changed to true as it should not need to run when nothing has changed
     //   "incremental": true,
     //   "watchForChanges": true,
@@ -100,7 +100,7 @@
       "ignoreDependencyOrder": false,
       // default: false. this command is just for convenience
       "ignoreMissingScript": true,
-      "allowWarningsInSuccessfulBuild": false,
+      "allowWarningsInSuccessfulBuild": true,
       "incremental": false,
       "watchForChanges": false,
       "disableBuildCache": false
@@ -197,7 +197,7 @@
     //    *
     //    * Note: The default value is false. In Rush 5.7.x and earlier, the default value was true.
     //    */
-    //   "allowWarningsInSuccessfulBuild": false,
+    //   "allowWarningsInSuccessfulBuild": true,
     //
     //   /**
     //    * If true then this command will be incremental like the built-in "build" command


### PR DESCRIPTION
Warnings are warnings, they should not make CI runs fail. A few notes:

- External tooling might use `console.warn` that's out of our control.
- ESLint warnings from rule violations that we consider errors should be configured as such.
- We shouldn't need to work around this by piping stuff (`stdout`/`stderr`), etc.

I wonder for what reason exactly we need this, and how we might mitigate that issue in a different way?