### PR TITLE
Feature/chainid type

### DIFF
--- a/common/changes/@kadena/chainweb-node-client/feature-chainid-type_2023-07-07-07-10.json
+++ b/common/changes/@kadena/chainweb-node-client/feature-chainid-type_2023-07-07-07-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-node-client",
+      "comment": "Updated Chain ID type to be usable during runtime as well",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@kadena/chainweb-node-client"
+}

--- a/common/changes/@kadena/client/feature-chainid-type_2023-07-07-07-10.json
+++ b/common/changes/@kadena/client/feature-chainid-type_2023-07-07-07-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "Implemented new Chain ID type from @kadena/chainweb-node-client",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/packages/apps/transfer/src/pages/transfer/cross-chain-transfer-finisher/index.tsx
+++ b/packages/apps/transfer/src/pages/transfer/cross-chain-transfer-finisher/index.tsx
@@ -1,7 +1,6 @@
 import { IPollResponse } from '@kadena/chainweb-node-client';
 import { ContCommand } from '@kadena/client';
 import { Button, TextField } from '@kadena/react-components';
-import { ChainId } from '@kadena/types';
 
 import MainLayout from '@/components/Common/Layout/MainLayout';
 import { DetailCard } from '@/components/Global/DetailsCard';
@@ -117,7 +116,7 @@ const CrossChainTransferFinisher: FC = () => {
       pollResults.tx.step,
       pollResults.tx.rollback,
       network,
-      pollResults.tx.receiver.chain as ChainId,
+      pollResults.tx.receiver.chain,
       kadenaXChainGas,
     );
 

--- a/packages/apps/transfer/src/services/cross-chain-transfer-finish/finish-xchain-transfer.ts
+++ b/packages/apps/transfer/src/services/cross-chain-transfer-finish/finish-xchain-transfer.ts
@@ -1,6 +1,8 @@
-import { ChainwebNetworkId } from '@kadena/chainweb-node-client';
+import {
+  ChainwebChainId,
+  ChainwebNetworkId,
+} from '@kadena/chainweb-node-client';
 import { ContCommand, getContCommand } from '@kadena/client';
-import { ChainId } from '@kadena/types';
 
 import {
   getKadenaConstantByNetwork,
@@ -24,7 +26,7 @@ export async function finishXChainTransfer(
   step: number,
   rollback: boolean,
   network: Network,
-  chainId: ChainId,
+  chainId: ChainwebChainId,
   sender: string,
 ): Promise<ContCommand | { error: string }> {
   const host = getKadenaConstantByNetwork(network).apiHost({

--- a/packages/apps/transfer/src/services/cross-chain-transfer-finish/get-transfer-data.ts
+++ b/packages/apps/transfer/src/services/cross-chain-transfer-finish/get-transfer-data.ts
@@ -1,6 +1,10 @@
-import { ICommandResult, IPollResponse } from '@kadena/chainweb-node-client';
+import {
+  ChainwebChainId,
+  ICommandResult,
+  IPollResponse,
+} from '@kadena/chainweb-node-client';
 import { PactCommand } from '@kadena/client';
-import { ChainId, IPactEvent, IPactExec, PactValue } from '@kadena/types';
+import { IPactEvent, IPactExec, PactValue } from '@kadena/types';
 
 import { getKadenaConstantByNetwork, Network } from '@/constants/kadena';
 import { chainNetwork } from '@/constants/network';
@@ -11,8 +15,8 @@ import {
 import { Translate } from 'next-translate';
 
 interface ITransactionData {
-  sender: { chain: ChainId; account: string };
-  receiver: { chain: ChainId; account: string };
+  sender: { chain: ChainwebChainId; account: string };
+  receiver: { chain: ChainwebChainId; account: string };
   amount: number;
   receiverGuard: {
     pred: string;
@@ -100,11 +104,11 @@ export async function getTransferData({
     return {
       tx: {
         sender: {
-          chain: found.chainId.toString() as ChainId,
+          chain: found.chainId.toString() as ChainwebChainId,
           account: senderAccount,
         },
         receiver: {
-          chain: targetChain as ChainId,
+          chain: targetChain as ChainwebChainId,
           account: receiverAccount,
         },
         amount: amount,

--- a/packages/apps/transfer/src/services/modules/describe-module.ts
+++ b/packages/apps/transfer/src/services/modules/describe-module.ts
@@ -1,6 +1,6 @@
+import { ChainwebChainId } from '@kadena/chainweb-node-client';
 import { PactCommand } from '@kadena/client';
 import { createExp } from '@kadena/pactjs';
-import { ChainId } from '@kadena/types';
 
 import {
   getKadenaConstantByNetwork,
@@ -17,7 +17,7 @@ export interface IModuleResult {
 
 export const describeModule = async (
   moduleName: string,
-  chainId: ChainId,
+  chainId: ChainwebChainId,
   network: Network,
   sender: string = kadenaConstants.DEFAULT_SENDER,
   gasPrice: number = kadenaConstants.GAS_PRICE,

--- a/packages/apps/transfer/src/services/transfer-tracker/get-transfer-status.ts
+++ b/packages/apps/transfer/src/services/transfer-tracker/get-transfer-status.ts
@@ -1,6 +1,8 @@
-import { ChainwebNetworkId } from '@kadena/chainweb-node-client';
+import {
+  ChainwebChainId,
+  ChainwebNetworkId,
+} from '@kadena/chainweb-node-client';
 import { getContCommand, pollSpvProof } from '@kadena/client';
-import { ChainId } from '@kadena/types';
 
 import { getTransferData } from '../cross-chain-transfer-finish/get-transfer-data';
 
@@ -149,8 +151,8 @@ export async function getXChainTransferInfo({
 }: {
   requestKey: string;
   senderAccount: string;
-  senderChain: ChainId;
-  receiverChain: ChainId;
+  senderChain: ChainwebChainId;
+  receiverChain: ChainwebChainId;
   network: Network;
   t: Translate;
 }): Promise<IStatusData> {
@@ -243,9 +245,9 @@ export async function checkForProof({
   requestKey: string;
   network: Network;
   senderAccount: string;
-  senderChain: ChainId;
+  senderChain: ChainwebChainId;
   receiverAccount: string;
-  receiverChain: ChainId;
+  receiverChain: ChainwebChainId;
   amount: number;
   options?: {
     onPoll?: (status: IStatusData) => void;

--- a/packages/apps/transfer/src/services/utils/utils.ts
+++ b/packages/apps/transfer/src/services/utils/utils.ts
@@ -1,7 +1,7 @@
-import { ChainId } from '@kadena/types';
+import { ChainwebChainId } from '@kadena/chainweb-node-client';
 
-export const convertIntToChainId = (value: number): ChainId => {
-  return value.toString() as ChainId;
+export const convertIntToChainId = (value: number): ChainwebChainId => {
+  return value.toString() as ChainwebChainId;
 };
 
 export const validateRequestKey = (key: string): string | undefined => {

--- a/packages/libs/chainweb-node-client/etc/chainweb-node-client.api.md
+++ b/packages/libs/chainweb-node-client/etc/chainweb-node-client.api.md
@@ -15,8 +15,11 @@ import type { IUnsignedCommand } from '@kadena/types';
 import type { PactValue } from '@kadena/types';
 import type { SPVProof } from '@kadena/types';
 
+// @alpha (undocumented)
+export const CHAINS: readonly ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"];
+
 // @alpha
-export type ChainwebChainId = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15' | '16' | '17' | '18' | '19';
+export type ChainwebChainId = (typeof CHAINS)[number];
 
 // @alpha
 export type ChainwebNetworkId = 'mainnet01' | 'testnet04' | 'development';

--- a/packages/libs/chainweb-node-client/etc/chainweb-node-client.api.md
+++ b/packages/libs/chainweb-node-client/etc/chainweb-node-client.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import type { ChainId } from '@kadena/types';
 import type { IBase64Url } from '@kadena/types';
 import type { ICap } from '@kadena/types';
 import type { ICommand } from '@kadena/types';
@@ -180,7 +179,7 @@ export interface ISPVRequestBody {
     // (undocumented)
     requestKey: IBase64Url;
     // (undocumented)
-    targetChainId: ChainId;
+    targetChainId: ChainwebChainId;
 }
 
 // @alpha

--- a/packages/libs/chainweb-node-client/src/interfaces/PactAPI.ts
+++ b/packages/libs/chainweb-node-client/src/interfaces/PactAPI.ts
@@ -1,5 +1,4 @@
 import type {
-  ChainId,
   IBase64Url,
   ICommand,
   IMetaData,
@@ -188,7 +187,7 @@ export type ListenResponse = ICommandResult;
  */
 export interface ISPVRequestBody {
   requestKey: IBase64Url;
-  targetChainId: ChainId;
+  targetChainId: ChainwebChainId;
 }
 
 /**

--- a/packages/libs/chainweb-node-client/src/interfaces/PactAPI.ts
+++ b/packages/libs/chainweb-node-client/src/interfaces/PactAPI.ts
@@ -58,27 +58,7 @@ interface IChainwebResponseMetaData {
  * Stringified Chainweb chain numbers.
  * @alpha
  */
-export type ChainwebChainId =
-  | '0'
-  | '1'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
-  | '6'
-  | '7'
-  | '8'
-  | '9'
-  | '10'
-  | '11'
-  | '12'
-  | '13'
-  | '14'
-  | '15'
-  | '16'
-  | '17'
-  | '18'
-  | '19';
+export type ChainwebChainId = ChainId; // For backwards compatibility just a re-export of ChainId from types package
 
 /**
  * Different Chainweb network versions.

--- a/packages/libs/chainweb-node-client/src/interfaces/PactAPI.ts
+++ b/packages/libs/chainweb-node-client/src/interfaces/PactAPI.ts
@@ -55,6 +55,9 @@ interface IChainwebResponseMetaData {
 
 // TODO: Move Chainweb Specific Types
 
+/**
+ * @alpha
+ */
 // eslint-disable-next-line @rushstack/typedef-var
 export const CHAINS = [
   '0',

--- a/packages/libs/chainweb-node-client/src/interfaces/PactAPI.ts
+++ b/packages/libs/chainweb-node-client/src/interfaces/PactAPI.ts
@@ -54,11 +54,38 @@ interface IChainwebResponseMetaData {
 }
 
 // TODO: Move Chainweb Specific Types
+
+// eslint-disable-next-line @rushstack/typedef-var
+export const CHAINS = [
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  '11',
+  '12',
+  '13',
+  '14',
+  '15',
+  '16',
+  '17',
+  '18',
+  '19',
+] as const;
+
 /**
  * Stringified Chainweb chain numbers.
+ *
+ * @see https://stackoverflow.com/a/45257357/1463352
  * @alpha
  */
-export type ChainwebChainId = ChainId; // For backwards compatibility just a re-export of ChainId from types package
+export type ChainwebChainId = (typeof CHAINS)[number];
 
 /**
  * Different Chainweb network versions.

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { ChainId } from '@kadena/types';
+import { ChainwebChainId } from '@kadena/chainweb-node-client';
 import { ChainwebNetworkId } from '@kadena/chainweb-node-client';
 import Client from '@walletconnect/sign-client';
 import { ICap } from '@kadena/types';
@@ -54,7 +54,7 @@ export function createWalletConnectQuicksign(client: Client, session: SessionTyp
 export function createWalletConnectSign(client: Client, session: SessionTypes.Struct, walletConnectChainId: TWalletConnectChainId): ISignSingleFunction;
 
 // @alpha
-export function getContCommand(requestKey: string, targetChainId: ChainId, apiHost: string, step: number, rollback: boolean): Promise<ContCommand>;
+export function getContCommand(requestKey: string, targetChainId: ChainwebChainId, apiHost: string, step: number, rollback: boolean): Promise<ContCommand>;
 
 // @alpha (undocumented)
 export interface IChainweaverCap {
@@ -218,7 +218,7 @@ export interface IPactModules {
 // @alpha (undocumented)
 export interface IPublicMeta {
     // (undocumented)
-    chainId: ChainId;
+    chainId: ChainwebChainId;
     // (undocumented)
     gasLimit: number;
     // (undocumented)
@@ -345,7 +345,7 @@ export class PactCommand implements IPactCommand, ICommandBuilder<Record<string,
     }): Promise<ICommandResult>;
     // (undocumented)
     publicMeta: {
-        chainId: ChainId;
+        chainId: ChainwebChainId;
         sender: string;
         gasLimit: number;
         gasPrice: number;
@@ -375,7 +375,7 @@ export class PactCommand implements IPactCommand, ICommandBuilder<Record<string,
 }
 
 // @alpha
-export const pollSpvProof: (requestKey: string, targetChainId: ChainId, apiHost: string, options?: {
+export const pollSpvProof: (requestKey: string, targetChainId: ChainwebChainId, apiHost: string, options?: {
     interval?: number | undefined;
     timeout?: number | undefined;
     onPoll?: ((status: string) => void) | undefined;

--- a/packages/libs/client/src/contPact.ts
+++ b/packages/libs/client/src/contPact.ts
@@ -1,5 +1,6 @@
+import { ChainwebChainId } from '@kadena/chainweb-node-client';
 import { hash as blakeHash } from '@kadena/cryptography-utils';
-import { ChainId, ICommandPayload, IUnsignedCommand } from '@kadena/types';
+import { ICommandPayload, IUnsignedCommand } from '@kadena/types';
 
 import { IContCommand } from './interfaces/IPactCommand';
 import { PactCommand } from './pact';
@@ -110,7 +111,7 @@ export class ContCommand
  */
 export const pollSpvProof = async (
   requestKey: string,
-  targetChainId: ChainId,
+  targetChainId: ChainwebChainId,
   apiHost: string,
   options?: {
     interval?: number;
@@ -179,7 +180,7 @@ export const pollSpvProof = async (
  */
 export async function getContCommand(
   requestKey: string,
-  targetChainId: ChainId,
+  targetChainId: ChainwebChainId,
   apiHost: string,
   step: number,
   rollback: boolean,

--- a/packages/libs/client/src/interfaces/IPactCommand.ts
+++ b/packages/libs/client/src/interfaces/IPactCommand.ts
@@ -1,5 +1,8 @@
-import { ChainwebNetworkId } from '@kadena/chainweb-node-client';
-import { ChainId, ICap, ISignatureJson } from '@kadena/types';
+import {
+  ChainwebChainId,
+  ChainwebNetworkId,
+} from '@kadena/chainweb-node-client';
+import { ICap, ISignatureJson } from '@kadena/types';
 
 import { NonceType, Type } from '../pact';
 /**
@@ -28,7 +31,7 @@ export interface IPactCommand {
  * @alpha
  */
 export interface IPublicMeta {
-  chainId: ChainId;
+  chainId: ChainwebChainId;
   sender: string;
   gasLimit: number;
   gasPrice: number;

--- a/packages/libs/client/src/pact.ts
+++ b/packages/libs/client/src/pact.ts
@@ -1,4 +1,5 @@
 import {
+  ChainwebChainId,
   ChainwebNetworkId,
   createSendRequest,
   ICommandResult,
@@ -11,7 +12,6 @@ import {
 import { hash as blakeHash } from '@kadena/cryptography-utils';
 import { ensureSignedCommand } from '@kadena/pactjs';
 import {
-  ChainId,
   ICap,
   ICommand,
   ICommandPayload,
@@ -130,7 +130,7 @@ export class PactCommand
   public code: string;
   public data: Record<string, unknown>;
   public publicMeta: {
-    chainId: ChainId;
+    chainId: ChainwebChainId;
     sender: string;
     gasLimit: number;
     gasPrice: number;

--- a/packages/libs/client/src/signing/walletconnect/walletConnectTypes.ts
+++ b/packages/libs/client/src/signing/walletconnect/walletConnectTypes.ts
@@ -1,4 +1,5 @@
-import { ChainId, ISigningCap } from '@kadena/types';
+import { ChainwebChainId } from '@kadena/chainweb-node-client';
+import { ISigningCap } from '@kadena/types';
 
 import { IPactCommand } from '../../interfaces/IPactCommand';
 
@@ -12,7 +13,7 @@ export interface ISigningRequest {
   data?: Record<string, unknown>;
   caps: ISigningCap[];
   nonce?: string;
-  chainId?: ChainId;
+  chainId?: ChainwebChainId;
   gasLimit?: number;
   gasPrice?: number;
   ttl?: number;
@@ -26,7 +27,7 @@ export interface IWalletConnectAccount {
   kadenaAccounts: [
     {
       name: string;
-      chains: ChainId[];
+      chains: ChainwebChainId[];
       contract: string;
     },
   ];
@@ -36,7 +37,7 @@ export interface IAccount {
   walletConnectChainId: TWalletConnectChainId;
   network: IPactCommand['networkId']; // Kadena network (mainnet, testnet, devnet)
   account: string; // Kadena account
-  chainId: ChainId; // Kadena ChainId
+  chainId: ChainwebChainId; // Kadena ChainId
 }
 
 export type TSigningType = 'sign' | 'quicksign';

--- a/packages/libs/client/src/tests/contPact.test.ts
+++ b/packages/libs/client/src/tests/contPact.test.ts
@@ -1,8 +1,8 @@
-import { ChainId } from '@kadena/types';
+import { ChainwebChainId } from '@kadena/chainweb-node-client';
 
 import { ContCommand, getContCommand, pollSpvProof } from '../contPact';
 
-let targetChainId: ChainId;
+let targetChainId: ChainwebChainId;
 let requestKey: string;
 let apiHost: string;
 let step: number;

--- a/packages/libs/types/src/PactCommand.ts
+++ b/packages/libs/types/src/PactCommand.ts
@@ -141,28 +141,35 @@ export type NetworkId = string | undefined;
 /**
  * @alpha
  */
-export type ChainId =
-  | ''
-  | '0'
-  | '1'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
-  | '6'
-  | '7'
-  | '8'
-  | '9'
-  | '10'
-  | '11'
-  | '12'
-  | '13'
-  | '14'
-  | '15'
-  | '16'
-  | '17'
-  | '18'
-  | '19';
+// eslint-disable-next-line @rushstack/typedef-var
+export const CHAINS = [
+  '0',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  '11',
+  '12',
+  '13',
+  '14',
+  '15',
+  '16',
+  '17',
+  '18',
+  '19',
+] as const;
+
+/**
+ * @see https://stackoverflow.com/a/45257357/1463352
+ * @alpha
+ */
+export type ChainId = (typeof CHAINS)[number];
 
 /**
  * The full transaction payload to be signed and sent to Chainweb.

--- a/packages/libs/types/src/PactCommand.ts
+++ b/packages/libs/types/src/PactCommand.ts
@@ -141,35 +141,28 @@ export type NetworkId = string | undefined;
 /**
  * @alpha
  */
-// eslint-disable-next-line @rushstack/typedef-var
-export const CHAINS = [
-  '0',
-  '1',
-  '2',
-  '3',
-  '4',
-  '5',
-  '6',
-  '7',
-  '8',
-  '9',
-  '10',
-  '11',
-  '12',
-  '13',
-  '14',
-  '15',
-  '16',
-  '17',
-  '18',
-  '19',
-] as const;
-
-/**
- * @see https://stackoverflow.com/a/45257357/1463352
- * @alpha
- */
-export type ChainId = (typeof CHAINS)[number];
+export type ChainId =
+  | ''
+  | '0'
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11'
+  | '12'
+  | '13'
+  | '14'
+  | '15'
+  | '16'
+  | '17'
+  | '18'
+  | '19';
 
 /**
  * The full transaction payload to be signed and sent to Chainweb.


### PR DESCRIPTION
This PR changes the `ChainwebChainId` type from the `@kadena/chainweb-node-client`. It's now also usable during runtime. To render a list of chain IDs before people would do something like;

`Array.from(Array(20)).map...`

Now you can loop through the `CHAINS` const whilst getting the correct type.