### PR TITLE
Fix/poll until reject

### DIFF
--- a/common/changes/@kadena/client/fix-pollUntil-reject_2023-07-05-08-51.json
+++ b/common/changes/@kadena/client/fix-pollUntil-reject_2023-07-05-08-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "PactCommand's `pollUntil` now rejects with the result of the request instead of the instance of the PactCommand class",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/packages/apps/transfer/src/pages/transfer/cross-chain-transfer-finisher/index.tsx
+++ b/packages/apps/transfer/src/pages/transfer/cross-chain-transfer-finisher/index.tsx
@@ -150,7 +150,10 @@ const CrossChainTransferFinisher: FC = () => {
             }
           },
         });
-        setFinalResults({ ...pollResult });
+        setFinalResults({
+          requestKey: pollResult.reqKey,
+          status: pollResult.result.status,
+        });
       } catch (tx) {
         setFinalResults({ ...tx });
       }

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -9,6 +9,7 @@ import { ChainwebNetworkId } from '@kadena/chainweb-node-client';
 import Client from '@walletconnect/sign-client';
 import { ICap } from '@kadena/types';
 import { ICommand } from '@kadena/types';
+import { ICommandResult } from '@kadena/chainweb-node-client';
 import { IPollResponse } from '@kadena/chainweb-node-client';
 import { ISignatureJson } from '@kadena/types';
 import { IUnsignedCommand } from '@kadena/types';
@@ -119,7 +120,7 @@ export interface ICommandBuilder<TCaps extends Record<string, TArgs>, TArgs exte
         interval?: number;
         timeout?: number;
         onPoll?: (transaction: IPactCommand & ICommandBuilder<Record<string, unknown>>, pollRequest: Promise<IPollResponse>) => void;
-    }): Promise<this>;
+    }): Promise<ICommandResult>;
     // (undocumented)
     send(apiHost: string): Promise<SendResponse>;
     // (undocumented)
@@ -341,7 +342,7 @@ export class PactCommand implements IPactCommand, ICommandBuilder<Record<string,
         interval?: number;
         timeout?: number;
         onPoll?: (transaction: IPactCommand & ICommandBuilder<Record<string, unknown>>, pollRequest: Promise<IPollResponse>) => void;
-    }): Promise<this>;
+    }): Promise<ICommandResult>;
     // (undocumented)
     publicMeta: {
         chainId: ChainId;

--- a/packages/libs/client/src/pact.ts
+++ b/packages/libs/client/src/pact.ts
@@ -1,6 +1,7 @@
 import {
   ChainwebNetworkId,
   createSendRequest,
+  ICommandResult,
   IPollResponse,
   local,
   poll,
@@ -60,7 +61,7 @@ export interface ICommandBuilder<
         pollRequest: Promise<IPollResponse>,
       ) => void;
     },
-  ): Promise<this>;
+  ): Promise<ICommandResult>;
   poll(apiHost: string): Promise<IPollResponse>;
   addSignatures(
     ...sig: {
@@ -365,7 +366,7 @@ export class PactCommand
         pollRequest: Promise<IPollResponse>,
       ) => void;
     },
-  ): Promise<this> {
+  ): Promise<ICommandResult> {
     if (this.requestKey === undefined) {
       throw new Error('`requestKey` not found');
     }
@@ -396,7 +397,7 @@ export class PactCommand
               // resolve the Promise when we get a "success" response
               this.status = 'success';
               clearTimeout(cancelTimeout);
-              resolve(this);
+              resolve(result[this.requestKey!]);
             } else if (result[this.requestKey!]?.result.status === 'failure') {
               // reject the Promise when we get a "failure" response
               this.status = 'failure';

--- a/packages/libs/client/src/pact.ts
+++ b/packages/libs/client/src/pact.ts
@@ -401,7 +401,7 @@ export class PactCommand
               // reject the Promise when we get a "failure" response
               this.status = 'failure';
               clearTimeout(cancelTimeout);
-              reject(this);
+              reject(result);
             } else if (Date.now() < endTime) {
               // no "success" response (yet), try again in `interval` seconds
               setTimeout(poll, interval);

--- a/packages/libs/client/src/pact.ts
+++ b/packages/libs/client/src/pact.ts
@@ -401,7 +401,7 @@ export class PactCommand
               // reject the Promise when we get a "failure" response
               this.status = 'failure';
               clearTimeout(cancelTimeout);
-              reject(result);
+              reject(result[this.requestKey!]);
             } else if (Date.now() < endTime) {
               // no "success" response (yet), try again in `interval` seconds
               setTimeout(poll, interval);
@@ -409,7 +409,7 @@ export class PactCommand
               // took longer than the specified `timeout`, reject the Promise
               this.status = 'timeout';
               clearTimeout(cancelTimeout);
-              reject(result);
+              reject(result[this.requestKey!]);
             }
           })
           .catch((err) => console.log('this.poll failed. Error:', err));

--- a/packages/libs/client/src/tests/pact.test.ts
+++ b/packages/libs/client/src/tests/pact.test.ts
@@ -245,7 +245,8 @@ describe('Pact proxy', () => {
         timeout: 5000,
       })
       .then((t) => {
-        expect(t.status).toBe('success');
+        expect(builder.status).toBe('success');
+        expect(t.result.status).toBe('success');
       });
 
     await advanceTimersAndFlushPromises(1000);

--- a/packages/libs/client/src/tests/pact.test.ts
+++ b/packages/libs/client/src/tests/pact.test.ts
@@ -356,7 +356,7 @@ describe('Pact proxy', () => {
     expect(onPoll.mock.lastCall[0].cmd).toBeDefined();
   });
 
-  it('should reject when timeout of polling has been exceeded', async () => {
+  it('rejects when the timeout of polling has been exceeded', async () => {
     jest.useFakeTimers();
 
     const builder = new PactCommand();

--- a/packages/libs/client/src/tests/pact.test.ts
+++ b/packages/libs/client/src/tests/pact.test.ts
@@ -307,7 +307,7 @@ describe('Pact proxy', () => {
     await advanceTimersAndFlushPromises(5000);
 
     expect(builder.status).toBe('failure');
-    expect(expectingError['key1'].result.status).toBe('failure');
+    expect(expectingError.result.status).toBe('failure');
 
     expect((poll as jest.Mock).mock.calls).toHaveLength(1);
   });

--- a/packages/libs/client/src/tests/pact.test.ts
+++ b/packages/libs/client/src/tests/pact.test.ts
@@ -306,7 +306,8 @@ describe('Pact proxy', () => {
 
     await advanceTimersAndFlushPromises(5000);
 
-    expect(expectingError.status).toBe('failure');
+    expect(builder.status).toBe('failure');
+    expect(expectingError['key1'].result.status).toBe('failure');
 
     expect((poll as jest.Mock).mock.calls).toHaveLength(1);
   });


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->
Instead of `reject`ing the `pollUntil` with `this` (which is an instance of the `PactCommand` class), it would be beneficial to `reject` with the `result` of the failed request, so that one could e.g. also give more information in the UI regarding why it's failed.