### PR TITLE
fix(kadena-docs): footer spacing

### DIFF
--- a/packages/apps/docs/src/components/NotFound/styles.ts
+++ b/packages/apps/docs/src/components/NotFound/styles.ts
@@ -1,6 +1,6 @@
 import { Stack, styled, StyledComponent } from '@kadena/react-components';
 
 export const Section: StyledComponent<typeof Stack> = styled(Stack, {
-  padding: '$20 0',
+  padding: '$20 0 0',
   gap: '$2',
 });

--- a/packages/libs/react-components/src/styles/stitches.config.ts
+++ b/packages/libs/react-components/src/styles/stitches.config.ts
@@ -30,6 +30,7 @@ const sizes: Record<string, string> = {
   24: '6rem', // 96px
   25: '6.25rem', // 100px
   32: '8rem', // 128px
+  35: '8.75rem', // 140px
   40: '10rem', // 160px
   48: '12rem', // 192px
   56: '14rem', // 224px


### PR DESCRIPTION
- Add spacing variables on components library
- Remove the Section bottom padding because with the default article padding it's becoming more space.
