### PR TITLE
chore: rename default branch to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/001-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/001-bug_report.yml
@@ -16,7 +16,7 @@ body:
       options:
         - label:
             I have read the [Code of
-            Conduct](https://github.com/kadena-community/kadena.js/blob/master/CODE_OF_CONDUCT.md)
+            Conduct](https://github.com/kadena-community/kadena.js/blob/main/CODE_OF_CONDUCT.md)
           required: true
         - label: The bug was not reported before
           required: true

--- a/.github/ISSUE_TEMPLATE/002-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/002-feature_request.yml
@@ -16,7 +16,7 @@ body:
       options:
         - label:
             I have read the [Code of
-            Conduct](https://github.com/kadena-community/kadena.js/blob/master/CODE_OF_CONDUCT.md)
+            Conduct](https://github.com/kadena-community/kadena.js/blob/main/CODE_OF_CONDUCT.md)
           required: true
         - label: The feature was not suggested before
           required: true

--- a/.github/ISSUE_TEMPLATE/003-improve_documentation.yml
+++ b/.github/ISSUE_TEMPLATE/003-improve_documentation.yml
@@ -16,7 +16,7 @@ body:
       options:
         - label:
             I have read the [Code of
-            Conduct](https://github.com/kadena-community/kadena.js/blob/master/CODE_OF_CONDUCT.md)
+            Conduct](https://github.com/kadena-community/kadena.js/blob/main/CODE_OF_CONDUCT.md)
           required: true
         - label: The improvement was not suggested before
           required: true

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,9 +1,9 @@
 newIssueWelcomeComment: >
   Thanks for opening this issue.
-  A Kadena team member should be by to give feedback soon. In the meantime, please check out the [contributing guidelines](https://github.com/kadena-community/kadena.js/blob/master/CONTRIBUTING.md).
+  A Kadena team member should be by to give feedback soon. In the meantime, please check out the [contributing guidelines](https://github.com/kadena-community/kadena.js/blob/main/CONTRIBUTING.md).
 
 newPRWelcomeComment: >
-  Thanks for opening this pull request! A GitHub docs team member should be by to give feedback soon. In the meantime, please check out the [contributing guidelines](https://github.com/kadena-community/kadena.js/blob/master/CONTRIBUTING.md).
+  Thanks for opening this pull request! A GitHub docs team member should be by to give feedback soon. In the meantime, please check out the [contributing guidelines](https://github.com/kadena-community/kadena.js/blob/main/CONTRIBUTING.md).
 
 
 <!-- Based on https://github.com/github/docs/blob/main/.github/config.yml -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - main
 
 env:
   AFFECTED_OR_ALL: |
-    ${{ github.ref_name == 'master' && ' ' || format('--to git:origin/{0}', github.base_ref)  }}
+    ${{ github.ref_name == 'main' && ' ' || format('--to git:origin/{0}', github.base_ref)  }}
 
 jobs:
   build:
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 2
 
       - name: Fetch base branch
-        if: github.ref_name != 'master'
+        if: github.ref_name != 'main'
         run: git fetch origin ${{ github.base_ref }}
 
       - uses: actions/setup-node@v3
@@ -51,7 +51,7 @@ jobs:
           key: cache-pnpm-${{ runner.os }}
 
       - name: List impacted packages
-        if: github.ref_name != 'master'
+        if: github.ref_name != 'main'
         run: |
           node common/scripts/install-run-rush.js list ${{ env.AFFECTED_OR_ALL }}
 
@@ -73,6 +73,6 @@ jobs:
           node common/scripts/install-run-rush.js format:ci --verbose --to git:origin/${{ github.base_ref }}
 
       - name: Rush verify Change Logs (install-run-rush)
-        if: github.ref_name != 'master'
+        if: github.ref_name != 'main'
         run: |
           node common/scripts/install-run-rush.js change --verify --target-branch origin/${{ github.base_ref }}

--- a/.github/workflows/docs-chores.yml
+++ b/.github/workflows/docs-chores.yml
@@ -9,7 +9,7 @@ jobs:
   cypress-run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@main
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,11 @@ jobs:
       # Disabled this step; it's better to run this step locally and submit it
       # as a PR. This makes a release explicit instead of automatic
       # - name: Rush version bump (install-run-rush)
-      #   run: node common/scripts/install-run-rush.js version --bump --target-branch master
+      #   run: node common/scripts/install-run-rush.js version --bump --target-branch main
 
       - name: Rush publish (install-run-rush)
         run: |
-          node common/scripts/install-run-rush.js publish --apply --publish --include-all --add-commit-details --set-access-level public --target-branch master
+          node common/scripts/install-run-rush.js publish --apply --publish --include-all --add-commit-details --set-access-level public --target-branch main
       # - name: Rush test (rush-lib)
       #   run: node apps/rush/lib/start-dev.js test --verbose --production --timeline
       #   env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,8 @@ For everything else, please discuss.
 To publish a new version of updated packages, please make sure you:
 
 - are part of the `@kadena` npm organization
-- have push rights to this repository's `master` branch
-- are on a clean `master` branch
+- have push rights to this repository's `main` branch
+- are on a clean `main` branch
 
 Follow these steps to publish the updated packages:
 
@@ -108,8 +108,8 @@ Follow these steps to publish the updated packages:
 ```bash
 rush build
 rush test
-rush version --bump -b master
-rush publish --apply --publish --include-all --add-commit-details --set-access-level public --target-branch master
+rush version --bump -b main
+rush publish --apply --publish --include-all --add-commit-details --set-access-level public --target-branch main
 ```
 
 [1]: https://github.com/kadena-community/kadena.js/issues/new/choose

--- a/README.md
+++ b/README.md
@@ -51,52 +51,51 @@ Special thanks to the wonderful people who have contributed to this project:
 [2]: https://discord.io/kadena
 [3]: https://stackoverflow.com/questions/tagged/kadena
 [4]: ./CONTRIBUTING.md
-[5]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/types
+[5]: https://github.com/kadena-community/kadena.js/tree/main/packages/libs/types
 [6]: ./packages/libs/types/CHANGELOG.md
 [7]: https://img.shields.io/npm/v/@kadena/types.svg
 [8]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/pactjs-generator
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/pactjs-generator
 [9]: ./packages/libs/pactjs-generator/CHANGELOG.md
 [10]: https://img.shields.io/npm/v/@kadena/pactjs-generator.svg
 [11]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/tools/pactjs-cli
+  https://github.com/kadena-community/kadena.js/tree/main/packages/tools/pactjs-cli
 [12]: ./packages/tools/pactjs-cli/CHANGELOG.md
 [13]: https://img.shields.io/npm/v/@kadena/pactjs-cli.svg
 [14]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/pactjs
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/pactjs
 [15]: ./packages/libs/pactjs/CHANGELOG.md
 [16]: https://img.shields.io/npm/v/@kadena/pactjs.svg
 [17]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/cryptography-utils
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/cryptography-utils
 [18]: ./packages/libs/cryptography-utils/CHANGELOG.md
 [19]: https://img.shields.io/npm/v/@kadena/cryptography-utils.svg
 [20]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/client
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/client
 [21]: ./packages/libs/client/CHANGELOG.md
 [22]: https://img.shields.io/npm/v/@kadena/client.svg
 [23]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/chainweb-stream-client
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/chainweb-stream-client
 [24]: ./packages/libs/chainweb-stream-client/CHANGELOG.md
 [25]: https://img.shields.io/npm/v/@kadena/chainweb-stream-client.svg
 [26]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/chainweb-node-client
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/chainweb-node-client
 [27]: ./packages/libs/chainweb-node-client/CHANGELOG.md
 [28]: https://img.shields.io/npm/v/@kadena/chainweb-node-client.svg
 [29]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/tools/rush-fix-versions
+  https://github.com/kadena-community/kadena.js/tree/main/packages/tools/rush-fix-versions
 [30]: ./packages/tools/rush-fix-versions/CHANGELOG.md
 [31]: https://img.shields.io/npm/v/@kadena-dev/rush-fix-versions.svg
 [32]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/tools/heft-rig
+  https://github.com/kadena-community/kadena.js/tree/main/packages/tools/heft-rig
 [33]: ./packages/tools/heft-rig/CHANGELOG.md
 [34]: https://img.shields.io/npm/v/@kadena-dev/heft-rig.svg
 [35]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/tools/eslint-plugin
+  https://github.com/kadena-community/kadena.js/tree/main/packages/tools/eslint-plugin
 [36]: ./packages/tools/eslint-plugin/CHANGELOG.md
 [37]: https://img.shields.io/npm/v/@kadena-dev/eslint-plugin.svg
 [38]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/tools/eslint-config
+  https://github.com/kadena-community/kadena.js/tree/main/packages/tools/eslint-config
 [39]: ./packages/tools/eslint-config/CHANGELOG.md
 [40]: https://img.shields.io/npm/v/@kadena-dev/eslint-config.svg
 [41]: https://github.com/kadena-community/kadena.js/graphs/contributors

--- a/common/changes/@kadena/chainweb-node-client/chore-rename-base-branch-to-main_2023-06-27-11-21.json
+++ b/common/changes/@kadena/chainweb-node-client/chore-rename-base-branch-to-main_2023-06-27-11-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-node-client",
+      "comment": "Rename master branch to main",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainweb-node-client"
+}

--- a/common/changes/@kadena/client/chore-rename-base-branch-to-main_2023-06-27-11-21.json
+++ b/common/changes/@kadena/client/chore-rename-base-branch-to-main_2023-06-27-11-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "Rename master branch to main",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/common/changes/@kadena/cryptography-utils/chore-rename-base-branch-to-main_2023-06-27-11-21.json
+++ b/common/changes/@kadena/cryptography-utils/chore-rename-base-branch-to-main_2023-06-27-11-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/cryptography-utils",
+      "comment": "Rename master branch to main",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/cryptography-utils"
+}

--- a/common/changes/@kadena/pactjs-cli/chore-rename-base-branch-to-main_2023-06-27-11-21.json
+++ b/common/changes/@kadena/pactjs-cli/chore-rename-base-branch-to-main_2023-06-27-11-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-cli",
+      "comment": "Rename master branch to main",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs-cli"
+}

--- a/common/changes/@kadena/pactjs-generator/chore-rename-base-branch-to-main_2023-06-27-11-21.json
+++ b/common/changes/@kadena/pactjs-generator/chore-rename-base-branch-to-main_2023-06-27-11-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-generator",
+      "comment": "Rename master branch to main",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs-generator"
+}

--- a/common/changes/@kadena/pactjs/chore-rename-base-branch-to-main_2023-06-27-11-21.json
+++ b/common/changes/@kadena/pactjs/chore-rename-base-branch-to-main_2023-06-27-11-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs",
+      "comment": "Rename master branch to main",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs"
+}

--- a/packages/apps/kadena-docs/package.json
+++ b/packages/apps/kadena-docs/package.json
@@ -6,9 +6,9 @@
     "7d:ingest": "npx 7d ingest --files 'src/pages/docs/**/*.md'  --files 'src/pages/docs/**/*.mdx' --namespace kda-docs",
     "7d:query": "npx 7d",
     "build": "npm run build:next",
-    "build:next": "npm run build:scripts && next build",
     "build:createSearchIndex": "node ./src/scripts/createSearchIndex.mjs && prettier ./src/data/searchIndex.json --write",
     "build:createtree": "node ./src/scripts/getdocstree.mjs && prettier ./src/data/menu.mjs --write",
+    "build:next": "npm run build:scripts && next build",
     "build:scripts": "npm run build:createSearchIndex &&  npm run build:createtree",
     "cypress:ci": "NEXT_PUBLIC_APP_DEV=test start-server-and-test dev http://localhost:3000 cypress:run",
     "cypress:cilocal": "NEXT_PUBLIC_APP_DEV=test start-server-and-test dev http://localhost:3000 cypress:open",
@@ -34,6 +34,7 @@
     "@mdx-js/loader": "~2.3.0",
     "@mdx-js/react": "~2.3.0",
     "@next/mdx": "~13.3.4",
+    "@vanilla-extract/css": "1.11.1",
     "acorn": "~8.8.2",
     "date-fns": "~2.30.0",
     "js-yaml": "~4.1.0",
@@ -48,8 +49,7 @@
     "rehype-pretty-code": "~0.9.5",
     "remark-frontmatter": "~4.0.1",
     "remark-gfm": "~3.0.1",
-    "shiki": "~0.14.2",
-    "@vanilla-extract/css": "1.11.1"
+    "shiki": "~0.14.2"
   },
   "devDependencies": {
     "@7-docs/cli": "0.1.7",

--- a/packages/apps/kadena-docs/src/pages/docs/build/guides/building-a-voting-dapp.mdx
+++ b/packages/apps/kadena-docs/src/pages/docs/build/guides/building-a-voting-dapp.mdx
@@ -699,8 +699,7 @@ interface. The `gas-payer-v1` interface is deployed to all chains on `testnet`
 and `mainnet` so you can directly use it in your contract. We can specify that a
 module implements an interface using the `(implements INTERFACE)` construct. :::
 
-:::info
-Pact interfaces are similar to Java's interfaces, Scala's traits,
+:::info Pact interfaces are similar to Java's interfaces, Scala's traits,
 Haskell's typeclasses or Solidity's interfaces. If you're not familiar with this
 concept you can
 [read more about it](https://pact-language.readthedocs.io/en/latest/pact-reference.html#interfaces)

--- a/packages/apps/kadena-docs/src/pages/docs/build/guides/building-a-voting-dapp.mdx
+++ b/packages/apps/kadena-docs/src/pages/docs/build/guides/building-a-voting-dapp.mdx
@@ -699,7 +699,8 @@ interface. The `gas-payer-v1` interface is deployed to all chains on `testnet`
 and `mainnet` so you can directly use it in your contract. We can specify that a
 module implements an interface using the `(implements INTERFACE)` construct. :::
 
-:::info Pact interfaces are similar to Java's interfaces, Scala's traits,
+:::info
+ Pact interfaces are similar to Java's interfaces, Scala's traits,
 Haskell's typeclasses or Solidity's interfaces. If you're not familiar with this
 concept you can
 [read more about it](https://pact-language.readthedocs.io/en/latest/pact-reference.html#interfaces)

--- a/packages/apps/kadena-docs/src/pages/docs/build/guides/building-a-voting-dapp.mdx
+++ b/packages/apps/kadena-docs/src/pages/docs/build/guides/building-a-voting-dapp.mdx
@@ -21,7 +21,7 @@ JavaScript libraries you can use to interact with nodes running Pact.
 ### Voting on the Blockchain
 
 :::info The complete code of this tutorial can also be found in the
-[github repo](https://github.com/kadena-community/kadena.js/tree/master/packages/tutorials/election-dapp).
+[github repo](https://github.com/kadena-community/kadena.js/tree/main/packages/tutorials/election-dapp).
 :::
 
 Elections are a necessary part of democracies and democratic organizations. The
@@ -439,7 +439,7 @@ the `create-table` calls if it's not since we cannot recreate tables when
 upgrading a module. :::
 
 You can find the complete source code of the `election.pact` contract
-[here](https://github.com/kadena-community/kadena.js/tree/master/packages/tutorials/election-dapp/pact).
+[here](https://github.com/kadena-community/kadena.js/tree/main/packages/tutorials/election-dapp/pact).
 
 It's time to summarize what we've learned so far:
 
@@ -699,10 +699,9 @@ interface. The `gas-payer-v1` interface is deployed to all chains on `testnet`
 and `mainnet` so you can directly use it in your contract. We can specify that a
 module implements an interface using the `(implements INTERFACE)` construct. :::
 
-:::info  
-Pact interfaces are similar to Java's interfaces, Scala's traits, Haskell's
-typeclasses or Solidity's interfaces. If you're not familiar with this concept
-you can
+:::info Pact interfaces are similar to Java's interfaces, Scala's traits,
+Haskell's typeclasses or Solidity's interfaces. If you're not familiar with this
+concept you can
 [read more about it](https://pact-language.readthedocs.io/en/latest/pact-reference.html#interfaces)
 in Pact reference. :::
 
@@ -1046,7 +1045,7 @@ async function deployContract(pactCode) {
 account with real KDA. :::
 
 The above snippets can also be found in the
-[tutorial repo](https://github.com/kadena-community/kadena.js/tree/master/packages/tutorials/election-dapp).
+[tutorial repo](https://github.com/kadena-community/kadena.js/tree/main/packages/tutorials/election-dapp).
 :::
 
 ### Frontend
@@ -1126,7 +1125,7 @@ application:
   a smart contract event was emitted
 
 The complete code of this tutorial can also be found in front-end folder in the
-[tutorial repo](https://github.com/kadena-community/kadena.js/tree/master/packages/tutorials/election-dapp/front-end).
+[tutorial repo](https://github.com/kadena-community/kadena.js/tree/main/packages/tutorials/election-dapp/front-end).
 For demonstration purposes the election smart contracts have been deployed to
 **_testnet chain 0_**
 
@@ -1179,7 +1178,7 @@ Here's a screenshot from our demo app where we display the candidates and the
 number of votes received by each candidate:
 
 //TODO: replace image
-https://github.com/kadena-community/kadena.js/blob/master/packages/tutorials/election-dapp/front-end/screens/main.png?raw=true
+https://github.com/kadena-community/kadena.js/blob/main/packages/tutorials/election-dapp/front-end/screens/main.png?raw=true
 
 #### Sign & Send Transaction
 
@@ -1276,7 +1275,7 @@ the **Vote Now** button will automatically open the Chainweaver signing wizard.
 Below is the first step of the Chainweaver request signing wizard:
 
 //TODO: replace image
-https://github.com/kadena-community/kadena.js/blob/master/packages/tutorials/election-dapp/front-end/screens/quicksign.png?raw=true
+https://github.com/kadena-community/kadena.js/blob/main/packages/tutorials/election-dapp/front-end/screens/quicksign.png?raw=true
 
 Once the transaction is signed, our dApp modal will automatically submit it to
 the network.

--- a/packages/apps/kadena-docs/src/pages/docs/build/guides/building-a-voting-dapp.mdx
+++ b/packages/apps/kadena-docs/src/pages/docs/build/guides/building-a-voting-dapp.mdx
@@ -700,7 +700,7 @@ and `mainnet` so you can directly use it in your contract. We can specify that a
 module implements an interface using the `(implements INTERFACE)` construct. :::
 
 :::info
- Pact interfaces are similar to Java's interfaces, Scala's traits,
+Pact interfaces are similar to Java's interfaces, Scala's traits,
 Haskell's typeclasses or Solidity's interfaces. If you're not familiar with this
 concept you can
 [read more about it](https://pact-language.readthedocs.io/en/latest/pact-reference.html#interfaces)

--- a/packages/apps/kadena-docs/src/pages/docs/contribute/contribute.mdx
+++ b/packages/apps/kadena-docs/src/pages/docs/contribute/contribute.mdx
@@ -206,7 +206,7 @@ git commit -m 'how to edit docs'
 Use **git push **to push your changes to your remote repository.
 
 ```bash title=" "
-git push origin master
+git push origin main
 ```
 
 ![github](/assets/docs/27-contribute.png)

--- a/packages/libs/bootstrap-lib/README.md
+++ b/packages/libs/bootstrap-lib/README.md
@@ -2,8 +2,8 @@
 
 <p align="center">
   <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
   </picture>
 </p>
 
@@ -26,4 +26,4 @@ crypto:
 - `stringifyAndMakePOSTRequest`
 
 [1]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/cryptography-utils/etc/cryptography-utils.api.md
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/cryptography-utils/etc/cryptography-utils.api.md

--- a/packages/libs/chainweb-node-client/README.md
+++ b/packages/libs/chainweb-node-client/README.md
@@ -5,8 +5,8 @@ chainweb-node API endpoints.
 
 <p align="center">
   <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
   </picture>
 </p>
 <hr>
@@ -154,6 +154,6 @@ stringifyAndMakePOSTRequest(body);
 <hr>
 
 [1]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/chainweb-node-client/etc/chainweb-node-client.api.md
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/chainweb-node-client/etc/chainweb-node-client.api.md
 [2]: https://api.chainweb.com/openapi/pact.html
 [3]: https://api.chainweb.com/openapi/#tag/rosetta

--- a/packages/libs/chainwebjs/package.json
+++ b/packages/libs/chainwebjs/package.json
@@ -10,7 +10,7 @@
     "blockchain",
     "api"
   ],
-  "homepage": "https://github.com/kadena-community/kadena.js/tree/master#readme",
+  "homepage": "https://github.com/kadena-community/kadena.js/tree/main#readme",
   "bugs": {
     "url": "https://github.com/kadena-community/kadena.js/issues"
   },

--- a/packages/libs/client/README.md
+++ b/packages/libs/client/README.md
@@ -7,9 +7,9 @@ Makes use of .kadena/pactjs-generated
 
 <picture>
 
-<source srcset="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+<source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
 
-<img src="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+<img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
 
 </picture>
 
@@ -151,7 +151,7 @@ by `@kadena/client` to give you type information.
 # Building a simple transaction from the contract
 
 > Take a look at
-> [https://github.com/kadena-community/kadena.js/blob/master/packages/libs/pactjs-test-project/src/example-contract/simple-transfer.ts][20]
+> [https://github.com/kadena-community/kadena.js/blob/main/packages/libs/pactjs-test-project/src/example-contract/simple-transfer.ts][20]
 > for the full example
 
 Now that everything is bootstrapped, we can start building transactions.
@@ -422,7 +422,7 @@ Probably the simplest call you can make is `describe-module`, but as this is not
 on the `coin` contract, we have to trick Typescript a little:
 
 > See:
-> [https://github.com/kadena-community/kadena.js/blob/master/packages/libs/pactjs-test-project/src/example-contract/get-balance.ts][23]
+> [https://github.com/kadena-community/kadena.js/blob/main/packages/libs/pactjs-test-project/src/example-contract/get-balance.ts][23]
 
 ```ts
 const res = await Pact.modules.coin['get-balance']('albert').local(
@@ -433,7 +433,7 @@ console.log(JSON.stringify(res, null, 2));
 
 > **A more elaborate example** that includes signing, sending, **and polling**
 > can be found here:
-> [https://github.com/kadena-community/kadena.js/blob/master/packages/libs/pactjs-test-project/src/example-contract/transfer.ts][24]
+> [https://github.com/kadena-community/kadena.js/blob/main/packages/libs/pactjs-test-project/src/example-contract/transfer.ts][24]
 
 # Further development
 
@@ -450,7 +450,7 @@ We try to be available via Discord and Github issues:
 - Discord in the [#kadena-js channel][25]
 
 [1]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/client/etc/client.api.md
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/client/etc/client.api.md
 [2]: #contract-based-interaction-using-kadenaclient
 [3]: #template-based-interaction-using-kadenaclient
 [4]: #using-the-pactcommand-class
@@ -470,11 +470,11 @@ We try to be available via Discord and Github issues:
 [18]: #further-development
 [19]: #contact-the-team
 [20]:
-  https://github.com/kadena-community/kadena.js/blob/master/packages/libs/pactjs-test-project/src/example-contract/simple-transfer.ts
+  https://github.com/kadena-community/kadena.js/blob/main/packages/libs/pactjs-test-project/src/example-contract/simple-transfer.ts
 [21]: https://kadena-io.github.io/signing-api/
 [22]: https://api.chainweb.com/openapi/pact.html
 [23]:
-  https://github.com/kadena-community/kadena.js/blob/master/packages/libs/pactjs-test-project/src/example-contract/get-balance.ts
+  https://github.com/kadena-community/kadena.js/blob/main/packages/libs/pactjs-test-project/src/example-contract/get-balance.ts
 [24]:
-  https://github.com/kadena-community/kadena.js/blob/master/packages/libs/pactjs-test-project/src/example-contract/transfer.ts
+  https://github.com/kadena-community/kadena.js/blob/main/packages/libs/pactjs-test-project/src/example-contract/transfer.ts
 [25]: https://github.com/kadena-community/kadena.js/issues

--- a/packages/libs/cryptography-utils/README.md
+++ b/packages/libs/cryptography-utils/README.md
@@ -2,8 +2,8 @@
 
 <p align="center">
   <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
   </picture>
 </p>
 
@@ -60,4 +60,4 @@ crypto:
 - `toTweetNaclSecretKey`
 
 [1]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/cryptography-utils/etc/cryptography-utils.api.md
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/cryptography-utils/etc/cryptography-utils.api.md

--- a/packages/libs/pactjs-generator/README.md
+++ b/packages/libs/pactjs-generator/README.md
@@ -4,8 +4,8 @@ Library for building type definitions based on smart contracts
 
 <p align="center">
   <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
   </picture>
 </p>
 <hr>
@@ -15,4 +15,4 @@ API Reference can be found here [pactjs-generator.api.md][1]
 <hr>
 
 [1]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/pactjs-generator/etc/pactjs-generator.api.md
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/pactjs-generator/etc/pactjs-generator.api.md

--- a/packages/libs/pactjs/README.md
+++ b/packages/libs/pactjs/README.md
@@ -2,8 +2,8 @@
 
 <p align="center">
   <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
   </picture>
 </p>
 
@@ -19,4 +19,4 @@ crypto:
 - `PactNumber`
 
 [1]:
-  https://github.com/kadena-community/kadena.js/blob/master/packages/libs/pactjs/etc/pactjs.api.md
+  https://github.com/kadena-community/kadena.js/blob/main/packages/libs/pactjs/etc/pactjs.api.md

--- a/packages/tools/cookbook/README.md
+++ b/packages/tools/cookbook/README.md
@@ -7,9 +7,9 @@ This project demonstrates common use cases for `@kadena/client` and
 
 <picture>
 
-<source srcset="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+<source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
 
-<img src="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+<img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
 
 </picture>
 
@@ -56,9 +56,9 @@ ts-node src/accounts/transfer-create.ts senderAccount receiverAccount 1
   directory to print the response for a non-transactional command execution.
 
 [1]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/client#kadenajs---client
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/client#kadenajs---client
 [2]: ./src/accounts/create-account.ts
 [3]: ./src/accounts/transfer-create.ts
 [4]: ./src/accounts/get-balance.ts
 [5]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/libs/client#load-contracts-from-the-blockchain
+  https://github.com/kadena-community/kadena.js/tree/main/packages/libs/client#load-contracts-from-the-blockchain

--- a/packages/tools/create-kadena-app/README.md
+++ b/packages/tools/create-kadena-app/README.md
@@ -5,8 +5,8 @@ kadena.js targetting the Kadena Blockchain.
 
 <p align="center">
   <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
   </picture>
 </p>
 
@@ -133,5 +133,5 @@ info on Pact development visit the **Build** section on [docs.kadena.io][7].
 [4]: https://vuejs.org/
 [5]: https://angular.io/
 [6]:
-  https://github.com/kadena-community/kadena.js/tree/master/packages/tools/create-kadena-app/pact
+  https://github.com/kadena-community/kadena.js/tree/main/packages/tools/create-kadena-app/pact
 [7]: https://docs.kadena.io/

--- a/packages/tools/create-kadena-app/templates/README.md
+++ b/packages/tools/create-kadena-app/templates/README.md
@@ -1,7 +1,7 @@
 # Project created with Create Kadena App CLI tool
 
 This is a project with Kadena Blockchain integration bootstrapped with
-[`create-kadena-app`](https://github.com/kadena-community/kadena.js/tree/master/packages/tools/create-kadena-app).
+[`create-kadena-app`](https://github.com/kadena-community/kadena.js/tree/main/packages/tools/create-kadena-app).
 
 ## Learn More
 

--- a/packages/tools/create-kadena-app/templates/angular/src/app/app.component.html
+++ b/packages/tools/create-kadena-app/templates/angular/src/app/app.component.html
@@ -57,7 +57,7 @@
         >Find in-depth information about Kadena. &rarr;</a
       >
       <a
-        href="https://github.com/kadena-community/kadena.js/tree/master/packages/tools/create-kadena-app/pact"
+        href="https://github.com/kadena-community/kadena.js/tree/main/packages/tools/create-kadena-app/pact"
         >The smart contract powering this page. &rarr;</a
       >
     </div>

--- a/packages/tools/create-kadena-app/templates/nextjs/src/pages/index.tsx
+++ b/packages/tools/create-kadena-app/templates/nextjs/src/pages/index.tsx
@@ -162,7 +162,7 @@ const Home: React.FC = (): JSX.Element => {
           <a href="https://docs.kadena.io/">
             Find in-depth information about Kadena. &rarr;
           </a>
-          <a href="https://github.com/kadena-community/kadena.js/tree/master/packages/tools/create-kadena-app/pact">
+          <a href="https://github.com/kadena-community/kadena.js/tree/main/packages/tools/create-kadena-app/pact">
             The smart contract powering this page. &rarr;
           </a>
         </div>

--- a/packages/tools/create-kadena-app/templates/vuejs/src/App.vue
+++ b/packages/tools/create-kadena-app/templates/vuejs/src/App.vue
@@ -150,7 +150,7 @@ export default {
         >Find in-depth information about Kadena. &rarr;</a
       >
       <a
-        href="https://github.com/kadena-community/kadena.js/tree/master/packages/tools/create-kadena-app/pact"
+        href="https://github.com/kadena-community/kadena.js/tree/main/packages/tools/create-kadena-app/pact"
         >The smart contract powering this page. &rarr;</a
       >
     </div>

--- a/packages/tools/kda-cli/package.json
+++ b/packages/tools/kda-cli/package.json
@@ -20,12 +20,13 @@
   "scripts": {
     "build": "heft build",
     "dev": "heft build -w",
-    "kda": "node lib/index.js",
-    "test": "ava",
+    "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:pkg": "sort-package-json",
-    "format:src": "prettier config src --write"
+    "format:src": "prettier config src --write",
+    "kda": "node lib/index.js",
+    "test": "ava"
   },
   "ava": {
     "extensions": {

--- a/packages/tools/pactjs-cli/README.md
+++ b/packages/tools/pactjs-cli/README.md
@@ -2,8 +2,8 @@
 
 <p align="center">
   <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/master/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
   </picture>
 </p>
 

--- a/packages/tools/remark-plugins/src/commentMarkers/packageTable.ts
+++ b/packages/tools/remark-plugins/src/commentMarkers/packageTable.ts
@@ -38,7 +38,7 @@ export function packageTable(): Table {
   const rows: TableRow[] = projects.map((project) => {
     const packageLink: Link = {
       type: 'link',
-      url: `${repoUrl}/tree/master/${project.projectFolder}`,
+      url: `${repoUrl}/tree/main/${project.projectFolder}`,
       children: [{ type: 'text', value: project.packageName }],
     };
 

--- a/rush.json
+++ b/rush.json
@@ -296,7 +296,7 @@
      * The default branch name. This tells "rush change" which remote branch to compare against.
      * The default value is "main"
      */
-    "defaultBranch": "master"
+    "defaultBranch": "main"
 
     /**
      * The default remote. This tells "rush change" which remote to compare against if the remote URL is


### PR DESCRIPTION
This applies changes in the codebase in preparation for updating our default branch to main.

### Important steps to do before merging this:

- [x] Create and push a `main` branch that reflects current `master`
- [x] Switch default branch to `main` in GitHub repository settings (cc @alber70g @Randynamic)
- [ ] Announce team contributors to update local git config at `~/.gitconfig` to add the snippet below (less friction afterwards when creating new repos)
- [x] Delete master branch

### Important steps after merging:

- [x] Update base branches in open PRs to `main` on GitHub

### `.gitconfig`

```
[init]
	defaultbranch = main
```

Closes https://app.asana.com/0/1202676524474548/1204615060102551/f
Ref: https://www.theserverside.com/feature/Why-GitHub-renamed-its-master-branch-to-main