### PR TITLE
Introduce generic doc headers

### DIFF
--- a/common/changes/@kadena-dev/heft-rig/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
+++ b/common/changes/@kadena-dev/heft-rig/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/heft-rig",
+      "comment": "Introduce generic package doc headers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena-dev/heft-rig"
+}

--- a/common/changes/@kadena-dev/rush-fix-versions/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
+++ b/common/changes/@kadena-dev/rush-fix-versions/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/rush-fix-versions",
+      "comment": "Introduce generic package doc headers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena-dev/rush-fix-versions"
+}

--- a/common/changes/@kadena/chainweb-node-client/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
+++ b/common/changes/@kadena/chainweb-node-client/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-node-client",
+      "comment": "Introduce generic package doc headers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainweb-node-client"
+}

--- a/common/changes/@kadena/chainweb-stream-client/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
+++ b/common/changes/@kadena/chainweb-stream-client/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-stream-client",
+      "comment": "Introduce generic package doc headers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainweb-stream-client"
+}

--- a/common/changes/@kadena/client/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
+++ b/common/changes/@kadena/client/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "Introduce generic package doc headers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/common/changes/@kadena/cryptography-utils/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
+++ b/common/changes/@kadena/cryptography-utils/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/cryptography-utils",
+      "comment": "Introduce generic package doc headers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/cryptography-utils"
+}

--- a/common/changes/@kadena/pactjs-cli/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
+++ b/common/changes/@kadena/pactjs-cli/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-cli",
+      "comment": "Introduce generic package doc headers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs-cli"
+}

--- a/common/changes/@kadena/pactjs-generator/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
+++ b/common/changes/@kadena/pactjs-generator/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-generator",
+      "comment": "Introduce generic package doc headers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs-generator"
+}

--- a/common/changes/@kadena/pactjs/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
+++ b/common/changes/@kadena/pactjs/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs",
+      "comment": "Introduce generic package doc headers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs"
+}

--- a/common/changes/@kadena/types/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
+++ b/common/changes/@kadena/types/chore-introduce-generic-doc-headers_2023-06-28-14-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/types",
+      "comment": "Introduce generic package doc headers",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/types"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1352,7 +1352,7 @@ importers:
       typescript: 5.0.4
       unified: ^10.1.2
       unist-util-visit: ^4.1.2
-      vfile: ~6.0.0
+      vfile: 5.3.7
     dependencies:
       mdast-builder: 1.1.1
       mdast-comment-marker: 2.1.2
@@ -1376,7 +1376,7 @@ importers:
       sort-package-json: 2.4.1
       typescript: 5.0.4
       unified: 10.1.2
-      vfile: 6.0.0
+      vfile: 5.3.7
 
   ../../packages/tools/rush-fix-versions:
     specifiers:
@@ -25671,13 +25671,6 @@ packages:
       '@types/unist': 2.0.6
       unist-util-stringify-position: 3.0.3
 
-  /vfile-message/4.0.1:
-    resolution: {integrity: sha512-Z1WqUoIK6T6LLoyO64ncUapmjlA84JqKRQFjcG0kZnnyysfq2rMyg5NvKhkQ16GH9FRCRT+Rk4G0aMxgKYS16g==}
-    dependencies:
-      '@types/unist': 2.0.6
-      unist-util-stringify-position: 3.0.3
-    dev: true
-
   /vfile-reporter/7.0.5:
     resolution: {integrity: sha512-NdWWXkv6gcd7AZMvDomlQbK3MqFWL1RlGzMn++/O2TI+68+nqxCPTvLugdOtfSzXmjh+xUyhp07HhlrbJjT+mw==}
     dependencies:
@@ -25712,14 +25705,6 @@ packages:
       is-buffer: 2.0.5
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
-
-  /vfile/6.0.0:
-    resolution: {integrity: sha512-wx7bOMmEl8bY5WPaXTGsK8YxPLoFiUiDg+m+lBACA1QGcagj3sUyxkX0F+W/Nmn4MHH7G4sXBekpYWRxQE2eHg==}
-    dependencies:
-      '@types/unist': 2.0.6
-      unist-util-stringify-position: 3.0.3
-      vfile-message: 4.0.1
-    dev: true
 
   /vite-node/0.28.5_@types+node@16.18.7:
     resolution: {integrity: sha512-LmXb9saMGlrMZbXTvOveJKwMTBTNUH66c8rJnQ0ZPNX+myPEol64+szRzXtV5ORb0Hb/91yq+/D3oERoyAt6LA==}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1336,6 +1336,7 @@ importers:
       '@types/mdast': ^3.0.11
       '@types/node': ^16.0.0
       eslint: ^8.15.0
+      mdast-builder: ~1.1.1
       mdast-comment-marker: ^2.1.2
       mdast-zone: ^5.1.1
       prettier: ~2.8.8
@@ -1351,7 +1352,9 @@ importers:
       typescript: 5.0.4
       unified: ^10.1.2
       unist-util-visit: ^4.1.2
+      vfile: ~6.0.0
     dependencies:
+      mdast-builder: 1.1.1
       mdast-comment-marker: 2.1.2
       mdast-zone: 5.1.1
       remark-cli: 11.0.0
@@ -1373,6 +1376,7 @@ importers:
       sort-package-json: 2.4.1
       typescript: 5.0.4
       unified: 10.1.2
+      vfile: 6.0.0
 
   ../../packages/tools/rush-fix-versions:
     specifiers:
@@ -19596,6 +19600,12 @@ packages:
       blueimp-md5: 2.19.0
     dev: true
 
+  /mdast-builder/1.1.1:
+    resolution: {integrity: sha512-a3KBk/LmYD6wKsWi8WJrGU/rXR4yuF4Men0JO0z6dSZCm5FrXXWTRDjqK0vGSqa+1M6p9edeuypZAZAzSehTUw==}
+    dependencies:
+      '@types/unist': 2.0.6
+    dev: false
+
   /mdast-comment-marker/2.1.2:
     resolution: {integrity: sha512-HED3ezseRVkBzZ0uK4q6RJMdufr/2p3VfVZstE3H1N9K8bwtspztWo6Xd7rEatuGNoCXaBna8oEqMwUn0Ve1bw==}
     dependencies:
@@ -25661,6 +25671,13 @@ packages:
       '@types/unist': 2.0.6
       unist-util-stringify-position: 3.0.3
 
+  /vfile-message/4.0.1:
+    resolution: {integrity: sha512-Z1WqUoIK6T6LLoyO64ncUapmjlA84JqKRQFjcG0kZnnyysfq2rMyg5NvKhkQ16GH9FRCRT+Rk4G0aMxgKYS16g==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-stringify-position: 3.0.3
+    dev: true
+
   /vfile-reporter/7.0.5:
     resolution: {integrity: sha512-NdWWXkv6gcd7AZMvDomlQbK3MqFWL1RlGzMn++/O2TI+68+nqxCPTvLugdOtfSzXmjh+xUyhp07HhlrbJjT+mw==}
     dependencies:
@@ -25695,6 +25712,14 @@ packages:
       is-buffer: 2.0.5
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
+
+  /vfile/6.0.0:
+    resolution: {integrity: sha512-wx7bOMmEl8bY5WPaXTGsK8YxPLoFiUiDg+m+lBACA1QGcagj3sUyxkX0F+W/Nmn4MHH7G4sXBekpYWRxQE2eHg==}
+    dependencies:
+      '@types/unist': 2.0.6
+      unist-util-stringify-position: 3.0.3
+      vfile-message: 4.0.1
+    dev: true
 
   /vite-node/0.28.5_@types+node@16.18.7:
     resolution: {integrity: sha512-LmXb9saMGlrMZbXTvOveJKwMTBTNUH66c8rJnQ0ZPNX+myPEol64+szRzXtV5ORb0Hb/91yq+/D3oERoyAt6LA==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "802d4bba5d484d35c9852ca52c90129ab8f627e0",
+  "pnpmShrinkwrapHash": "0e248a0f20b50a22e597d963dd5868592158ec89",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "9617a2b5c7db3662acd7f857780d3e6e84fb57cf",
+  "pnpmShrinkwrapHash": "802d4bba5d484d35c9852ca52c90129ab8f627e0",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/apps/transfer/package.json
+++ b/packages/apps/transfer/package.json
@@ -27,6 +27,7 @@
     "@kadena/react-ui": "workspace:*",
     "@radix-ui/colors": "~0.1.8",
     "@stitches/react": "1.3.1-1",
+    "@vanilla-extract/next-plugin": "2.1.2",
     "ace-builds": "~1.22.1",
     "jest-standard-reporter": "~2.0.0",
     "js-cookie": "~3.0.5",
@@ -35,8 +36,7 @@
     "react": "^18.2.0",
     "react-ace": "~10.1.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1",
-    "@vanilla-extract/next-plugin": "2.1.2"
+    "react-scripts": "5.0.1"
   },
   "devDependencies": {
     "@jest/reporters": "~29.5.0",

--- a/packages/libs/bootstrap-lib/README.md
+++ b/packages/libs/bootstrap-lib/README.md
@@ -1,13 +1,13 @@
-# kadena.js - Chainweb Node Client
+<!-- genericHeader start -->
 
-<p align="center">
-  <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
-  </picture>
-</p>
+# @kadena/bootstrap-lib
 
-> Cryptography-Utils is a collection of utility functions cryptography related
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 API Reference can be found here [chainweb-node-client.api.md][1]
 

--- a/packages/libs/chainweb-node-client/README.md
+++ b/packages/libs/chainweb-node-client/README.md
@@ -1,15 +1,15 @@
-# kadena.js - Chainweb Node Client
+<!-- genericHeader start -->
 
-Chainweb Node Client is a typed JavaScript wrapper with fetch to call
-chainweb-node API endpoints.
+# @kadena/chainweb-node-client
 
-<p align="center">
-  <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
-  </picture>
-</p>
-<hr>
+Typed JavaScript wrapper with fetch to call chainweb-node API endpoints
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 API Reference can be found here [chainweb-node-client.api.md][1]
 

--- a/packages/libs/chainweb-node-client/package.json
+++ b/packages/libs/chainweb-node-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kadena/chainweb-node-client",
   "version": "0.3.2",
-  "description": "",
+  "description": "Typed JavaScript wrapper with fetch to call chainweb-node API endpoints",
   "keywords": [],
   "repository": {
     "type": "git",

--- a/packages/libs/chainweb-stream-client/README.md
+++ b/packages/libs/chainweb-stream-client/README.md
@@ -1,4 +1,15 @@
-# Chainweb Stream Client
+<!-- genericHeader start -->
+
+# @kadena/chainweb-stream-client
+
+Chainweb SSE client for browsers and node.js
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 [Chainweb-SSE][1] client for browsers and node.js
 

--- a/packages/libs/chainweb-stream-client/package.json
+++ b/packages/libs/chainweb-stream-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kadena/chainweb-stream-client",
   "version": "0.0.4",
-  "description": "",
+  "description": "Chainweb SSE client for browsers and node.js",
   "keywords": [],
   "repository": {
     "type": "git",

--- a/packages/libs/chainwebjs/README.md
+++ b/packages/libs/chainwebjs/README.md
@@ -1,3 +1,16 @@
+<!-- genericHeader start -->
+
+# @kadena/chainwebjs
+
+Javascript (Typescript) bindings for the Kadena Chainweb API
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
+
 High level Typescript bindings and types for the [Kadena][1] [Chainweb REST
 API][2].
 

--- a/packages/libs/client/README.md
+++ b/packages/libs/client/README.md
@@ -1,19 +1,16 @@
-# kadena.js - Client
+<!-- genericHeader start -->
+
+# @kadena/client
 
 Core library for building Pact expressions to send to the blockchain in js.
 Makes use of .kadena/pactjs-generated
 
-<p align="center">
-
 <picture>
-
-<source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-
-<img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
-
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
 </picture>
 
-</p>
+<!-- genericHeader end -->
 
 <hr>
 

--- a/packages/libs/cryptography-utils/README.md
+++ b/packages/libs/cryptography-utils/README.md
@@ -1,11 +1,15 @@
-# kadena.js - Cryptography-Utils
+<!-- genericHeader start -->
 
-<p align="center">
-  <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
-  </picture>
-</p>
+# @kadena/cryptography-utils
+
+Collection of Kadena cryptography utility functions
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 > Cryptography-Utils is a collection of cryptography utility functions. This
 > library is used by kadena.js to hash your transactions. If you have private

--- a/packages/libs/cryptography-utils/package.json
+++ b/packages/libs/cryptography-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kadena/cryptography-utils",
   "version": "0.3.2",
-  "description": "",
+  "description": "Collection of Kadena cryptography utility functions",
   "keywords": [],
   "repository": {
     "type": "git",

--- a/packages/libs/kadena.js/README.md
+++ b/packages/libs/kadena.js/README.md
@@ -1,11 +1,16 @@
-<p align="center">
-  <picture>
-    <source srcset="../../../common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="../../../common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
-  </picture>
-</p>
+<!-- genericHeader start -->
 
-# kadena.js - Kadena Javascript API
+# kadena.js
+
+A practical util library for JavaScript programmers who are building on the
+Kadena blockchain
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 > Kadena.js is a collection of libraries that will allow you to interact with
 > the `local`, `development`, `testnet` or `mainnet` Kadena chainweb. It will

--- a/packages/libs/pactjs-generator/README.md
+++ b/packages/libs/pactjs-generator/README.md
@@ -1,14 +1,15 @@
-# kadena.js - PactJS Generator
+<!-- genericHeader start -->
 
-Library for building type definitions based on smart contracts
+# @kadena/pactjs-generator
 
-<p align="center">
-  <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
-  </picture>
-</p>
-<hr>
+Generates TypeScript definitions of Pact contracts, for use in @kadena/pactjs
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 API Reference can be found here [pactjs-generator.api.md][1]
 

--- a/packages/libs/pactjs-test-project/README.md
+++ b/packages/libs/pactjs-test-project/README.md
@@ -1,4 +1,15 @@
-# pactjs-test-project
+<!-- genericHeader start -->
+
+# @kadena/pactjs-test-project
+
+Test project to verify pactjs-cli and pactjs-generator
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 This project demonstrates the use of the `@kadena/pact-cli` together with
 `@kadena/client` for _smart contracts_ and _transaction templates_.

--- a/packages/libs/pactjs/README.md
+++ b/packages/libs/pactjs/README.md
@@ -1,13 +1,15 @@
-# kadena.js - Pactjs
+<!-- genericHeader start -->
 
-<p align="center">
-  <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
-  </picture>
-</p>
+# @kadena/pactjs
 
-> Pactjs is a collection of utility functions pactjs related
+Collection of utility functions pactjs related
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 API Reference can be found here [pactjs.api.md][1]
 

--- a/packages/libs/pactjs/package.json
+++ b/packages/libs/pactjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kadena/pactjs",
   "version": "0.2.8",
-  "description": "",
+  "description": "Collection of utility functions pactjs related",
   "keywords": [],
   "repository": {
     "type": "git",

--- a/packages/libs/types/README.md
+++ b/packages/libs/types/README.md
@@ -1,8 +1,10 @@
-<p align="center">
-  <picture>
-    <source srcset="../../../common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="../../../common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
-  </picture>
-</p>
+<!-- genericHeader start -->
 
-# kadena.js - types
+# @kadena/types
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->

--- a/packages/tools/cookbook/README.md
+++ b/packages/tools/cookbook/README.md
@@ -1,4 +1,16 @@
-# Kadena.js Cookbook
+<!-- genericHeader start -->
+
+# @kadena/cookbook
+
+Demonstrates common use cases for @kadena/client and @kadena/pact-cli for smart
+contracts
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 This project demonstrates common use cases for `@kadena/client` and
 `@kadena/pact-cli` for _smart contracts_

--- a/packages/tools/cookbook/package.json
+++ b/packages/tools/cookbook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kadena/cookbook",
   "version": "1.0.0",
-  "description": "",
+  "description": "Demonstrates common use cases for @kadena/client and @kadena/pact-cli for smart contracts",
   "keywords": [],
   "license": "ISC",
   "author": "",

--- a/packages/tools/create-kadena-app/README.md
+++ b/packages/tools/create-kadena-app/README.md
@@ -1,14 +1,15 @@
-# kadena.js - Create Kadena App
+<!-- genericHeader start -->
 
-Create Kadena App is an easy way to get started with building apps using
-kadena.js targetting the Kadena Blockchain.
+# @kadena/create-kadena-app
 
-<p align="center">
-  <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
-  </picture>
-</p>
+CLI tool to create a starter project with @kadena/client integration
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 <hr>
 

--- a/packages/tools/create-kadena-app/package.json
+++ b/packages/tools/create-kadena-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kadena/create-kadena-app",
   "version": "0.1.0",
-  "description": "create-kadena-app CLI tool to create a starter project with @kadena/client integration",
+  "description": "CLI tool to create a starter project with @kadena/client integration",
   "repository": {
     "type": "git",
     "url": "https://github.com/kadena-community/kadena.js.git",

--- a/packages/tools/heft-rig/README.md
+++ b/packages/tools/heft-rig/README.md
@@ -1,4 +1,15 @@
-## @kadena-dev/heft-rig
+<!-- genericHeader start -->
+
+# @kadena-dev/heft-rig
+
+Our own rig package, based on @rushstack/heft-node-rig
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 A rig package for Node.js projects that build using [Heft][1] build system. To
 learn more about rig packages, consult the [@rushstack/rig-package][2]

--- a/packages/tools/kda-cli/README.md
+++ b/packages/tools/kda-cli/README.md
@@ -1,7 +1,15 @@
-# kda-cli
+<!-- genericHeader start -->
 
-This cli tool is here to assist you with your development on the kadena
-blockchain.
+# @kadena/kda-cli
+
+CLI tool to assist development on the kadena blockchain
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 ## Prerequisite
 

--- a/packages/tools/kda-cli/package.json
+++ b/packages/tools/kda-cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kadena/kda-cli",
   "version": "0.0.1",
+  "description": "CLI tool to assist development on the kadena blockchain",
   "keywords": [
     "kadena",
     "kda",

--- a/packages/tools/pactjs-cli/README.md
+++ b/packages/tools/pactjs-cli/README.md
@@ -1,14 +1,16 @@
-# kadena.js - pactjs-cli
+<!-- genericHeader start -->
 
-<p align="center">
-  <picture>
-    <source srcset="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
-    <img src="https://github.com/kadena-community/kadena.js/raw/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
-  </picture>
-</p>
+# @kadena/pactjs-cli
 
-> pactjs-cli is a cli tool to create TypeScript types (d.ts files) from Pact
-> Smart Contracts
+CLI tool accompanying @kadena/pactjs-core and @kadena/pactjs-client to generate
+TypeScript definitions and Pact client
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 ## generate
 

--- a/packages/tools/remark-plugins/README.md
+++ b/packages/tools/remark-plugins/README.md
@@ -1,4 +1,15 @@
-# @kadena-dev/remark-plugins
+<!-- genericHeader start -->
+
+# @kadena-dev/markdown
+
+Kadena monorepo Remark plugins
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 ## Included Plugins
 

--- a/packages/tools/remark-plugins/package.json
+++ b/packages/tools/remark-plugins/package.json
@@ -41,6 +41,7 @@
     "prettier": "~2.8.8",
     "sort-package-json": "~2.4.1",
     "typescript": "5.0.4",
-    "unified": "^10.1.2"
+    "unified": "^10.1.2",
+    "vfile": "~6.0.0"
   }
 }

--- a/packages/tools/remark-plugins/package.json
+++ b/packages/tools/remark-plugins/package.json
@@ -43,6 +43,6 @@
     "sort-package-json": "~2.4.1",
     "typescript": "5.0.4",
     "unified": "^10.1.2",
-    "vfile": "~6.0.0"
+    "vfile": "5.3.7"
   }
 }

--- a/packages/tools/remark-plugins/package.json
+++ b/packages/tools/remark-plugins/package.json
@@ -20,6 +20,7 @@
     "test": ""
   },
   "dependencies": {
+    "mdast-builder": "~1.1.1",
     "mdast-comment-marker": "^2.1.2",
     "mdast-zone": "^5.1.1",
     "remark-cli": "~11.0.0",

--- a/packages/tools/remark-plugins/src/commentMarkers/genericHeader.ts
+++ b/packages/tools/remark-plugins/src/commentMarkers/genericHeader.ts
@@ -1,0 +1,31 @@
+import { heading, html, paragraph, root, text } from 'mdast-builder';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { VFile } from 'vfile';
+
+interface PackageJSON {
+  name: string;
+  description: string;
+}
+
+const whiteLogoPath =
+  'https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png';
+const blackLogoPath =
+  'https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png';
+
+export function genericHeader(vFile: VFile) {
+  const p = join(vFile.cwd, 'package.json');
+  const pkg: PackageJSON = JSON.parse(readFileSync(p, 'utf-8'));
+  const { name, description } = pkg;
+
+  const logo = `<picture>
+  <source srcset="${whiteLogoPath}" media="(prefers-color-scheme: dark)"/>
+  <img src="${blackLogoPath}" width="200" alt="kadena.js logo" />
+</picture>`;
+
+  return root([
+    heading(1, text(name)),
+    paragraph(text(description)),
+    html(logo),
+  ]);
+}

--- a/packages/tools/remark-plugins/src/commentMarkers/index.ts
+++ b/packages/tools/remark-plugins/src/commentMarkers/index.ts
@@ -1,1 +1,2 @@
+export * from './genericHeader.js';
 export * from './packageTable.js';

--- a/packages/tools/remark-plugins/src/commentMarkers/packageTable.ts
+++ b/packages/tools/remark-plugins/src/commentMarkers/packageTable.ts
@@ -5,11 +5,14 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import stripJsonComments from 'strip-json-comments';
+import { VFile } from 'vfile';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const rushConfigPath = join(__dirname, '../../../../../rush.json');
+const contents = readFileSync(rushConfigPath, 'utf-8');
+const rushConfig: RushConfig = JSON.parse(stripJsonComments(contents));
 
 const repoUrl = 'https://github.com/kadena-community/kadena.js';
 const badgeBase = 'https://img.shields.io/npm/v';
@@ -28,9 +31,7 @@ const headerRow: TableRow = {
   ],
 };
 
-export function packageTable(): Table {
-  const contents = readFileSync(rushConfigPath, 'utf-8');
-  const rushConfig: RushConfig = JSON.parse(stripJsonComments(contents));
+export function packageTable(vFile: VFile): Table {
   const projects = rushConfig.projects
     .filter((project) => project.shouldPublish)
     .sort((a, b) => b.packageName.localeCompare(a.packageName));

--- a/packages/tools/remark-plugins/src/handleCommentMarkers.ts
+++ b/packages/tools/remark-plugins/src/handleCommentMarkers.ts
@@ -2,12 +2,13 @@ import type { Content, Root } from 'mdast';
 import { commentMarker } from 'mdast-comment-marker';
 import { zone } from 'mdast-zone';
 import { visit } from 'unist-util-visit';
+import type { VFile } from 'vfile';
 
 type Node = Root | Content;
-type CommentMarkers = Record<string, () => Node | undefined>;
+type CommentMarkers = Record<string, (vFile: VFile) => Node | undefined>;
 
 export const handleCommentMarkers =
-  (commentMarkers: CommentMarkers) => (tree: Root) => {
+  (commentMarkers: CommentMarkers) => (tree: Root, vFile: VFile) => {
     visit(tree, (node) => {
       const info = commentMarker(node);
       if (!info) return;
@@ -15,7 +16,7 @@ export const handleCommentMarkers =
       const name = info.name;
       if (typeof commentMarkers[name] !== 'function') return;
 
-      const nodes = commentMarkers[name]();
+      const nodes = commentMarkers[name](vFile);
 
       zone(tree, name, (start, _nodes, end) => [start, nodes, end]);
     });

--- a/packages/tools/rush-fix-versions/README.md
+++ b/packages/tools/rush-fix-versions/README.md
@@ -1,4 +1,15 @@
-# @kadena-dev/rush-fix-version
+<!-- genericHeader start -->
+
+# @kadena-dev/rush-fix-versions
+
+Tool to assist with making consistent versions across rush monorepo
+
+<picture>
+  <source srcset="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-white.png" media="(prefers-color-scheme: dark)"/>
+  <img src="https://raw.githubusercontent.com/kadena-community/kadena.js/main/common/images/Kadena.JS_logo-black.png" width="200" alt="kadena.js logo" />
+</picture>
+
+<!-- genericHeader end -->
 
 Package allows to align versions to align with `ensureConsistentVersions=true`
 option in rush.json


### PR DESCRIPTION
The `@kadena-dev/markdown` allows us to do all sorts of stuff with our Markdown files.

Today's idea is to have a generic header in every package's `README.md`:

```
# [[package.json#name]]

[[package.json#description]]

<img src="kadena-logo">
```

In case this does not come out well for a package, there are two options (in order of preference):

1. Update the `description` in `package.json` (and run `rush format`)
2. Opt out of the generated header by removing the `<!-- genericHeader start/end -->` comments.