### PR TITLE
Housekeeping lint config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,16 @@
   "files.associations": {
     "*.json": "jsonc"
   },
+  "eslint.options": {
+    "overrideConfig": {
+      "settings": {
+        "import/resolver": {
+          "typescript": {
+            "project": "packages/*/*/tsconfig.json"
+          }
+        }
+      }
+    }
+  },
   "graphql-config.load.rootDir": "packages/apps/graph"
 }

--- a/common/changes/@kadena-dev/eslint-config/chore-housekeeping-lint-config_2023-07-05-21-25.json
+++ b/common/changes/@kadena-dev/eslint-config/chore-housekeeping-lint-config_2023-07-05-21-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/eslint-config",
+      "comment": "Fix up lint config",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena-dev/eslint-config"
+}

--- a/common/changes/@kadena-dev/eslint-plugin/chore-housekeeping-lint-config_2023-07-05-21-25.json
+++ b/common/changes/@kadena-dev/eslint-plugin/chore-housekeeping-lint-config_2023-07-05-21-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/eslint-plugin",
+      "comment": "Fix up lint config",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena-dev/eslint-plugin"
+}

--- a/common/changes/@kadena-dev/rush-fix-versions/chore-housekeeping-lint-config_2023-07-05-21-25.json
+++ b/common/changes/@kadena-dev/rush-fix-versions/chore-housekeeping-lint-config_2023-07-05-21-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/rush-fix-versions",
+      "comment": "Fix up lint config",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena-dev/rush-fix-versions"
+}

--- a/common/changes/@kadena/chainweb-node-client/chore-housekeeping-lint-config_2023-07-05-21-25.json
+++ b/common/changes/@kadena/chainweb-node-client/chore-housekeeping-lint-config_2023-07-05-21-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-node-client",
+      "comment": "Fix up lint config",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainweb-node-client"
+}

--- a/common/changes/@kadena/chainweb-stream-client/chore-housekeeping-lint-config_2023-07-05-21-25.json
+++ b/common/changes/@kadena/chainweb-stream-client/chore-housekeeping-lint-config_2023-07-05-21-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-stream-client",
+      "comment": "Fix up lint config",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainweb-stream-client"
+}

--- a/common/changes/@kadena/cryptography-utils/chore-housekeeping-lint-config_2023-07-05-21-25.json
+++ b/common/changes/@kadena/cryptography-utils/chore-housekeeping-lint-config_2023-07-05-21-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/cryptography-utils",
+      "comment": "Fix up lint config",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/cryptography-utils"
+}

--- a/common/changes/@kadena/pactjs-cli/chore-housekeeping-lint-config_2023-07-05-21-25.json
+++ b/common/changes/@kadena/pactjs-cli/chore-housekeeping-lint-config_2023-07-05-21-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-cli",
+      "comment": "Fix up lint config",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs-cli"
+}

--- a/common/changes/@kadena/pactjs/chore-housekeeping-lint-config_2023-07-05-21-25.json
+++ b/common/changes/@kadena/pactjs/chore-housekeeping-lint-config_2023-07-05-21-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs",
+      "comment": "Fix up lint config",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -385,6 +385,7 @@ importers:
 
   ../../packages/libs/bootstrap-lib:
     specifiers:
+      '@kadena-dev/eslint-config': workspace:*
       '@kadena-dev/heft-rig': workspace:*
       '@kadena-dev/markdown': workspace:*
       '@kadena/cryptography-utils': workspace:*
@@ -408,6 +409,7 @@ importers:
       cross-fetch: 3.1.8
       node-fetch: 2.6.12
     devDependencies:
+      '@kadena-dev/eslint-config': link:../../tools/eslint-config
       '@kadena-dev/heft-rig': link:../../tools/heft-rig
       '@kadena-dev/markdown': link:../../tools/remark-plugins
       '@rushstack/eslint-config': 3.3.2_eslint@8.44.0
@@ -420,6 +422,7 @@ importers:
 
   ../../packages/libs/chainweb-node-client:
     specifiers:
+      '@kadena-dev/eslint-config': workspace:*
       '@kadena-dev/heft-rig': workspace:*
       '@kadena-dev/markdown': workspace:*
       '@kadena/cryptography-utils': workspace:*
@@ -443,6 +446,7 @@ importers:
       cross-fetch: 3.1.8
       node-fetch: 2.6.12
     devDependencies:
+      '@kadena-dev/eslint-config': link:../../tools/eslint-config
       '@kadena-dev/heft-rig': link:../../tools/heft-rig
       '@kadena-dev/markdown': link:../../tools/remark-plugins
       '@rushstack/eslint-config': 3.3.2_eslint@8.44.0
@@ -455,6 +459,7 @@ importers:
 
   ../../packages/libs/chainweb-stream-client:
     specifiers:
+      '@kadena-dev/eslint-config': workspace:*
       '@kadena-dev/heft-rig': workspace:*
       '@kadena-dev/markdown': workspace:*
       '@kadena/cryptography-utils': workspace:*
@@ -477,6 +482,7 @@ importers:
       eventemitter2: 6.4.9
       eventsource: 2.0.2
     devDependencies:
+      '@kadena-dev/eslint-config': link:../../tools/eslint-config
       '@kadena-dev/heft-rig': link:../../tools/heft-rig
       '@kadena-dev/markdown': link:../../tools/remark-plugins
       '@rushstack/eslint-config': 3.3.2_eslint@8.44.0
@@ -578,6 +584,7 @@ importers:
 
   ../../packages/libs/cryptography-utils:
     specifiers:
+      '@kadena-dev/eslint-config': workspace:*
       '@kadena-dev/heft-rig': workspace:*
       '@kadena-dev/markdown': workspace:*
       '@kadena/types': workspace:*
@@ -597,6 +604,7 @@ importers:
       buffer: 6.0.3
       tweetnacl: 1.0.3
     devDependencies:
+      '@kadena-dev/eslint-config': link:../../tools/eslint-config
       '@kadena-dev/heft-rig': link:../../tools/heft-rig
       '@kadena-dev/markdown': link:../../tools/remark-plugins
       '@rushstack/eslint-config': 3.3.2_eslint@8.44.0
@@ -654,6 +662,7 @@ importers:
 
   ../../packages/libs/pactjs:
     specifiers:
+      '@kadena-dev/eslint-config': workspace:*
       '@kadena-dev/heft-rig': workspace:*
       '@kadena-dev/markdown': workspace:*
       '@kadena/types': workspace:*
@@ -669,6 +678,7 @@ importers:
       '@kadena/types': link:../types
       bignumber.js: 9.1.1
     devDependencies:
+      '@kadena-dev/eslint-config': link:../../tools/eslint-config
       '@kadena-dev/heft-rig': link:../../tools/heft-rig
       '@kadena-dev/markdown': link:../../tools/remark-plugins
       '@rushstack/eslint-config': 3.3.2_eslint@8.44.0
@@ -1004,6 +1014,7 @@ importers:
       '@kadena-dev/markdown': workspace:*
       '@kadena/chainweb-node-client': workspace:*
       '@kadena/client': workspace:*
+      '@kadena/cryptography-utils': workspace:*
       '@kadena/pactjs-cli': workspace:*
       '@kadena/types': workspace:*
       '@rushstack/eslint-config': ~3.3.0
@@ -1017,6 +1028,7 @@ importers:
     dependencies:
       '@kadena/chainweb-node-client': link:../../libs/chainweb-node-client
       '@kadena/client': link:../../libs/client
+      '@kadena/cryptography-utils': link:../../libs/cryptography-utils
     devDependencies:
       '@kadena-dev/eslint-config': link:../eslint-config
       '@kadena-dev/heft-rig': link:../heft-rig
@@ -1087,7 +1099,9 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.23.0
       '@typescript-eslint/parser': ^5.23.0
       eslint: ^8.15.0
+      eslint-config-next: 13.4.5
       eslint-config-prettier: ~8.8.0
+      eslint-import-resolver-typescript: 3.5.5
       eslint-plugin-import: ~2.27.5
       eslint-plugin-jsx-a11y: ~6.7.1
       eslint-plugin-prettier: ~4.2.1
@@ -1099,17 +1113,19 @@ importers:
     dependencies:
       '@kadena-dev/eslint-plugin': link:../eslint-plugin
       '@next/eslint-plugin-next': 12.3.4
+      '@rushstack/eslint-config': 3.3.2_eslint@8.44.0+typescript@5.0.4
       '@typescript-eslint/eslint-plugin': 5.60.1_cfa258330b4359c79edc87badfcf28a3
       '@typescript-eslint/parser': 5.60.1_eslint@8.44.0+typescript@5.0.4
+      eslint: 8.44.0
+      eslint-config-next: 13.4.5_eslint@8.44.0+typescript@5.0.4
       eslint-config-prettier: 8.8.0_eslint@8.44.0
+      eslint-import-resolver-typescript: 3.5.5_e813a63fe0cff7c4281576d9d101cdc8
       eslint-plugin-import: 2.27.5_eslint@8.44.0
       eslint-plugin-jsx-a11y: 6.7.1_eslint@8.44.0
       eslint-plugin-prettier: 4.2.1_828c11c77cea18acf6cec0fa4eabd791
       eslint-plugin-react: 7.31.11_eslint@8.44.0
       eslint-plugin-simple-import-sort: 7.0.0_eslint@8.44.0
     devDependencies:
-      '@rushstack/eslint-config': 3.3.2_eslint@8.44.0+typescript@5.0.4
-      eslint: 8.44.0
       prettier: 2.8.8
       sort-package-json: 2.4.1
       typescript: 5.0.4
@@ -1357,6 +1373,7 @@ importers:
       '@rushstack/heft': ~0.50.6
       '@types/inquirer': ^9.0.3
       '@types/node': ^16.0.0
+      eslint: ^8.15.0
       execa: ^7.1.1
       inquirer: ^9.2.6
       jsonc-parser: ~3.2.0
@@ -1370,10 +1387,11 @@ importers:
       '@kadena-dev/eslint-config': link:../eslint-config
       '@kadena-dev/heft-rig': link:../heft-rig
       '@kadena-dev/markdown': link:../remark-plugins
-      '@rushstack/eslint-config': 3.3.2
+      '@rushstack/eslint-config': 3.3.2_eslint@8.44.0
       '@rushstack/heft': 0.50.7_@types+node@16.18.38
       '@types/inquirer': 9.0.3
       '@types/node': 16.18.38
+      eslint: 8.44.0
       prettier: 2.8.8
       sort-package-json: 2.4.1
 
@@ -5591,15 +5609,6 @@ packages:
     os: [win32]
     optional: true
 
-  /@eslint-community/eslint-utils/4.4.0:
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint-visitor-keys: 3.4.1
-    dev: true
-
   /@eslint-community/eslint-utils/4.4.0_eslint@8.44.0:
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -7069,7 +7078,6 @@ packages:
     resolution: {integrity: sha512-/xD/kyJhXmBZq+0xGKOdjL22c9/4i3mBAXaU9aOGEHTXqqFeOz8scJbScWF13aMqigeoFCsDqngIB2MIatcn4g==}
     dependencies:
       glob: 7.1.7
-    dev: true
 
   /@next/mdx/13.3.4_64a67b8d3589d83515f0801746210334:
     resolution: {integrity: sha512-17wcHH/fDp+z+Ts8EjWvArI2+IIb7VRSPS+fGoEjVjtH1jQXwiLQSa6a1eJiuD4Grb4350Lw8zwi355xiyi+rw==}
@@ -7551,7 +7559,6 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       tslib: 2.6.0
-    dev: true
 
   /@pmmmwh/react-refresh-webpack-plugin/0.5.10_0518714fbd97967111ebc0bdad16eea3:
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
@@ -8017,27 +8024,6 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rushstack/eslint-config/3.3.2:
-    resolution: {integrity: sha512-uSrPkiZxh34I88tRdnrdDcn7tGZDKS/AMe6f8ieBdktvSROrBgNUlBoeAjtbXnbRxUmCOpkZRAAN+J/vP7IgmA==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '>=4.7.0'
-    dependencies:
-      '@rushstack/eslint-patch': 1.3.2
-      '@rushstack/eslint-plugin': 0.12.0
-      '@rushstack/eslint-plugin-packlets': 0.7.0
-      '@rushstack/eslint-plugin-security': 0.6.0
-      '@typescript-eslint/eslint-plugin': 5.59.11_39817f9c94f199c0b2c49b0e74cf9a33
-      '@typescript-eslint/experimental-utils': 5.59.11
-      '@typescript-eslint/parser': 5.59.11
-      '@typescript-eslint/typescript-estree': 5.59.11
-      eslint-plugin-promise: 6.0.1
-      eslint-plugin-react: 7.27.1
-      eslint-plugin-tsdoc: 0.2.17
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@rushstack/eslint-config/3.3.2_eslint@8.44.0:
     resolution: {integrity: sha512-uSrPkiZxh34I88tRdnrdDcn7tGZDKS/AMe6f8ieBdktvSROrBgNUlBoeAjtbXnbRxUmCOpkZRAAN+J/vP7IgmA==}
     peerDependencies:
@@ -8081,22 +8067,9 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@rushstack/eslint-patch/1.3.2:
     resolution: {integrity: sha512-V+MvGwaHH03hYhY+k6Ef/xKd6RYlc4q8WBx+2ANmipHJcKuktNcI/NgEsJgdSUF6Lw32njT6OnrRsKYCdgHjYw==}
-
-  /@rushstack/eslint-plugin-packlets/0.7.0:
-    resolution: {integrity: sha512-ftvrRvN7a5dfpDidDtrqJHH25JvL4huqk3a0S4zv5Rlh1kz6sfPvaKosDQowzEHBIWLvAtTN+P8ygWoyL0/XYw==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.59.11
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
 
   /@rushstack/eslint-plugin-packlets/0.7.0_eslint@8.44.0:
     resolution: {integrity: sha512-ftvrRvN7a5dfpDidDtrqJHH25JvL4huqk3a0S4zv5Rlh1kz6sfPvaKosDQowzEHBIWLvAtTN+P8ygWoyL0/XYw==}
@@ -8122,19 +8095,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin-security/0.6.0:
-    resolution: {integrity: sha512-gJFBGoCCofU34GGFtR3zEjymEsRr2wDLu2u13mHVcDzXyZ3EDlt6ImnJtmn8VRDLGjJ7QFPOiYMSZQaArxWmGg==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.59.11
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
 
   /@rushstack/eslint-plugin-security/0.6.0_eslint@8.44.0:
     resolution: {integrity: sha512-gJFBGoCCofU34GGFtR3zEjymEsRr2wDLu2u13mHVcDzXyZ3EDlt6ImnJtmn8VRDLGjJ7QFPOiYMSZQaArxWmGg==}
@@ -8160,7 +8120,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
   /@rushstack/eslint-plugin/0.11.0_eslint@8.44.0+typescript@5.0.4:
     resolution: {integrity: sha512-e8eVBOgb/xkpkgFmPP+oifrqCLh8I5BFI/emB/nf5+WnuS4hsTHkgprCEiJuvkhJRypsWrbchkIda9/1YFadxg==}
@@ -8170,18 +8129,6 @@ packages:
       '@rushstack/tree-pattern': 0.2.4
       '@typescript-eslint/experimental-utils': 5.38.1_eslint@8.44.0+typescript@5.0.4
       eslint: 8.44.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin/0.12.0:
-    resolution: {integrity: sha512-kDB35khQeoDjabzHkHDs/NgvNNZzogkoU/UfrXnNSJJlcCxOxmhyscUQn5OptbixiiYCOFZh9TN9v2yGBZ3vJQ==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.2.4
-      '@typescript-eslint/experimental-utils': 5.59.11
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -8211,7 +8158,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
   /@rushstack/heft-config-file/0.12.3:
     resolution: {integrity: sha512-69t0A/fcSSAih/qRA/FJYh0qSoBKtB7WhpLDz3UXvdSTVxIKLazYU9Rvnic8sK9krm8xTjRUpHQx5AnWKFlKxw==}
@@ -8390,7 +8336,6 @@ packages:
 
   /@rushstack/tree-pattern/0.2.4:
     resolution: {integrity: sha512-H8i0OinWsdKM1TKEKPeRRTw85e+/7AIFpxm7q1blceZJhuxRBjCGAUZvQXZK4CMLx75xPqh/h1t5WHwFmElAPA==}
-    dev: true
 
   /@rushstack/ts-command-line/4.13.3:
     resolution: {integrity: sha512-6aQIv/o1EgsC/+SpgUyRmzg2QIAL6sudEzw3sWzJKwWuQTc5XRsyZpyldfE7WAmIqMXDao9QG35/NYORjHm5Zw==}
@@ -10713,32 +10658,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.59.11_39817f9c94f199c0b2c49b0e74cf9a33:
-    resolution: {integrity: sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.11
-      '@typescript-eslint/scope-manager': 5.59.11
-      '@typescript-eslint/type-utils': 5.59.11
-      '@typescript-eslint/utils': 5.59.11
-      debug: 4.3.4
-      grapheme-splitter: 1.0.4
-      ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      semver: 7.5.3
-      tsutils: 3.21.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin/5.59.11_fc3c7e10fd28b37346eb388eb316549f:
     resolution: {integrity: sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -10765,7 +10684,6 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/eslint-plugin/5.60.1_cfa258330b4359c79edc87badfcf28a3:
     resolution: {integrity: sha512-KSWsVvsJsLJv3c4e73y/Bzt7OpqMCADUO846bHcuWYSYM19bldbAeDv7dYyV0jwkbMfJ2XdlzwjhXtuD7OY6bw==}
@@ -10820,18 +10738,6 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/experimental-utils/5.59.11:
-    resolution: {integrity: sha512-GkQGV0UF/V5Ra7gZMBmiD1WrYUFOJNvCZs+XQnUyJoxmqfWMXVNyB2NVCPRKefoQcpvTv9UpJyfCvsJFs8NzzQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@typescript-eslint/utils': 5.59.11
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/experimental-utils/5.59.11_eslint@8.44.0:
     resolution: {integrity: sha512-GkQGV0UF/V5Ra7gZMBmiD1WrYUFOJNvCZs+XQnUyJoxmqfWMXVNyB2NVCPRKefoQcpvTv9UpJyfCvsJFs8NzzQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -10856,25 +10762,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
-
-  /@typescript-eslint/parser/5.59.11:
-    resolution: {integrity: sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.59.11
-      '@typescript-eslint/types': 5.59.11
-      '@typescript-eslint/typescript-estree': 5.59.11
-      debug: 4.3.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/parser/5.59.11_eslint@8.44.0:
     resolution: {integrity: sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==}
@@ -10913,7 +10800,6 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/parser/5.60.1_eslint@8.44.0+typescript@5.0.4:
     resolution: {integrity: sha512-pHWlc3alg2oSMGwsU/Is8hbm3XFbcrb6P5wIxcQW9NsYBfnrubl/GhVVD/Jm/t8HXhA2WncoIRfBtnCgRGV96Q==}
@@ -10956,7 +10842,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.11
       '@typescript-eslint/visitor-keys': 5.59.11
-    dev: true
 
   /@typescript-eslint/scope-manager/5.60.1:
     resolution: {integrity: sha512-Dn/LnN7fEoRD+KspEOV0xDMynEmR3iSHdgNsarlXNLGGtcUok8L4N71dxUgt3YvlO8si7E+BJ5Fe3wb5yUw7DQ==}
@@ -10964,24 +10849,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.60.1
       '@typescript-eslint/visitor-keys': 5.60.1
-
-  /@typescript-eslint/type-utils/5.59.11:
-    resolution: {integrity: sha512-LZqVY8hMiVRF2a7/swmkStMYSoXMFlzL6sXV6U/2gL5cwnLWQgLEG8tjWPpaE4rMIdZ6VKWwcffPlo1jPfk43g==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.11
-      '@typescript-eslint/utils': 5.59.11
-      debug: 4.3.4
-      tsutils: 3.21.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@typescript-eslint/type-utils/5.59.11_eslint@8.44.0:
     resolution: {integrity: sha512-LZqVY8hMiVRF2a7/swmkStMYSoXMFlzL6sXV6U/2gL5cwnLWQgLEG8tjWPpaE4rMIdZ6VKWwcffPlo1jPfk43g==}
@@ -11020,7 +10887,6 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/type-utils/5.60.1_eslint@8.44.0+typescript@5.0.4:
     resolution: {integrity: sha512-vN6UztYqIu05nu7JqwQGzQKUJctzs3/Hg7E2Yx8rz9J+4LgtIDFWjjl1gm3pycH0P3mHAcEUBd23LVgfrsTR8A==}
@@ -11054,7 +10920,6 @@ packages:
   /@typescript-eslint/types/5.59.11:
     resolution: {integrity: sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
 
   /@typescript-eslint/types/5.60.1:
     resolution: {integrity: sha512-zDcDx5fccU8BA0IDZc71bAtYIcG9PowaOwaD8rjYbqwK7dpe/UMQl3inJ4UtUK42nOCT41jTSCwg76E62JpMcg==}
@@ -11141,7 +11006,6 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/typescript-estree/5.60.1_typescript@5.0.4:
     resolution: {integrity: sha512-hkX70J9+2M2ZT6fhti5Q2FoU9zb+GeZK2SLP1WZlvUDqdMbEKhexZODD1WodNRyO8eS+4nScvT0dts8IdaBzfw==}
@@ -11201,25 +11065,6 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/utils/5.59.11:
-    resolution: {integrity: sha512-didu2rHSOMUdJThLk4aZ1Or8IcO3HzCw/ZvEjTTIfjIrcdd5cvSIwwDy2AOlE7htSNp7QIZ10fLMyRCveesMLg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0
-      '@types/json-schema': 7.0.12
-      '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 5.59.11
-      '@typescript-eslint/types': 5.59.11
-      '@typescript-eslint/typescript-estree': 5.59.11
-      eslint-scope: 5.1.1
-      semver: 7.5.3
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/utils/5.59.11_eslint@8.44.0:
     resolution: {integrity: sha512-didu2rHSOMUdJThLk4aZ1Or8IcO3HzCw/ZvEjTTIfjIrcdd5cvSIwwDy2AOlE7htSNp7QIZ10fLMyRCveesMLg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -11258,7 +11103,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
   /@typescript-eslint/utils/5.60.1_eslint@8.44.0+typescript@5.0.4:
     resolution: {integrity: sha512-tiJ7FFdFQOWssFa3gqb94Ilexyw0JVxj6vBzaSpfN/8IhoKkDuSAenUKvsSHw2A/TMpJb26izIszTXaqygkvpQ==}
@@ -11301,7 +11145,6 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.11
       eslint-visitor-keys: 3.4.1
-    dev: true
 
   /@typescript-eslint/visitor-keys/5.60.1:
     resolution: {integrity: sha512-xEYIxKcultP6E/RMKqube11pGjXH1DCo60mQoWhVYyKfLkwbIVVjYxmOenNMxILx0TjCujPTjjnTIVzm09TXIw==}
@@ -12905,7 +12748,6 @@ packages:
   /big-integer/1.6.51:
     resolution: {integrity: sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==}
     engines: {node: '>=0.6'}
-    dev: true
 
   /big.js/5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
@@ -12996,7 +12838,6 @@ packages:
     engines: {node: '>= 5.10.0'}
     dependencies:
       big-integer: 1.6.51
-    dev: true
 
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -13097,7 +12938,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       run-applescript: 5.0.0
-    dev: true
 
   /busboy/1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -14552,7 +14392,6 @@ packages:
     dependencies:
       bplist-parser: 0.2.0
       untildify: 4.0.0
-    dev: true
 
   /default-browser/4.0.0:
     resolution: {integrity: sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==}
@@ -14562,7 +14401,6 @@ packages:
       default-browser-id: 3.0.0
       execa: 7.1.1
       titleize: 3.0.0
-    dev: true
 
   /default-gateway/6.0.3:
     resolution: {integrity: sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==}
@@ -14583,7 +14421,6 @@ packages:
   /define-lazy-prop/3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
-    dev: true
 
   /define-properties/1.2.0:
     resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
@@ -15309,7 +15146,6 @@ packages:
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /eslint-config-prettier/8.8.0_eslint@8.44.0:
     resolution: {integrity: sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==}
@@ -15375,7 +15211,6 @@ packages:
       synckit: 0.8.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /eslint-module-utils/2.8.0_eslint@8.44.0:
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
@@ -15510,13 +15345,6 @@ packages:
       prettier-linter-helpers: 1.0.0
     dev: false
 
-  /eslint-plugin-promise/6.0.1:
-    resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-    dev: true
-
   /eslint-plugin-promise/6.0.1_eslint@8.44.0:
     resolution: {integrity: sha512-uM4Tgo5u3UWQiroOyDEsYcVMOo7re3zmno0IZmB5auxoaQNIceAbXEkSt8RNrKtaYehARHG06pYK6K1JhtP0Zw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -15524,7 +15352,6 @@ packages:
       eslint: ^7.0.0 || ^8.0.0
     dependencies:
       eslint: 8.44.0
-    dev: true
 
   /eslint-plugin-react-hooks/4.6.0_eslint@8.44.0:
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
@@ -15533,28 +15360,6 @@ packages:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
       eslint: 8.44.0
-
-  /eslint-plugin-react/7.27.1:
-    resolution: {integrity: sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-    dependencies:
-      array-includes: 3.1.6
-      array.prototype.flatmap: 1.3.1
-      doctrine: 2.1.0
-      estraverse: 5.3.0
-      jsx-ast-utils: 3.3.4
-      minimatch: 3.1.2
-      object.entries: 1.1.6
-      object.fromentries: 2.0.6
-      object.hasown: 1.1.2
-      object.values: 1.1.6
-      prop-types: 15.8.1
-      resolve: 2.0.0-next.4
-      semver: 6.3.0
-      string.prototype.matchall: 4.0.8
-    dev: true
 
   /eslint-plugin-react/7.27.1_eslint@8.44.0:
     resolution: {integrity: sha512-meyunDjMMYeWr/4EBLTV1op3iSG3mjT/pz5gti38UzfM4OPpNc2m0t2xvKCOMU5D6FSdd34BIMFOvQbW+i8GAA==}
@@ -15577,7 +15382,6 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.0
       string.prototype.matchall: 4.0.8
-    dev: true
 
   /eslint-plugin-react/7.31.11_eslint@8.44.0:
     resolution: {integrity: sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==}
@@ -15644,7 +15448,6 @@ packages:
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-    dev: true
 
   /eslint-scope/5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
@@ -16706,7 +16509,6 @@ packages:
     resolution: {integrity: sha512-E5XrT4CbbXcXWy+1jChlZmrmCwd5KGx502kDCXJJ7y898TtWW9FwoG5HfOLVRKmlmDGkWN2HM9Ho+/Y8F0sJDg==}
     dependencies:
       resolve-pkg-maps: 1.0.0
-    dev: true
 
   /getos/3.2.1:
     resolution: {integrity: sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==}
@@ -16896,7 +16698,6 @@ packages:
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 4.0.0
-    dev: true
 
   /google-auth-library/8.9.0:
     resolution: {integrity: sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==}
@@ -17840,7 +17641,6 @@ packages:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
-    dev: true
 
   /is-empty/1.2.0:
     resolution: {integrity: sha512-F2FnH/otLNJv0J6wc73A5Xo7oHLNnqplYqZhUu01tD54DIPvxIRSTSLkrUB/M0nHO4vo1O9PDfN4KoTxCzLh/w==}
@@ -17894,7 +17694,6 @@ packages:
     hasBin: true
     dependencies:
       is-docker: 3.0.0
-    dev: true
 
   /is-installed-globally/0.4.0:
     resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==}
@@ -21505,7 +21304,6 @@ packages:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       is-wsl: 2.2.0
-    dev: true
 
   /openapi-sampler/1.3.1:
     resolution: {integrity: sha512-Ert9mvc2tLPmmInwSyGZS+v4Ogu9/YoZuq9oP3EdUklg2cad6+IGndP9yqJJwbgdXwZibiq5fpv6vYujchdJFg==}
@@ -24111,7 +23909,6 @@ packages:
 
   /resolve-pkg-maps/1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-    dev: true
 
   /resolve-url-loader/4.0.0:
     resolution: {integrity: sha512-05VEMczVREcbtT7Bz+C+96eUO5HDNvdthIiMB34t7FcF8ehcu4wC0sSgPUubs3XW2Q3CNLJk/BJrCU9wVRymiA==}
@@ -24263,7 +24060,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       execa: 5.1.1
-    dev: true
 
   /run-async/2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
@@ -25511,7 +25307,6 @@ packages:
     dependencies:
       '@pkgr/utils': 2.4.1
       tslib: 2.6.0
-    dev: true
 
   /tabbable/6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
@@ -25661,7 +25456,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.18.2
-      webpack: 5.73.0_webpack-cli@4.10.0
+      webpack: 5.73.0
 
   /terser/5.18.2:
     resolution: {integrity: sha512-Ah19JS86ypbJzTzvUCX7KOsEIhDaRONungA4aYBjEP3JZRf4ocuDzTg4QWZnPn9DEMiMYGJPiSOy7aykoCc70w==}
@@ -25739,7 +25534,6 @@ packages:
   /titleize/3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
-    dev: true
 
   /tmp/0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -26402,7 +26196,6 @@ packages:
   /untildify/4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
     engines: {node: '>=8'}
-    dev: true
 
   /upath/1.2.0:
     resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "d4af3ba29e0d8d0a7c98cdeb1b8ca4ec1a00d3c1",
+  "pnpmShrinkwrapHash": "1e4f2bf2175f11afc7a4aff38b4ab6689c14ede0",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/apps/docs/package.json
+++ b/packages/apps/docs/package.json
@@ -22,7 +22,7 @@
     "format:ci": "prettier config cypress src --check",
     "format:pkg": "sort-package-json",
     "format:src": "prettier config cypress src --write",
-    "lint": "eslint ./src --ext .js,.ts,.jsx,.tsx --fix",
+    "lint": "eslint ./src --ext .js,.ts,.jsx,.tsx,.mjs --fix",
     "start": "next start",
     "storybook": "storybook dev -p 6006",
     "test": "echo 'No tests, until there is time to debug the build'"

--- a/packages/apps/docs/src/pages/_error.tsx
+++ b/packages/apps/docs/src/pages/_error.tsx
@@ -3,7 +3,7 @@ import { Stack } from '@kadena/react-components';
 import {
   checkSubTreeForActive,
   getPathName,
-} from '@/utils/staticGeneration/checkSubTreeForActive';
+} from '@/utils/staticGeneration/checkSubTreeForActive.mjs';
 import { GetStaticProps } from 'next';
 import React, { FC } from 'react';
 

--- a/packages/apps/docs/src/pages/docs/__tests/index.tsx
+++ b/packages/apps/docs/src/pages/docs/__tests/index.tsx
@@ -3,7 +3,7 @@ import { Stack } from '@kadena/react-components';
 import {
   checkSubTreeForActive,
   getPathName,
-} from '@/utils/staticGeneration/checkSubTreeForActive';
+} from '@/utils/staticGeneration/checkSubTreeForActive.mjs';
 import { GetStaticProps } from 'next';
 import React, { FC } from 'react';
 

--- a/packages/apps/docs/src/pages/docs/__tests/pact/atom-sdk/atom.tsx
+++ b/packages/apps/docs/src/pages/docs/__tests/pact/atom-sdk/atom.tsx
@@ -1,7 +1,7 @@
 import {
   checkSubTreeForActive,
   getPathName,
-} from '@/utils/staticGeneration/checkSubTreeForActive';
+} from '@/utils/staticGeneration/checkSubTreeForActive.mjs';
 import { GetStaticProps } from 'next';
 import React, { FC } from 'react';
 

--- a/packages/apps/docs/src/pages/docs/build/index.tsx
+++ b/packages/apps/docs/src/pages/docs/build/index.tsx
@@ -3,7 +3,7 @@ import { Stack } from '@kadena/react-components';
 import {
   checkSubTreeForActive,
   getPathName,
-} from '@/utils/staticGeneration/checkSubTreeForActive';
+} from '@/utils/staticGeneration/checkSubTreeForActive.mjs';
 import { GetStaticProps } from 'next';
 import React, { FC } from 'react';
 

--- a/packages/apps/docs/src/pages/docs/chainweb/index.tsx
+++ b/packages/apps/docs/src/pages/docs/chainweb/index.tsx
@@ -3,7 +3,7 @@ import { ILayout } from '@/types/Layout';
 import {
   checkSubTreeForActive,
   getPathName,
-} from '@/utils/staticGeneration/checkSubTreeForActive';
+} from '@/utils/staticGeneration/checkSubTreeForActive.mjs';
 import { GetStaticProps } from 'next';
 import { OpenAPIV3 } from 'openapi-types';
 import React, { FC } from 'react';

--- a/packages/apps/docs/src/pages/docs/contribute/index.tsx
+++ b/packages/apps/docs/src/pages/docs/contribute/index.tsx
@@ -4,7 +4,7 @@ import { BrowseSection } from '@/components';
 import {
   checkSubTreeForActive,
   getPathName,
-} from '@/utils/staticGeneration/checkSubTreeForActive';
+} from '@/utils/staticGeneration/checkSubTreeForActive.mjs';
 import { GetStaticProps } from 'next';
 import React, { FC } from 'react';
 

--- a/packages/apps/docs/src/pages/docs/kadena/index.tsx
+++ b/packages/apps/docs/src/pages/docs/kadena/index.tsx
@@ -4,7 +4,7 @@ import { BrowseSection } from '@/components';
 import {
   checkSubTreeForActive,
   getPathName,
-} from '@/utils/staticGeneration/checkSubTreeForActive';
+} from '@/utils/staticGeneration/checkSubTreeForActive.mjs';
 import { GetStaticProps } from 'next';
 import Link from 'next/link';
 import React, { FC } from 'react';

--- a/packages/apps/docs/src/pages/docs/pact/api/index.tsx
+++ b/packages/apps/docs/src/pages/docs/pact/api/index.tsx
@@ -3,7 +3,7 @@ import { ILayout } from '@/types/Layout';
 import {
   checkSubTreeForActive,
   getPathName,
-} from '@/utils/staticGeneration/checkSubTreeForActive';
+} from '@/utils/staticGeneration/checkSubTreeForActive.mjs';
 import { GetStaticProps } from 'next';
 import { OpenAPIV3 } from 'openapi-types';
 import React, { FC } from 'react';

--- a/packages/apps/docs/src/pages/help/index.tsx
+++ b/packages/apps/docs/src/pages/help/index.tsx
@@ -3,7 +3,7 @@ import { Heading } from '@kadena/react-components';
 import {
   checkSubTreeForActive,
   getPathName,
-} from '@/utils/staticGeneration/checkSubTreeForActive';
+} from '@/utils/staticGeneration/checkSubTreeForActive.mjs';
 import { GetStaticProps } from 'next';
 import React, { FC } from 'react';
 

--- a/packages/apps/docs/src/pages/index.tsx
+++ b/packages/apps/docs/src/pages/index.tsx
@@ -7,7 +7,7 @@ import { getTopDocs, ITopDoc } from '@/data/getTopDocs';
 import {
   checkSubTreeForActive,
   getPathName,
-} from '@/utils/staticGeneration/checkSubTreeForActive';
+} from '@/utils/staticGeneration/checkSubTreeForActive.mjs';
 import { GetStaticProps } from 'next';
 import Link from 'next/link';
 import React, { FC } from 'react';

--- a/packages/apps/docs/src/pages/search/index.tsx
+++ b/packages/apps/docs/src/pages/search/index.tsx
@@ -7,7 +7,7 @@ import { useSearch } from '@/hooks';
 import {
   checkSubTreeForActive,
   getPathName,
-} from '@/utils/staticGeneration/checkSubTreeForActive';
+} from '@/utils/staticGeneration/checkSubTreeForActive.mjs';
 import { GetStaticProps } from 'next';
 import React, { FC } from 'react';
 

--- a/packages/apps/docs/src/scripts/remarkSideMenuToProps.mjs
+++ b/packages/apps/docs/src/scripts/remarkSideMenuToProps.mjs
@@ -4,22 +4,19 @@ const getPath = (filename) => {
   const arr = filename.split('/');
   let complete = false;
 
-  return (
-    '/' +
-    arr
-      .reverse()
-      .reduce((acc, val) => {
-        const fileName = val.split('.')[0];
-        if (fileName.includes('index') || complete) return acc;
-        if (fileName === 'docs') {
-          complete = true;
-        }
-        acc.push(fileName);
-        return acc;
-      }, [])
-      .reverse()
-      .join('/')
-  );
+  return `/${arr
+    .reverse()
+    .reduce((acc, val) => {
+      const fileName = val.split('.')[0];
+      if (fileName.includes('index') || complete) return acc;
+      if (fileName === 'docs') {
+        complete = true;
+      }
+      acc.push(fileName);
+      return acc;
+    }, [])
+    .reverse()
+    .join('/')}`;
 };
 
 const remarkSideMenuToProps = () => {

--- a/packages/apps/graph-client/package.json
+++ b/packages/apps/graph-client/package.json
@@ -12,7 +12,7 @@
     "format:src": "prettier config src --write",
     "generate:sdk": "graphql-codegen --config codegen-sdk.yml",
     "postinstall": "npm run generate:sdk",
-    "lint": "next lint",
+    "lint": "eslint ./src --fix",
     "next:dev": "next dev",
     "start": "next start",
     "start:graph": "cd ../graph && rushx start",

--- a/packages/apps/graph-client/src/components/chainweb/chain-block/chain-block.tsx
+++ b/packages/apps/graph-client/src/components/chainweb/chain-block/chain-block.tsx
@@ -14,7 +14,7 @@ interface IChainBlockProps {
   textColor: string;
 }
 
-export function ChainBlock(props: IChainBlockProps): JSX.Element {
+export const ChainBlock = (props: IChainBlockProps): JSX.Element => {
   const { color, textColor, block } = props;
 
   return (
@@ -49,4 +49,4 @@ export function ChainBlock(props: IChainBlockProps): JSX.Element {
       ) : null}
     </Container>
   );
-}
+};

--- a/packages/apps/graph-client/src/components/chainweb/chainweb-graph/chainweb-graph.tsx
+++ b/packages/apps/graph-client/src/components/chainweb/chainweb-graph/chainweb-graph.tsx
@@ -9,7 +9,7 @@ interface IChainwebGraphProps {
   blocks: Record<number, IBlock[]>;
 }
 
-export function ChainwebGraph({ blocks }: IChainwebGraphProps): JSX.Element {
+export const ChainwebGraph = ({ blocks }: IChainwebGraphProps): JSX.Element => {
   return (
     <>
       <ChainwebHeader />
@@ -24,4 +24,4 @@ export function ChainwebGraph({ blocks }: IChainwebGraphProps): JSX.Element {
         ))}
     </>
   );
-}
+};

--- a/packages/apps/graph-client/src/components/chainweb/chainweb-header/chainweb-header.tsx
+++ b/packages/apps/graph-client/src/components/chainweb/chainweb-header/chainweb-header.tsx
@@ -4,7 +4,7 @@ import { Text } from '../../text';
 
 import React from 'react';
 
-export function ChainwebHeader(): JSX.Element {
+export const ChainwebHeader = (): JSX.Element => {
   return (
     <Box
       css={{
@@ -46,4 +46,4 @@ export function ChainwebHeader(): JSX.Element {
       ))}
     </Box>
   );
-}
+};

--- a/packages/apps/graph-client/src/components/chainweb/chainweb-row/chainweb-row.tsx
+++ b/packages/apps/graph-client/src/components/chainweb/chainweb-row/chainweb-row.tsx
@@ -12,10 +12,10 @@ interface IChainwebRowProps {
   height: number;
 }
 
-export function ChainwebRow({
+export const ChainwebRow = ({
   blocks,
   height,
-}: IChainwebRowProps): JSX.Element {
+}: IChainwebRowProps): JSX.Element => {
   const row: Array<IBlock | undefined> = new Array(20).fill(undefined);
   blocks.forEach((block) => (row[block.chainid] = block));
 
@@ -66,4 +66,4 @@ export function ChainwebRow({
       })}
     </Box>
   );
-}
+};

--- a/packages/apps/graph-client/src/components/chainweb/time-ticker/time-ticker.tsx
+++ b/packages/apps/graph-client/src/components/chainweb/time-ticker/time-ticker.tsx
@@ -6,7 +6,7 @@ interface ITimeTickerProps {
   date: Date;
 }
 
-export function TimeTicker({ date }: ITimeTickerProps): JSX.Element {
+export const TimeTicker = ({ date }: ITimeTickerProps): JSX.Element => {
   const [timeDiff, setTimeDiff] = useState<number>(0);
 
   useEffect(() => {
@@ -36,4 +36,4 @@ export function TimeTicker({ date }: ITimeTickerProps): JSX.Element {
       {timeDiff < 100 ? timeDiff : '>99'} s
     </Text>
   );
-}
+};

--- a/packages/apps/graph-client/src/styles/stitches.config.ts
+++ b/packages/apps/graph-client/src/styles/stitches.config.ts
@@ -2,6 +2,7 @@
 
 import type { CSS as StitchesCSS, PropertyValue } from '@stitches/react';
 import { createStitches } from '@stitches/react';
+
 export type { VariantProps } from '@stitches/react';
 
 import {

--- a/packages/apps/transfer/package.json
+++ b/packages/apps/transfer/package.json
@@ -15,8 +15,7 @@
     "generate:contracts": "npm run generate:coin:contract && npm run generate:faucet:contract",
     "generate:faucet:contract": "npx @kadena/pactjs-cli contract-generate --contract user.coin-faucet --api https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/1/pact --chain 1 --network testnet",
     "generate:icons": "npx @svgr/cli --typescript --out-dir src/resources/svg/generated -- src/resources/svg",
-    "lint": "next lint",
-    "lint:fix": "eslint --fix .",
+    "lint": "eslint ./src --fix",
     "start": "next start",
     "test": "jest --silent"
   },

--- a/packages/libs/bootstrap-lib/.eslintrc.js
+++ b/packages/libs/bootstrap-lib/.eslintrc.js
@@ -2,6 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node'],
+  extends: ['@kadena-dev/eslint-config/profile/lib'],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/libs/bootstrap-lib/package.json
+++ b/packages/libs/bootstrap-lib/package.json
@@ -48,6 +48,7 @@
     "node-fetch": "~2.6.2"
   },
   "devDependencies": {
+    "@kadena-dev/eslint-config": "workspace:*",
     "@kadena-dev/heft-rig": "workspace:*",
     "@kadena-dev/markdown": "workspace:*",
     "@rushstack/eslint-config": "~3.3.0",

--- a/packages/libs/chainweb-node-client/.eslintrc.js
+++ b/packages/libs/chainweb-node-client/.eslintrc.js
@@ -2,6 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node'],
+  extends: ['@kadena-dev/eslint-config/profile/lib'],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/libs/chainweb-node-client/package.json
+++ b/packages/libs/chainweb-node-client/package.json
@@ -50,6 +50,7 @@
     "node-fetch": "~2.6.2"
   },
   "devDependencies": {
+    "@kadena-dev/eslint-config": "workspace:*",
     "@kadena-dev/heft-rig": "workspace:*",
     "@kadena-dev/markdown": "workspace:*",
     "@rushstack/eslint-config": "~3.3.0",

--- a/packages/libs/chainweb-node-client/src/createListenRequest.ts
+++ b/packages/libs/chainweb-node-client/src/createListenRequest.ts
@@ -1,4 +1,5 @@
 import { unique } from '@kadena/cryptography-utils';
+
 import type {
   IListenRequestBody,
   ISendRequestBody,

--- a/packages/libs/chainweb-node-client/src/createPollRequest.ts
+++ b/packages/libs/chainweb-node-client/src/createPollRequest.ts
@@ -1,4 +1,5 @@
 import { unique } from '@kadena/cryptography-utils';
+
 import type { IPollRequestBody, ISendRequestBody } from './interfaces/PactAPI';
 
 /**

--- a/packages/libs/chainweb-node-client/src/createSendRequest.ts
+++ b/packages/libs/chainweb-node-client/src/createSendRequest.ts
@@ -1,4 +1,5 @@
 import type { ICommand } from '@kadena/types';
+
 import type { ISendRequestBody } from './interfaces/PactAPI';
 
 /**

--- a/packages/libs/chainweb-node-client/src/interfaces/PactAPI.ts
+++ b/packages/libs/chainweb-node-client/src/interfaces/PactAPI.ts
@@ -1,12 +1,12 @@
 import type {
   ChainId,
-  IMetaData,
+  IBase64Url,
   ICommand,
+  IMetaData,
+  IPactEvent,
+  IPactExec,
   IUnsignedCommand,
   PactValue,
-  IBase64Url,
-  IPactExec,
-  IPactEvent,
   SPVProof,
 } from '@kadena/types';
 

--- a/packages/libs/chainweb-node-client/src/listen.ts
+++ b/packages/libs/chainweb-node-client/src/listen.ts
@@ -1,5 +1,4 @@
 import type { ICommandResult, IListenRequestBody } from './interfaces/PactAPI';
-
 import { parseResponse } from './parseResponse';
 import { stringifyAndMakePOSTRequest } from './stringifyAndMakePOSTRequest';
 

--- a/packages/libs/chainweb-node-client/src/local.ts
+++ b/packages/libs/chainweb-node-client/src/local.ts
@@ -1,14 +1,15 @@
-import type { ICommand, IUnsignedCommand, ISignatureJson } from '@kadena/types';
+import { ensureSignedCommand } from '@kadena/pactjs';
+import type { ICommand, ISignatureJson,IUnsignedCommand } from '@kadena/types';
+
 import type {
   ICommandResult,
-  LocalRequestBody,
-  IPreflightResult,
   ILocalCommandResult,
+  IPreflightResult,
+  LocalRequestBody,
   LocalResultWithoutPreflight,
 } from './interfaces/PactAPI';
-import { parseResponse, parsePreflight } from './parseResponse';
+import { parsePreflight,parseResponse } from './parseResponse';
 import { stringifyAndMakePOSTRequest } from './stringifyAndMakePOSTRequest';
-import { ensureSignedCommand } from '@kadena/pactjs';
 
 import fetch from 'cross-fetch';
 

--- a/packages/libs/chainweb-node-client/src/local.ts
+++ b/packages/libs/chainweb-node-client/src/local.ts
@@ -1,5 +1,5 @@
 import { ensureSignedCommand } from '@kadena/pactjs';
-import type { ICommand, ISignatureJson,IUnsignedCommand } from '@kadena/types';
+import type { ICommand, ISignatureJson, IUnsignedCommand } from '@kadena/types';
 
 import type {
   ICommandResult,
@@ -8,7 +8,7 @@ import type {
   LocalRequestBody,
   LocalResultWithoutPreflight,
 } from './interfaces/PactAPI';
-import { parsePreflight,parseResponse } from './parseResponse';
+import { parsePreflight, parseResponse } from './parseResponse';
 import { stringifyAndMakePOSTRequest } from './stringifyAndMakePOSTRequest';
 
 import fetch from 'cross-fetch';

--- a/packages/libs/chainweb-node-client/src/parseResponse.ts
+++ b/packages/libs/chainweb-node-client/src/parseResponse.ts
@@ -1,5 +1,6 @@
-import type { Response } from 'cross-fetch';
 import type { ILocalCommandResult, ILocalResult } from './interfaces/PactAPI';
+
+import type { Response } from 'cross-fetch';
 /**
  * Parses raw `fetch` response into a typed JSON value.
  *

--- a/packages/libs/chainweb-node-client/src/poll.ts
+++ b/packages/libs/chainweb-node-client/src/poll.ts
@@ -1,5 +1,4 @@
 import type { IPollRequestBody, IPollResponse } from './interfaces/PactAPI';
-
 import { parseResponse } from './parseResponse';
 import { stringifyAndMakePOSTRequest } from './stringifyAndMakePOSTRequest';
 

--- a/packages/libs/chainweb-node-client/src/send.ts
+++ b/packages/libs/chainweb-node-client/src/send.ts
@@ -1,4 +1,4 @@
-import { ISendRequestBody,SendResponse } from './interfaces/PactAPI';
+import { ISendRequestBody, SendResponse } from './interfaces/PactAPI';
 import { parseResponse } from './parseResponse';
 import { stringifyAndMakePOSTRequest } from './stringifyAndMakePOSTRequest';
 

--- a/packages/libs/chainweb-node-client/src/send.ts
+++ b/packages/libs/chainweb-node-client/src/send.ts
@@ -1,6 +1,7 @@
+import { ISendRequestBody,SendResponse } from './interfaces/PactAPI';
 import { parseResponse } from './parseResponse';
 import { stringifyAndMakePOSTRequest } from './stringifyAndMakePOSTRequest';
-import { SendResponse, ISendRequestBody } from './interfaces/PactAPI';
+
 import fetch from 'cross-fetch';
 /**
  * Asynchronous submission of one or more public (unencrypted) commands to the blockchain for execution.

--- a/packages/libs/chainweb-node-client/src/spv.ts
+++ b/packages/libs/chainweb-node-client/src/spv.ts
@@ -1,5 +1,4 @@
 import type { ISPVRequestBody, SPVResponse } from './interfaces/PactAPI';
-
 import { parseResponseTEXT } from './parseResponseTEXT';
 import { stringifyAndMakePOSTRequest } from './stringifyAndMakePOSTRequest';
 

--- a/packages/libs/chainweb-node-client/src/tests/index.test.ts
+++ b/packages/libs/chainweb-node-client/src/tests/index.test.ts
@@ -1,15 +1,15 @@
 import {
-  listen,
-  poll,
-  send,
-  spv,
-  local,
-  createSendRequest,
-  createPollRequest,
   createListenRequest,
+  createPollRequest,
+  createSendRequest,
+  listen,
+  local,
   mkCap,
   parseResponse,
   parseResponseTEXT,
+  poll,
+  send,
+  spv,
   stringifyAndMakePOSTRequest,
 } from '../';
 

--- a/packages/libs/chainweb-node-client/src/tests/listen.test.ts
+++ b/packages/libs/chainweb-node-client/src/tests/listen.test.ts
@@ -1,17 +1,16 @@
 jest.mock('cross-fetch');
 
-import fetch, { Response } from 'cross-fetch';
-
 import type {
+  ICommandResult,
   IListenRequestBody,
   ListenResponse,
-  ICommandResult,
 } from '../interfaces/PactAPI';
-
 import { listen } from '../listen';
 
 import { mockFetch } from './mockdata/mockFetch';
 import { testURL } from './mockdata/Pact';
+
+import fetch, { Response } from 'cross-fetch';
 
 const mockedFunctionFetch = fetch as jest.MockedFunction<typeof fetch>;
 mockedFunctionFetch.mockImplementation(

--- a/packages/libs/chainweb-node-client/src/tests/local.test.ts
+++ b/packages/libs/chainweb-node-client/src/tests/local.test.ts
@@ -38,7 +38,9 @@ test('local should return preflight result of tx queried ', async () => {
     cmd: commandStr1,
     hash: cmdWithOneSignature1.hash,
     sigs: [
-      cmdWithOneSignature1.sig ? { sig: cmdWithOneSignature1.sig } : undefined,
+      typeof cmdWithOneSignature1.sig === 'string'
+        ? { sig: cmdWithOneSignature1.sig }
+        : undefined,
     ],
   };
   const signedCommand1: ICommand = ensureSignedCommand(sampleCommand1);
@@ -78,7 +80,9 @@ test('local with `{preflight: false}` option returns non-preflight result', asyn
     cmd: commandStr1,
     hash: cmdWithOneSignature1.hash,
     sigs: [
-      cmdWithOneSignature1.sig ? { sig: cmdWithOneSignature1.sig } : undefined,
+      typeof cmdWithOneSignature1.sig === 'string'
+        ? { sig: cmdWithOneSignature1.sig }
+        : undefined,
     ],
   };
   const signedCommand1: ICommand = ensureSignedCommand(sampleCommand1);

--- a/packages/libs/chainweb-node-client/src/tests/local.test.ts
+++ b/packages/libs/chainweb-node-client/src/tests/local.test.ts
@@ -4,15 +4,15 @@ import { sign } from '@kadena/cryptography-utils';
 import { ensureSignedCommand } from '@kadena/pactjs';
 import type {
   ICommand,
-  SignatureWithHash,
   IUnsignedCommand,
+  SignatureWithHash,
 } from '@kadena/types';
+
 import type {
   ICommandResult,
   ILocalCommandResult,
   LocalResultWithoutPreflight,
 } from '../interfaces/PactAPI';
-
 import { local } from '../local';
 
 import { mockFetch } from './mockdata/mockFetch';

--- a/packages/libs/chainweb-node-client/src/tests/mockdata/Pact.ts
+++ b/packages/libs/chainweb-node-client/src/tests/mockdata/Pact.ts
@@ -1,6 +1,7 @@
 import type { ISPVRequestBody, SPVResponse } from '../../interfaces/PactAPI';
 
 import type { ICommandPayload } from '@kadena/types';
+
 export const testURL: string = 'https://fake-api-host.local.co';
 
 export const pactTestCommand: ICommandPayload = {

--- a/packages/libs/chainweb-node-client/src/tests/mockdata/Pact.ts
+++ b/packages/libs/chainweb-node-client/src/tests/mockdata/Pact.ts
@@ -1,6 +1,6 @@
-import type { ISPVRequestBody, SPVResponse } from '../../interfaces/PactAPI';
-
 import type { ICommandPayload } from '@kadena/types';
+
+import type { ISPVRequestBody, SPVResponse } from '../../interfaces/PactAPI';
 
 export const testURL: string = 'https://fake-api-host.local.co';
 

--- a/packages/libs/chainweb-node-client/src/tests/mockdata/mockFetch.ts
+++ b/packages/libs/chainweb-node-client/src/tests/mockdata/mockFetch.ts
@@ -1,12 +1,13 @@
 import type {
+  ILocalCommandResult,
   IPollResponse,
+  IPreflightResult,
   ISendRequestBody,
   ListenResponse,
-  ILocalCommandResult,
   SendResponse,
   SPVResponse,
-  IPreflightResult,
 } from '../../interfaces/PactAPI';
+
 import { testSPVProof, testURL } from './Pact';
 
 /**

--- a/packages/libs/chainweb-node-client/src/tests/poll.test.ts
+++ b/packages/libs/chainweb-node-client/src/tests/poll.test.ts
@@ -1,11 +1,11 @@
 jest.mock('cross-fetch');
 
 import type { IPollRequestBody, IPollResponse } from '../interfaces/PactAPI';
-
 import { poll } from '../poll';
 
 import { mockFetch } from './mockdata/mockFetch';
 import { testURL } from './mockdata/Pact';
+
 import fetch from 'cross-fetch';
 
 const mockedFunctionFetch = fetch as jest.MockedFunction<typeof fetch>;

--- a/packages/libs/chainweb-node-client/src/tests/send.test.ts
+++ b/packages/libs/chainweb-node-client/src/tests/send.test.ts
@@ -29,7 +29,9 @@ test('/send should return request keys of txs submitted', async () => {
     cmd: commandStr,
     hash: cmdWithOneSignature1.hash,
     sigs: [
-      cmdWithOneSignature1.sig ? { sig: cmdWithOneSignature1.sig } : undefined,
+      typeof cmdWithOneSignature1.sig === 'string'
+        ? { sig: cmdWithOneSignature1.sig }
+        : undefined,
     ],
   };
   const signedCommand1: ICommand = ensureSignedCommand(sampleCommand1);

--- a/packages/libs/chainweb-node-client/src/tests/send.test.ts
+++ b/packages/libs/chainweb-node-client/src/tests/send.test.ts
@@ -1,13 +1,15 @@
 jest.mock('cross-fetch');
 
 import { pactTestCommand, sign } from '@kadena/cryptography-utils';
-import type { IUnsignedCommand, SignCommand, ICommand } from '@kadena/types';
-import type { ISendRequestBody, SendResponse } from '../interfaces/PactAPI';
-import { createSendRequest } from '../createSendRequest';
-import { send } from '../send';
 import { ensureSignedCommand } from '@kadena/pactjs';
-import { testURL } from './mockdata/Pact';
+import type { ICommand,IUnsignedCommand, SignCommand } from '@kadena/types';
+
+import { createSendRequest } from '../createSendRequest';
+import type { ISendRequestBody, SendResponse } from '../interfaces/PactAPI';
+import { send } from '../send';
+
 import { mockFetch } from './mockdata/mockFetch';
+import { testURL } from './mockdata/Pact';
 
 import fetch, { Response } from 'cross-fetch';
 

--- a/packages/libs/chainweb-node-client/src/tests/send.test.ts
+++ b/packages/libs/chainweb-node-client/src/tests/send.test.ts
@@ -2,7 +2,7 @@ jest.mock('cross-fetch');
 
 import { pactTestCommand, sign } from '@kadena/cryptography-utils';
 import { ensureSignedCommand } from '@kadena/pactjs';
-import type { ICommand,IUnsignedCommand, SignCommand } from '@kadena/types';
+import type { ICommand, IUnsignedCommand, SignCommand } from '@kadena/types';
 
 import { createSendRequest } from '../createSendRequest';
 import type { ISendRequestBody, SendResponse } from '../interfaces/PactAPI';

--- a/packages/libs/chainweb-node-client/src/tests/spv.test.ts
+++ b/packages/libs/chainweb-node-client/src/tests/spv.test.ts
@@ -1,7 +1,6 @@
 jest.mock('cross-fetch');
 
 import type { SPVResponse } from '../interfaces/PactAPI';
-
 import { spv } from '../spv';
 
 import { mockFetch } from './mockdata/mockFetch';

--- a/packages/libs/chainweb-stream-client/.eslintrc.js
+++ b/packages/libs/chainweb-stream-client/.eslintrc.js
@@ -2,6 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node'],
+  extends: ['@kadena-dev/eslint-config/profile/lib'],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/libs/chainweb-stream-client/package.json
+++ b/packages/libs/chainweb-stream-client/package.json
@@ -47,6 +47,7 @@
     "eventsource": "~2.0.2"
   },
   "devDependencies": {
+    "@kadena-dev/eslint-config": "workspace:*",
     "@kadena-dev/heft-rig": "workspace:*",
     "@kadena-dev/markdown": "workspace:*",
     "@rushstack/eslint-config": "~3.3.0",

--- a/packages/libs/chainweb-stream-client/src/index.ts
+++ b/packages/libs/chainweb-stream-client/src/index.ts
@@ -118,6 +118,7 @@ class ChainwebStream extends EventEmitter {
     this._eventSource.onopen = this._handleConnect;
     this._eventSource.onerror = this._handleError;
     // reset & set custom connect timeout handler
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this._connectTimer) {
       clearTimeout(this._connectTimer);
     }
@@ -170,6 +171,7 @@ class ChainwebStream extends EventEmitter {
     _eventSource.addEventListener('message', this._handleData);
     _eventSource.addEventListener('ping', this._resetHeartbeatTimeout);
     this._resetHeartbeatTimeout();
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this._connectTimer) {
       clearTimeout(this._connectTimer);
     }
@@ -191,6 +193,7 @@ class ChainwebStream extends EventEmitter {
     this._eventSource?.close();
 
     // cancel connection timeout timer, if exists
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this._connectTimer) {
       clearTimeout(this._connectTimer);
     }
@@ -215,6 +218,7 @@ class ChainwebStream extends EventEmitter {
     });
 
     this._desiredState = ConnectionState.WaitReconnect;
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this._reconnectTimer) {
       clearTimeout(this._reconnectTimer);
     }
@@ -345,6 +349,7 @@ class ChainwebStream extends EventEmitter {
   }
 
   private _stopHeartbeatMonitor = (): void => {
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (this._heartbeatTimer) {
       clearTimeout(this._heartbeatTimer);
     }

--- a/packages/libs/chainweb-stream-client/src/index.ts
+++ b/packages/libs/chainweb-stream-client/src/index.ts
@@ -380,7 +380,7 @@ class ChainwebStream extends EventEmitter {
       urlParamArgs.push(['minHeight', String(this._lastHeight - 3)]);
     }
     if (urlParamArgs.length) {
-      path += '?' + new URLSearchParams(urlParamArgs).toString();
+      path += `?${new URLSearchParams(urlParamArgs).toString()}`;
     }
     return `${host}${path}`;
   }

--- a/packages/libs/chainweb-stream-client/src/index.ts
+++ b/packages/libs/chainweb-stream-client/src/index.ts
@@ -1,20 +1,21 @@
-import EventSource from 'eventsource';
-import EventEmitter from 'eventemitter2';
 import {
-  parseError,
   ConnectTimeoutError,
   HeartbeatTimeoutError,
+  parseError,
 } from './errors';
+import { isClientAhead,isMajorCompatible, isMinorCompatible } from './semver';
 import {
-  ConnectionState,
-  IChainwebStreamConstructorArgs,
   ChainwebStreamType,
-  ITransaction,
+  ConnectionState,
+  IChainwebStreamConfig,
+  IChainwebStreamConstructorArgs,
   IDebugMsgObject,
   IInitialEvent,
-  IChainwebStreamConfig,
+  ITransaction,
 } from './types';
-import { isMajorCompatible, isMinorCompatible, isClientAhead } from './semver';
+
+import EventEmitter from 'eventemitter2';
+import EventSource from 'eventsource';
 
 export * from './types';
 

--- a/packages/libs/chainweb-stream-client/src/index.ts
+++ b/packages/libs/chainweb-stream-client/src/index.ts
@@ -3,7 +3,7 @@ import {
   HeartbeatTimeoutError,
   parseError,
 } from './errors';
-import { isClientAhead,isMajorCompatible, isMinorCompatible } from './semver';
+import { isClientAhead, isMajorCompatible, isMinorCompatible } from './semver';
 import {
   ChainwebStreamType,
   ConnectionState,

--- a/packages/libs/chainwebjs/package.json
+++ b/packages/libs/chainwebjs/package.json
@@ -56,7 +56,6 @@
     "format:src": "prettier config src --write",
     "preinstall": "npx only-allow pnpm",
     "lint": "eslint ./src --ext .js,.ts --fix",
-    "lint-staged": "lint-staged",
     "test": "heft test --no-build"
   },
   "dependencies": {

--- a/packages/libs/cryptography-utils/.eslintrc.js
+++ b/packages/libs/cryptography-utils/.eslintrc.js
@@ -2,6 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node'],
+  extends: ['@kadena-dev/eslint-config/profile/lib'],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/libs/cryptography-utils/package.json
+++ b/packages/libs/cryptography-utils/package.json
@@ -37,7 +37,6 @@
     "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
     "lint": "eslint ./src --ext .js,.ts --fix",
-    "lint-staged": "lint-staged",
     "test": "heft test --no-build"
   },
   "dependencies": {

--- a/packages/libs/cryptography-utils/package.json
+++ b/packages/libs/cryptography-utils/package.json
@@ -46,8 +46,10 @@
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
+    "@kadena-dev/eslint-config": "workspace:*",
     "@kadena-dev/heft-rig": "workspace:*",
     "@kadena-dev/markdown": "workspace:*",
+    "@kadena/types": "workspace:*",
     "@rushstack/eslint-config": "~3.3.0",
     "@rushstack/heft": "~0.50.6",
     "@types/heft-jest": "~1.0.3",

--- a/packages/libs/cryptography-utils/src/base64UrlDecode.ts
+++ b/packages/libs/cryptography-utils/src/base64UrlDecode.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-bitwise */
 import type { IBase64Url } from '@kadena/types';
 
 import { InvalidCharacterError } from './InvalidCharacterError';
@@ -32,7 +31,8 @@ export function base64UrlDecode(str: IBase64Url): string {
     // and if not first of each 4 characters,
     // convert the first 8 bits to one ascii character
     bc++ % 4)
-      ? (output += String.fromCharCode(255 & (bs >> ((-2 * bc) & 6))))
+      ? // eslint-disable-next-line no-bitwise
+        (output += String.fromCharCode(255 & (bs >> ((-2 * bc) & 6))))
       : 0
   ) {
     // try to find character in table (0-63, not found => -1)

--- a/packages/libs/cryptography-utils/src/base64UrlEncode.ts
+++ b/packages/libs/cryptography-utils/src/base64UrlEncode.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-bitwise */
 import type { IBase64Url } from '@kadena/types';
 
 import { InvalidCharacterError } from './InvalidCharacterError';
@@ -18,7 +17,9 @@ export function base64UrlEncode(str: string): IBase64Url {
   let output: string = '';
   for (
     let idx = 0, map = chars;
+    // eslint-disable-next-line no-bitwise
     str.charAt(idx | 0);
+    // eslint-disable-next-line no-bitwise
     output += map.charAt(63 & (block >> (8 - (idx % 1) * 8)))
   ) {
     charCode = str.charCodeAt((idx += 3 / 4));
@@ -27,7 +28,7 @@ export function base64UrlEncode(str: string): IBase64Url {
         "'btoa' failed: The string to be encoded contains characters outside of the Latin1 range.",
       );
     }
-    /* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, no-bitwise
     block = ((block || 0) << 8) | charCode;
   }
   return output;

--- a/packages/libs/cryptography-utils/src/genKeyPair.ts
+++ b/packages/libs/cryptography-utils/src/genKeyPair.ts
@@ -1,8 +1,8 @@
-import nacl from 'tweetnacl';
-
 import type { IKeyPair } from '@kadena/types';
 
 import { binToHex } from './binToHex';
+
+import nacl from 'tweetnacl';
 
 /**
  * Generate a random ED25519 keypair.

--- a/packages/libs/cryptography-utils/src/restoreKeyPairFromSecretKey.ts
+++ b/packages/libs/cryptography-utils/src/restoreKeyPairFromSecretKey.ts
@@ -1,9 +1,9 @@
-import nacl from 'tweetnacl';
-
 import type { IKeyPair } from '@kadena/types';
 
 import { binToHex } from './binToHex';
 import { hexToBin } from './hexToBin';
+
+import nacl from 'tweetnacl';
 
 /**
  * Generate a deterministic ED25519 keypair from a given Kadena secretKey

--- a/packages/libs/cryptography-utils/src/sign.ts
+++ b/packages/libs/cryptography-utils/src/sign.ts
@@ -1,11 +1,11 @@
 import type { IKeyPair, SignCommand } from '@kadena/types';
 
-import nacl from 'tweetnacl';
-
 import { base64UrlEncodeArr } from './base64UrlEncodeArr';
 import { binToHex } from './binToHex';
 import { hashBin } from './hashBin';
 import { toTweetNaclSecretKey } from './toTweetNaclSecretKey';
+
+import nacl from 'tweetnacl';
 
 /**
 Perform blake2b256 hashing on a message, and sign using keyPair.

--- a/packages/libs/cryptography-utils/src/tests/base64UrlDecode.test.ts
+++ b/packages/libs/cryptography-utils/src/tests/base64UrlDecode.test.ts
@@ -1,6 +1,7 @@
-import { throws } from 'assert';
 import { base64UrlDecode } from '../base64UrlDecode';
 import { uint8ArrayToStr } from '../uint8ArrayToStr';
+
+import { throws } from 'assert';
 
 describe('base64Decode', () => {
   it('takes in a Base 64 URL encoded string and outputs a decoded string', () => {

--- a/packages/libs/cryptography-utils/src/tests/base64UrlEncode.test.ts
+++ b/packages/libs/cryptography-utils/src/tests/base64UrlEncode.test.ts
@@ -1,6 +1,7 @@
-import { throws } from 'assert';
 import { base64UrlEncode } from '../base64UrlEncode';
 import { uint8ArrayToStr } from '../uint8ArrayToStr';
+
+import { throws } from 'assert';
 
 describe('base64UrlEncode', () => {
   it('takes in a string and outputs a Base 64 URL encoded string', () => {

--- a/packages/libs/pactjs/.eslintrc.js
+++ b/packages/libs/pactjs/.eslintrc.js
@@ -2,6 +2,6 @@
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
 module.exports = {
-  extends: ['@rushstack/eslint-config/profile/node'],
+  extends: ['@kadena-dev/eslint-config/profile/lib'],
   parserOptions: { tsconfigRootDir: __dirname },
 };

--- a/packages/libs/pactjs/package.json
+++ b/packages/libs/pactjs/package.json
@@ -44,6 +44,7 @@
     "bignumber.js": "^9.0.2"
   },
   "devDependencies": {
+    "@kadena-dev/eslint-config": "workspace:*",
     "@kadena-dev/heft-rig": "workspace:*",
     "@kadena-dev/markdown": "workspace:*",
     "@rushstack/eslint-config": "~3.3.0",

--- a/packages/libs/pactjs/src/PactNumber.ts
+++ b/packages/libs/pactjs/src/PactNumber.ts
@@ -1,4 +1,5 @@
 import { IPactDecimal, IPactInt } from '@kadena/types';
+
 import BigNumber from 'bignumber.js';
 
 /**

--- a/packages/libs/pactjs/src/tests/isSignedCommand.test.ts
+++ b/packages/libs/pactjs/src/tests/isSignedCommand.test.ts
@@ -1,4 +1,5 @@
 import { ICommand, IUnsignedCommand } from '@kadena/types';
+
 import { ensureSignedCommand, isSignedCommand } from '../isSignedCommand';
 
 const sampleSignedCommand: IUnsignedCommand = {

--- a/packages/libs/react-components/.eslintrc.js
+++ b/packages/libs/react-components/.eslintrc.js
@@ -4,12 +4,4 @@ require('@rushstack/eslint-config/patch/modern-module-resolution');
 module.exports = {
   extends: ['@kadena-dev/eslint-config/profile/react'],
   parserOptions: { tsconfigRootDir: __dirname },
-  rules: {
-    'import/no-unresolved': [
-      'warn',
-      {
-        ignore: ['^@stitches/react'],
-      },
-    ],
-  }
 };

--- a/packages/libs/react-ui/.eslintrc.js
+++ b/packages/libs/react-ui/.eslintrc.js
@@ -1,18 +1,11 @@
 // This is a workaround for https://github.com/eslint/eslint/issues/3458
 require('@rushstack/eslint-config/patch/modern-module-resolution');
 
-const fs = require('fs');
-
 module.exports = {
   extends: [
     '@kadena-dev/eslint-config/profile/react',
     'plugin:storybook/recommended',
   ],
-  settings: {
-    'import/resolver': {
-      typescript: {},
-    },
-  },
   parserOptions: {
     tsconfigRootDir: __dirname,
     ecmaVersion: 'latest',

--- a/packages/libs/react-ui/src/components/Stack/Stack.stories.tsx
+++ b/packages/libs/react-ui/src/components/Stack/Stack.stories.tsx
@@ -1,4 +1,4 @@
-import { vars, Sprinkles } from '../../styles';
+import { Sprinkles,vars } from '../../styles';
 
 import { Stack } from './Stack';
 import { itemClass, itemSizeClass } from './stories.css';

--- a/packages/libs/react-ui/src/components/Stack/Stack.stories.tsx
+++ b/packages/libs/react-ui/src/components/Stack/Stack.stories.tsx
@@ -1,4 +1,4 @@
-import { Sprinkles,vars } from '../../styles';
+import { Sprinkles, vars } from '../../styles';
 
 import { Stack } from './Stack';
 import { itemClass, itemSizeClass } from './stories.css';

--- a/packages/libs/react-ui/src/components/Stack/Stack.test.tsx
+++ b/packages/libs/react-ui/src/components/Stack/Stack.test.tsx
@@ -1,5 +1,6 @@
-import { Stack } from '@components/Stack';
 import { itemClass } from './stories.css';
+
+import { Stack } from '@components/Stack';
 import { render } from '@testing-library/react';
 import React from 'react';
 

--- a/packages/libs/react-ui/src/components/Table/Table.css.ts
+++ b/packages/libs/react-ui/src/components/Table/Table.css.ts
@@ -1,6 +1,7 @@
 import { sprinkles, vars } from '../../styles';
 
 import { style } from '@vanilla-extract/css';
+
 export const tdClass = style([
   sprinkles({
     paddingY: '$3',

--- a/packages/tools/cookbook/package.json
+++ b/packages/tools/cookbook/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "@kadena/chainweb-node-client": "workspace:*",
-    "@kadena/client": "workspace:*"
+    "@kadena/client": "workspace:*",
+    "@kadena/cryptography-utils": "workspace:*"
   },
   "devDependencies": {
     "@kadena-dev/eslint-config": "workspace:*",

--- a/packages/tools/cookbook/src/accounts/create-account.ts
+++ b/packages/tools/cookbook/src/accounts/create-account.ts
@@ -3,6 +3,7 @@ import { Pact, signWithChainweaver } from '@kadena/client';
 
 import { accountKey } from '../utils/account-key';
 import { apiHost } from '../utils/api-host';
+// eslint-disable-next-line import/no-unresolved -- TODO FILE NOT FOUND
 import { pollTransactions } from '../utils/poll-transactions';
 
 const HELP: string = `Usage example: \n\nts-node create-account.js k:{gasProviderPublicKey} k:{receiverPublicKey}`;

--- a/packages/tools/create-kadena-app/package.json
+++ b/packages/tools/create-kadena-app/package.json
@@ -22,6 +22,7 @@
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:pkg": "sort-package-json",
     "format:src": "prettier config src templates --write",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "start": "ts-node --transpile-only src/index.ts",
     "test": "rimraf test-* && heft test --no-build && cross-env NG_CLI_ANALYTICS=false ./scripts/generate-test.sh"
   },

--- a/packages/tools/eslint-config/package.json
+++ b/packages/tools/eslint-config/package.json
@@ -13,15 +13,19 @@
     "format:ci": "prettier mixins profile --check",
     "format:pkg": "sort-package-json",
     "format:src": "prettier mixins profile --write",
-    "lint": "eslint mixins profile --ext .js,.ts --fix",
+    "lint": "eslint ./mixins ./profile --ext .js,.ts --fix",
     "test": ""
   },
   "dependencies": {
     "@kadena-dev/eslint-plugin": "workspace:*",
     "@next/eslint-plugin-next": "^12.0.8",
+    "@rushstack/eslint-config": "~3.3.0",
     "@typescript-eslint/eslint-plugin": "^5.23.0",
     "@typescript-eslint/parser": "^5.23.0",
+    "eslint": "^8.15.0",
+    "eslint-config-next": "13.4.5",
     "eslint-config-prettier": "~8.8.0",
+    "eslint-import-resolver-typescript": "3.5.5",
     "eslint-plugin-import": "~2.27.5",
     "eslint-plugin-jsx-a11y": "~6.7.1",
     "eslint-plugin-prettier": "~4.2.1",
@@ -29,8 +33,6 @@
     "eslint-plugin-simple-import-sort": "~7.0.0"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "~3.3.0",
-    "eslint": "^8.15.0",
     "prettier": "~2.8.8",
     "sort-package-json": "~2.4.1",
     "typescript": "5.0.4"

--- a/packages/tools/eslint-config/profile/lib.js
+++ b/packages/tools/eslint-config/profile/lib.js
@@ -1,22 +1,3 @@
-const fs = require('fs');
-const path = require('path');
-
-/**
- * according to rush.json#projectFolderMin/MaxDepth packages specific to this
- * monorepo are always placed in 3rd nested directory
- * e.g. packages/{apps,libs,tools}/package-name/*
- */
-const prettierOptions = JSON.parse(
-  fs.readFileSync(path.resolve(__dirname, '../../../../.prettierrc'), 'utf8'),
-);
-/**
- * an alternative to above code is
- */
-// const prettierrcPath = `${require('child_process')
-//   .execSync('git rev-parse --show-toplevel')
-//   .toString()
-//   .replace(/\n/, '')}/.prettierrc`;
-
 module.exports = {
   root: true,
   extends: [
@@ -29,29 +10,22 @@ module.exports = {
     '../mixins/simple-import-sort.js',
     '../mixins/typedef-allow-implicitly-typed-parameters.js',
   ],
-  plugins: [
-    '@kadena-dev/eslint-plugin',
-    'import',
-    'simple-import-sort',
-    'prettier',
-  ],
+  plugins: ['@kadena-dev/eslint-plugin', 'import', 'simple-import-sort'],
   rules: {
     '@kadena-dev/no-eslint-disable': 'error',
-    'prettier/prettier': ['warn', prettierOptions],
     'prefer-template': 'warn',
-    'import/newline-after-import': 'warn',
-    'import/no-unresolved': [
-      'warn',
-      {
-        ignore: ['^@/'], // Ignore custom paths starting with '@/'
-      },
-    ],
+    'import/newline-after-import': 'error',
+    'import/no-unresolved': 'error',
   },
   settings: {
+    'import/parsers': {
+      '@typescript-eslint/parser': ['.ts', '.tsx'],
+    },
     'import/resolver': {
-      node: {
-        extensions: ['.js', '.jsx', '.ts', '.tsx'],
-        moduleDirectory: ['node_modules'],
+      typescript: {
+        // Rush uses `path.resolve('tsconfig.json')` to resolve each TS config separately, but in VS Code ESLint we
+        // want to the next glob to resolve them all. So we use this in `.vscode/settings.json` instead:
+        // project: 'packages/*/*/tsconfig.json',
       },
     },
   },

--- a/packages/tools/eslint-config/profile/lib.js
+++ b/packages/tools/eslint-config/profile/lib.js
@@ -1,3 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
+const prettierOptions = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../../../.prettierrc'), 'utf8'),
+);
+
 module.exports = {
   root: true,
   extends: [
@@ -10,9 +17,15 @@ module.exports = {
     '../mixins/simple-import-sort.js',
     '../mixins/typedef-allow-implicitly-typed-parameters.js',
   ],
-  plugins: ['@kadena-dev/eslint-plugin', 'import', 'simple-import-sort'],
+  plugins: [
+    '@kadena-dev/eslint-plugin',
+    'import',
+    'simple-import-sort',
+    'prettier',
+  ],
   rules: {
     '@kadena-dev/no-eslint-disable': 'error',
+    'prettier/prettier': ['warn', prettierOptions],
     'prefer-template': 'warn',
     'import/newline-after-import': 'error',
     'import/no-unresolved': 'error',

--- a/packages/tools/eslint-config/profile/next.js
+++ b/packages/tools/eslint-config/profile/next.js
@@ -1,11 +1,10 @@
 module.exports = {
   root: true,
   extends: [
-    'plugin:@next/next/recommended',
+    'next',
     './react',
     // TODO: temporarily disabled as it cannot be resolved by VSCode eslint
     // plugin. Packages need to add this themselves
     // 'next/core-web-vitals',
   ],
-  plugins: ['import', 'simple-import-sort'],
 };

--- a/packages/tools/eslint-config/profile/react.js
+++ b/packages/tools/eslint-config/profile/react.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   extends: ['./lib', 'plugin:react/recommended'],
-  plugins: ['import', 'simple-import-sort', 'react', 'jsx-a11y'],
+  plugins: ['react', 'jsx-a11y'],
   rules: {
     '@rushstack/typedef-var': 'off',
     // @kadena-dev/typedef-var allows for inferred types in exported constants
@@ -20,6 +20,7 @@ module.exports = {
         unnamedComponents: 'arrow-function',
       },
     ],
+    'import/no-unresolved': ['error', { ignore: ['^@stitches/react'] }],
   },
   settings: {
     react: {

--- a/packages/tools/eslint-plugin/package.json
+++ b/packages/tools/eslint-plugin/package.json
@@ -11,7 +11,6 @@
     "format:ci": "prettier src --check",
     "format:pkg": "sort-package-json",
     "format:src": "prettier src --write",
-    "lint-staged": "lint-staged",
     "test": "heft test --no-build"
   },
   "dependencies": {

--- a/packages/tools/integration-tests/package.json
+++ b/packages/tools/integration-tests/package.json
@@ -27,7 +27,7 @@
     "format:ci": "prettier config src --check",
     "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint src --ext .js,.ts --fix",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "precommit": "pnpm run test --silent",
     "start:pact": "rm -Rf ./log && mkdir log && pact --serve src/tests/pact-server.conf",
     "test": "",

--- a/packages/tools/kda-cli/.eslintrc.cjs
+++ b/packages/tools/kda-cli/.eslintrc.cjs
@@ -4,7 +4,4 @@ require('@rushstack/eslint-config/patch/modern-module-resolution');
 module.exports = {
   extends: ['@kadena-dev/eslint-config/profile/lib'],
   parserOptions: { tsconfigRootDir: __dirname },
-  rules: {
-    'import/no-unresolved': 'off',
-  },
 };

--- a/packages/tools/kda-cli/package.json
+++ b/packages/tools/kda-cli/package.json
@@ -27,7 +27,7 @@
     "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
     "kda": "node lib/index.js",
-    "lint": "eslint ./src --ext .js,.t,.tsx --fix",
+    "lint": "eslint ./src --ext .js,.ts,.tsx --fix",
     "test": "ava"
   },
   "ava": {

--- a/packages/tools/kda-cli/package.json
+++ b/packages/tools/kda-cli/package.json
@@ -27,6 +27,7 @@
     "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
     "kda": "node lib/index.js",
+    "lint": "eslint ./src --ext .js,.t,.tsx --fix",
     "test": "ava"
   },
   "ava": {

--- a/packages/tools/pactjs-cli/package.json
+++ b/packages/tools/pactjs-cli/package.json
@@ -22,7 +22,6 @@
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint-staged": "lint-staged",
     "test": "heft test --no-build"
   },
   "dependencies": {

--- a/packages/tools/pactjs-cli/package.json
+++ b/packages/tools/pactjs-cli/package.json
@@ -22,6 +22,7 @@
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "test": "heft test --no-build"
   },
   "dependencies": {

--- a/packages/tools/remark-plugins/package.json
+++ b/packages/tools/remark-plugins/package.json
@@ -16,7 +16,7 @@
     "format:md": "remark README.md -o --use ./lib/index.js",
     "format:pkg": "sort-package-json",
     "format:src": "prettier src --write",
-    "lint": "eslint src",
+    "lint": "eslint ./src --ext .ts --fix",
     "test": ""
   },
   "dependencies": {

--- a/packages/tools/remark-plugins/src/commentMarkers/packageTable.ts
+++ b/packages/tools/remark-plugins/src/commentMarkers/packageTable.ts
@@ -1,6 +1,6 @@
 import type { RushConfig } from './rush.json';
 
-import { Link, Table, TableRow } from 'mdast';
+import type { Link, Table, TableRow } from 'mdast';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/tools/rush-fix-versions/package.json
+++ b/packages/tools/rush-fix-versions/package.json
@@ -39,6 +39,7 @@
     "@rushstack/heft": "~0.50.6",
     "@types/inquirer": "^9.0.3",
     "@types/node": "^16.0.0",
+    "eslint": "^8.15.0",
     "prettier": "~2.8.8",
     "sort-package-json": "~2.4.1"
   }

--- a/packages/tools/rush-fix-versions/package.json
+++ b/packages/tools/rush-fix-versions/package.json
@@ -23,6 +23,7 @@
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
+    "lint": "eslint ./src --ext .js,.ts --fix",
     "test": ""
   },
   "dependencies": {


### PR DESCRIPTION
Sorry, one thing led to another so this PR is larger than intended... Bottom line is that we missed quite a few issues (warnings/errors), caused by the way things are configured. Let's try to align things a bit more moving forward.

- Fix `import/no-unresolved` (both from Rush scripts and in VS Code) and increase severity from `warn` to `error`, and fix revealed issues
- Replace `@rushstack/eslint-config/profile/node` with `@kadena-dev/eslint-config/profile/lib`, this revealed lint issues, also fixed in this PR
- Remove `prettier` plugin from ESLint (we already have that in `format` commands/scripts)
- Remove `next lint` from Next.js packages and migrate to central lint config
- Consistent `lint` script in each `package.json`
- Remove last traces of `lint-staged`
- Cleanups & dedupes, etc.

From a review perspective, please make sure things aren't off in your packages and workflows.