### PR TITLE
Remove temp CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
           BROWSERSLIST_IGNORE_OLD_DATA: 1
 
       - name: Rush format (install-run-rush)
-        run: |
-          node common/scripts/install-run-rush.js format:ci --verbose --to git:origin/${{ github.base_ref }}
+        if: github.ref_name != 'main'
+        run: node common/scripts/install-run-rush.js format:ci --verbose
 
       - name: Rush verify Change Logs (install-run-rush)
         if: github.ref_name != 'main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,6 @@ jobs:
             common/temp/pnpm-store
           key: cache-pnpm-${{ runner.os }}
 
-      - name: List impacted packages
-        if: github.ref_name != 'main'
-        run: |
-          node common/scripts/install-run-rush.js list ${{ env.AFFECTED_OR_ALL }}
-
       - name: Rush install (install-run-rush)
         run: |
           node common/scripts/install-run-rush.js install ${{ env.AFFECTED_OR_ALL }}


### PR DESCRIPTION
No longer necessary, affected packages also logged in the actual step.

Also fixed formatting step when in `main`.