### PR TITLE
[@kadena/react-ui]: Fix export for styling utilities

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -956,6 +956,7 @@ importers:
       focus-trap-react: ~10.1.4
       jest: ~29.5.0
       jest-environment-jsdom: ~29.5.0
+      jest-standard-reporter: ~2.0.0
       mini-css-extract-plugin: 2.7.6
       prettier: ~2.8.8
       prop-types: ^15.8.1
@@ -1015,6 +1016,7 @@ importers:
       eslint-plugin-storybook: 0.6.12_eslint@8.44.0+typescript@5.0.4
       jest: 29.5.0_@types+node@16.18.38
       jest-environment-jsdom: 29.5.0
+      jest-standard-reporter: 2.0.0
       mini-css-extract-plugin: 2.7.6
       prettier: 2.8.8
       prop-types: 15.8.1

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "3021671ac499e7b3c780c2f2615226a06d666713",
+  "pnpmShrinkwrapHash": "5c5bb5691a674db6c8cefd9b4a59d6827a01f1c1",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/apps/kadena-docs/src/pages/_app.tsx
+++ b/packages/apps/kadena-docs/src/pages/_app.tsx
@@ -3,7 +3,8 @@ import {
   darkTheme as stitchesDarkTheme,
   globalCss,
 } from '@kadena/react-components';
-import { darkThemeClass, ModalProvider } from '@kadena/react-ui';
+import { ModalProvider } from '@kadena/react-ui';
+import { darkThemeClass } from '@kadena/react-ui/theme';
 
 import { Analytics, ConsentModal } from '@/components';
 import { Main } from '@/components/Layout/components';

--- a/packages/libs/react-ui/.gitignore
+++ b/packages/libs/react-ui/.gitignore
@@ -1,2 +1,3 @@
 types
+theme
 storybook-static

--- a/packages/libs/react-ui/README.md
+++ b/packages/libs/react-ui/README.md
@@ -80,6 +80,39 @@ integration docs][5].
 After the plugin is setup, you should be able to use styling utilities exported
 from @kadena/react-ui and components within your application.
 
+### Usage
+
+As mentioned earlier, @kadena/react-ui provides components and styling utilities
+that align with the Kadena design system.
+
+Example for importing and using components:
+
+```js
+import { Text } from '@kadena/react-ui';
+
+export const Component = () => {
+  return <Text>Hello World!</Text>;
+};
+```
+
+We are using [vanilla-extract/css][1] to define our design system and style our
+components. To utilize the same theme variables and utility classes in
+conjunction with [vanilla-extract/css][1] in your own project, you can import
+them via `@kadena/react-ui/theme`:
+
+```ts
+import { sprinkles, vars } from '@kadena/react-ui/theme';
+import { style } from '@vanilla-extract/css';
+
+export const exampleClass = style([
+  sprinkles({
+    bg: '$negativeSurface',
+    color: '$negativeAccent',
+    margin: '$3',
+  }),
+]);
+```
+
 ### Dark Theme
 
 We are utilizing the [theming][6] feature from VE to create CSS color variables
@@ -91,10 +124,10 @@ You can use "next-themes" to set this up in Next.js projects by wrapping
 `Component` with the `ThemeProvider` in `__app.tsx`
 
 ```js
-import { darkThemeClass } from '@kadena/react-ui';
+import { darkThemeClass } from '@kadena/react-ui/theme';
 import { ThemeProvider } from 'next-themes';
 
-export const MyApp = ({ Component, pageProps }) {
+export const MyApp = ({ Component, pageProps }) => {
   return (
     <ThemeProvider
       attribute="class"

--- a/packages/libs/react-ui/package.json
+++ b/packages/libs/react-ui/package.json
@@ -86,6 +86,7 @@
     "eslint-plugin-storybook": "~0.6.12",
     "jest": "~29.5.0",
     "jest-environment-jsdom": "~29.5.0",
+    "jest-standard-reporter": "~2.0.0",
     "mini-css-extract-plugin": "2.7.6",
     "prettier": "~2.8.8",
     "prop-types": "^15.8.1",

--- a/packages/libs/react-ui/package.json
+++ b/packages/libs/react-ui/package.json
@@ -9,6 +9,11 @@
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
       "types": "./types/index.d.ts"
+    },
+    "./theme": {
+      "import": "./dist/esm/styles/index.js",
+      "require": "./dist/cjs/styles/index.js",
+      "types": "./types/styles/index.d.ts"
     }
   },
   "main": "dist/cjs/index.js",
@@ -16,10 +21,11 @@
   "types": "types/index.d.ts",
   "files": [
     "dist",
-    "types"
+    "types",
+    "theme"
   ],
   "scripts": {
-    "build": "tsc & tsc -p ./tsconfig.cjs.json",
+    "build": "rm -rf theme && tsc && tsc -p ./tsconfig.cjs.json && cp -r types/styles theme",
     "build:storybook": "storybook build",
     "build:test": "tsc --noEmit & tsc -p ./tsconfig.cjs.json --noEmit",
     "format": "npm run format:md && npm run format:pkg && npm run format:src",

--- a/packages/libs/react-ui/src/index.ts
+++ b/packages/libs/react-ui/src/index.ts
@@ -43,12 +43,3 @@ export {
   TextField,
   ITextFieldProps,
 } from './components';
-export {
-  sprinkles,
-  Sprinkles,
-  vars,
-  darkThemeClass,
-  ColorType,
-} from './styles';
-
-export { style } from '@vanilla-extract/css';


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->

When trying to import any VE styling utilities like theme variables or utility classes, consuming applications would error. This is due to do the following issue: https://github.com/vanilla-extract-css/vanilla-extract/issues/850#issuecomment-1493719209

This PR creates separate entry points for components and styles to fix this.
