### PR TITLE
chore(ui): lock version of vanilla extract

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -177,8 +177,8 @@ importers:
       '@types/node': ^16.0.0
       '@types/react': ^18.0.30
       '@types/react-dom': 18.0.11
-      '@vanilla-extract/css': ~1.11.1
-      '@vanilla-extract/next-plugin': ^2.1.2
+      '@vanilla-extract/css': 1.11.1
+      '@vanilla-extract/next-plugin': 2.1.2
       acorn: ~8.8.2
       cypress: ~12.12.0
       date-fns: ~2.30.0
@@ -911,14 +911,14 @@ importers:
       '@types/node': ^16.0.0
       '@types/react': ^18.0.30
       '@types/react-dom': 18.0.11
-      '@vanilla-extract/css': ~1.11.1
-      '@vanilla-extract/recipes': ~0.4.0
-      '@vanilla-extract/sprinkles': ~1.6.0
-      '@vanilla-extract/webpack-plugin': ~2.2.0
+      '@vanilla-extract/css': 1.11.1
+      '@vanilla-extract/recipes': 0.4.0
+      '@vanilla-extract/sprinkles': 1.6.0
+      '@vanilla-extract/webpack-plugin': 2.2.0
       classnames: ^2.3.1
       eslint: ^8.15.0
       eslint-plugin-storybook: ~0.6.12
-      mini-css-extract-plugin: ~2.7.6
+      mini-css-extract-plugin: 2.7.6
       prettier: ~2.8.8
       prop-types: ^15.8.1
       react: ^18.2.0
@@ -2759,7 +2759,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.21.3:
@@ -2769,7 +2769,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-arrow-functions/7.18.6:
     resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
@@ -11052,7 +11052,7 @@ packages:
       cssesc: 3.0.0
       csstype: 3.1.1
       deep-object-diff: 1.1.9
-      deepmerge: 4.2.2
+      deepmerge: 4.3.1
       media-query-parser: 2.0.2
       outdent: 0.8.0
 

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "b96d48f4728aaae962ca8e210dd1ec01a601c2e6",
+  "pnpmShrinkwrapHash": "eb9c027f9cf77294a8ad91b16c45f50efcbd9d7a",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/apps/kadena-docs/package.json
+++ b/packages/apps/kadena-docs/package.json
@@ -44,7 +44,7 @@
     "remark-frontmatter": "~4.0.1",
     "remark-gfm": "~3.0.1",
     "shiki": "~0.14.2",
-    "@vanilla-extract/css": "~1.11.1"
+    "@vanilla-extract/css": "1.11.1"
   },
   "devDependencies": {
     "@7-docs/cli": "~0.1.7",
@@ -74,7 +74,7 @@
     "@types/node": "^16.0.0",
     "@types/react": "^18.0.30",
     "@types/react-dom": "18.0.11",
-    "@vanilla-extract/next-plugin": "^2.1.2",
+    "@vanilla-extract/next-plugin": "2.1.2",
     "cypress": "~12.12.0",
     "eslint": "^8.15.0",
     "eslint-config-next": "13.4.5",

--- a/packages/libs/react-ui/package.json
+++ b/packages/libs/react-ui/package.json
@@ -32,9 +32,9 @@
     "test": "rushx build:test && heft test"
   },
   "dependencies": {
-    "@vanilla-extract/css": "~1.11.1",
-    "@vanilla-extract/recipes": "~0.4.0",
-    "@vanilla-extract/sprinkles": "~1.6.0",
+    "@vanilla-extract/css": "1.11.1",
+    "@vanilla-extract/recipes": "0.4.0",
+    "@vanilla-extract/sprinkles": "1.6.0",
     "classnames": "^2.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -67,10 +67,10 @@
     "@types/node": "^16.0.0",
     "@types/react": "^18.0.30",
     "@types/react-dom": "18.0.11",
-    "@vanilla-extract/webpack-plugin": "~2.2.0",
+    "@vanilla-extract/webpack-plugin": "2.2.0",
     "eslint": "^8.15.0",
     "eslint-plugin-storybook": "~0.6.12",
-    "mini-css-extract-plugin": "~2.7.6",
+    "mini-css-extract-plugin": "2.7.6",
     "prettier": "~2.8.8",
     "prop-types": "^15.8.1",
     "sort-package-json": "~2.4.1",


### PR DESCRIPTION
we get a lot of errors on the `mini-css-extract-plugin` for vanilla-extract.
This has to do with running the `rush update`.

I want to try if the problems are resolved if we lock the versions of vanilla extract