### PR TITLE
Fenced code blocks always `sh`

### DIFF
--- a/common/changes/@kadena/client/chore-fenced-code-blocks-sh_2023-07-06-08-29.json
+++ b/common/changes/@kadena/client/chore-fenced-code-blocks-sh_2023-07-06-08-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "Consistent fenced code block shell language",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/common/changes/@kadena/pactjs-cli/chore-fenced-code-blocks-sh_2023-07-06-08-29.json
+++ b/common/changes/@kadena/pactjs-cli/chore-fenced-code-blocks-sh_2023-07-06-08-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-cli",
+      "comment": "Consistent fenced code block shell language",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs-cli"
+}

--- a/packages/apps/graph-client/README.md
+++ b/packages/apps/graph-client/README.md
@@ -4,7 +4,7 @@ This is a [Next.js][1] project bootstrapped with [`create-next-app`][2].
 
 First, run the development server:
 
-```bash
+```sh
 npm run dev
 # or
 yarn dev

--- a/packages/apps/transfer/README.md
+++ b/packages/apps/transfer/README.md
@@ -20,7 +20,7 @@ To install and run the Kadena Transfer App locally, follow these steps:
 
 2.  Navigate to the `kadena-transfer/packages/apps/transfer` directory:
 
-```bash
+```sh
 cd kadena.js/kadena-transfer/packages/apps/transfer
 ```
 
@@ -29,31 +29,31 @@ cd kadena.js/kadena-transfer/packages/apps/transfer
 Note: On Windows, run in PowerShell as Administrator and restart the terminal
 after installation.
 
-```bash
+```sh
 npm install --global @microsoft/rush
 ```
 
 4.  Install the dependencies:
 
-```bash
+```sh
 rush install
 ```
 
 5.  Build the app and its dependencies:
 
-```bash
+```sh
 rush build -t @kadena/transfer
 ```
 
 6.  Setup environment variables:
 
-```bash
+```sh
 cp .env.example .env.local
 ```
 
 7.  Start the app:
 
-```bash
+```sh
 rushx dev
 ```
 

--- a/packages/libs/client/README.md
+++ b/packages/libs/client/README.md
@@ -134,7 +134,7 @@ The module you want to retrieve (e.g. "coin")
 Using the contract we'll now generate all the functions (`defun`s) with their
 (typed) arguments and the capabilities (`defcap`s).
 
-```bash
+```sh
 pactjs contract-generate --file "./contracts/coin.module.pact"
 ```
 

--- a/packages/libs/kadena.js/README.md
+++ b/packages/libs/kadena.js/README.md
@@ -22,13 +22,13 @@ Kadena blockchain
 
 To run the unit tests:
 
-```shell
+```sh
 $ npm test
 ```
 
 To run single unit tests:
 
-```shell
+```sh
 $ npm test --single=[nameOfFile] where [nameOfFile] can be a regex
 ```
 
@@ -39,7 +39,7 @@ $ npm test --single=[nameOfFile] where [nameOfFile] can be a regex
 To run integration tests against a pact server the following command can be
 used:
 
-```shell
+```sh
 $ npm test:integration:pactserver
 ```
 
@@ -51,7 +51,7 @@ instructions at the [Devnet Github repository][2].
 
 The following command can be used:
 
-```shell
+```sh
 $ npm test:integration:devnet
 ```
 

--- a/packages/libs/react-ui/README.md
+++ b/packages/libs/react-ui/README.md
@@ -18,7 +18,7 @@ their configuration options.
 
 Run the following commands to install dependencies and build the library:
 
-```bash
+```sh
 git clone git@github.com:kadena-community/kadena.js.git
 cd kadena.js
 cd packages/libs/react-ui
@@ -47,14 +47,14 @@ Add @kadena/react-ui as a dependency in your `package.json`:
 Then run the following commands to install the package and update the monorepo's
 state:
 
-```bash
+```sh
 rush update
 ```
 
 VE requires bundler configuration to handle CSS. To set this up in Next.js you
 will need to install the following plugin:
 
-```bash
+```sh
 rush add -p @vanilla-extract/next-plugin --dev
 ```
 
@@ -155,7 +155,7 @@ export default MyApp;
 After installing dependencies, you can start Storybook with the following
 command:
 
-```bash
+```sh
 rushx storybook
 ```
 
@@ -165,7 +165,7 @@ The component library is not yet published, to use it in an app outside of this
 mono repo you first clone this repo and then reference this library from your
 app.
 
-```bash
+```sh
 git clone git@github.com:kadena-community/kadena.js.git
 cd kadena.js
 cd packages/libs/react-ui

--- a/packages/tools/cookbook/README.md
+++ b/packages/tools/cookbook/README.md
@@ -50,7 +50,7 @@ In depth documentation for setting up and using @kadena/client can be found at
 
 Example: Running the transfer-create script:
 
-```bash
+```sh
 ts-node src/accounts/transfer-create.ts senderAccount receiverAccount 1
 ```
 

--- a/packages/tools/kda-cli/README.md
+++ b/packages/tools/kda-cli/README.md
@@ -33,7 +33,7 @@ echo $GITHUB_TOKEN | docker login ghcr.io --username <your gh username> --passwo
 Note that the package is not yet published, so for now you need to clone this
 repo and make a symlink.
 
-```bash
+```sh
 $ npm install --global @kadena/kda-cli
 ```
 
@@ -41,7 +41,7 @@ $ npm install --global @kadena/kda-cli
 
 To install the executable from this repo:
 
-```bash
+```sh
 rush install --to @kadena/kda-cli
 rush build --to @kadena/kda-cli
 chmod +x ./lib/index.js
@@ -52,7 +52,7 @@ ln -s $(pwd)/lib/index.js $NVM_BIN/kda
 
 ## CLI
 
-```bash
+```sh
 $ kda --help
 
   Usage

--- a/packages/tools/pactjs-cli/README.md
+++ b/packages/tools/pactjs-cli/README.md
@@ -28,13 +28,13 @@ Generate client based on a contract
 
 **Generate from file**
 
-```bash
+```sh
 pactjs contract-generate --file ./myContract.pact
 ```
 
 **Generate from chain**
 
-```bash
+```sh
 pactjs contract-generate --contract free.coin --api https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/1/pact --chain 1 --network testnet
 ```
 
@@ -51,7 +51,7 @@ Retrieve a contract from an API using a /local call
 
 Retrieve a contract from chain
 
-```bash
+```sh
 pactjs retrieve-contract --out ./myContract.pact --module coin --api https://api.chainweb.com/chainweb/0.0/mainnet01/chain/8/pact
 ```
 
@@ -67,7 +67,7 @@ Generate statically typed generators for templates
 
 Generate a client from a template
 
-```bash
+```sh
 pactjs template-generate --file ./contractDir --out ./myContract.pact
 ```
 

--- a/packages/tools/remark-plugins/README.md
+++ b/packages/tools/remark-plugins/README.md
@@ -31,13 +31,13 @@ Make sure the package is built (`rush build`).
 
 Format a single Markdown file and output the result to `stdout`:
 
-```bash
+```sh
 pnpm dlx remark-cli --use ./packages/tools/remark-plugins/lib/index.js README.md
 ```
 
 Format a single Markdown file and overwrite the same file:
 
-```bash
+```sh
 pnpm dlx remark-cli --use ./packages/tools/remark-plugins/lib/index.js README.md -o
 ```
 

--- a/packages/tools/remark-plugins/src/fencedCodeBlocks/index.ts
+++ b/packages/tools/remark-plugins/src/fencedCodeBlocks/index.ts
@@ -1,10 +1,14 @@
 import type { Root } from 'mdast';
 import { visit } from 'unist-util-visit';
 
+const shellLanguages = ['sh', 'shell', 'bash', 'zsh'];
+
 export function fencedCodeBlocks() {
   return (tree: Root) => {
     visit(tree, 'code', (node) => {
       if (node.lang === null) node.lang = ' ';
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (node.lang && shellLanguages.includes(node.lang)) node.lang = 'sh';
     });
   };
 }


### PR DESCRIPTION
This one is a bit "over the top" and totally over-engineered, but it's to show how we can leverage the Markdown pipeline we have. We can add more remark plugins to manipulate the Markdown AST (mdast) and improve and streamline it in many ways. See the `@kadena-dev/markdown` package in our monorepo for more details. Or AMA:)