### PR TITLE
fix(kadena-react-ui): tabs responsiveness for mobile devices

### DIFF
--- a/packages/libs/react-ui/src/components/Tabs/Tabs.css.ts
+++ b/packages/libs/react-ui/src/components/Tabs/Tabs.css.ts
@@ -7,7 +7,7 @@ export const tabsContainer = style([
     position: 'relative',
     display: 'flex',
     alignItems: 'center',
-    width: '100%',
+    flexGrow: 1,
     marginBottom: '$4',
   }),
   {
@@ -24,6 +24,9 @@ export const tabClass = style([
     backgroundColor: 'transparent',
     color: '$foreground',
   }),
+  {
+    whiteSpace: 'nowrap',
+  },
 ]);
 
 export const selectedClass = style([
@@ -45,5 +48,15 @@ export const selectorLine = style([
     bottom: '-4px', // for some reason a negative cant be done with vars
     transition: 'all .4s ease',
     transform: `translateX(0)`,
+  },
+]);
+
+export const tabsContainerWrapper = style([
+  sprinkles({
+    display: 'flex',
+    width: '100%',
+  }),
+  {
+    overflowY: 'scroll',
   },
 ]);

--- a/packages/libs/react-ui/src/components/Tabs/TabsContainer.tsx
+++ b/packages/libs/react-ui/src/components/Tabs/TabsContainer.tsx
@@ -1,6 +1,6 @@
 import { Tab } from './Tab';
 import { TabContent } from './TabContent';
-import { selectorLine, tabsContainer } from './Tabs.css';
+import { selectorLine, tabsContainer, tabsContainerWrapper } from './Tabs.css';
 
 import React, { FC, ReactNode, useEffect, useRef, useState } from 'react';
 
@@ -47,23 +47,25 @@ export const TabsContainer: FC<ITabsContainerProps> = ({
 
   return (
     <section>
-      <div ref={containerRef} className={tabsContainer}>
-        {React.Children.map(children, (child, idx) => {
-          if (!React.isValidElement(child)) return null;
+      <div className={tabsContainerWrapper}>
+        <div ref={containerRef} className={tabsContainer}>
+          {React.Children.map(children, (child, idx) => {
+            if (!React.isValidElement(child)) return null;
 
-          if (child.type === Tab) {
-            const props = {
-              ...child.props,
-              key: child.props.value,
-              selected: selectedTab === child.props.value,
-              handleClick,
-            };
-            return React.cloneElement(child, props);
-          }
-          return null;
-        })}
+            if (child.type === Tab) {
+              const props = {
+                ...child.props,
+                key: child.props.value,
+                selected: selectedTab === child.props.value,
+                handleClick,
+              };
+              return React.cloneElement(child, props);
+            }
+            return null;
+          })}
 
-        <span ref={selectedUnderlineRef} className={selectorLine}></span>
+          <span ref={selectedUnderlineRef} className={selectorLine}></span>
+        </div>
       </div>
 
       {React.Children.map(children, (child, idx) => {


### PR DESCRIPTION
## What to test

For smaller screens, tab names are going into multiple lines. So, instead of going into multiple lines and having a scrollbar at page level. This change introduces a horizontal scrollbar to `Tabs` for mobile devices when multiple tabs are present and then tab names will fit in a single line. 

**Before**
<img width="393" alt="image" src="https://github.com/kadena-community/kadena.js/assets/7163943/4169ba92-f19b-49a7-bee0-d49e24aa81fc">


**After**
<img width="382" alt="image" src="https://github.com/kadena-community/kadena.js/assets/7163943/112d38f9-ab88-4bf2-b54e-78469f1f6084">

