### PR TITLE
chore(client): use @kadena/client 0.5.0 until the new version is released

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -280,7 +280,7 @@ importers:
       '@kadena-dev/heft-rig': workspace:*
       '@kadena-dev/markdown': workspace:*
       '@kadena/chainweb-node-client': workspace:*
-      '@kadena/client': workspace:*
+      '@kadena/client': 0.5.0
       '@kadena/cryptography-utils': workspace:*
       '@kadena/pactjs': workspace:*
       '@kadena/pactjs-cli': workspace:*
@@ -329,7 +329,7 @@ importers:
       typescript: 5.0.4
     dependencies:
       '@kadena/chainweb-node-client': link:../../libs/chainweb-node-client
-      '@kadena/client': link:../../libs/client
+      '@kadena/client': 0.5.0
       '@kadena/cryptography-utils': link:../../libs/cryptography-utils
       '@kadena/pactjs': link:../../libs/pactjs
       '@kadena/react-components': link:../../libs/react-components
@@ -1013,7 +1013,7 @@ importers:
       '@kadena-dev/heft-rig': workspace:*
       '@kadena-dev/markdown': workspace:*
       '@kadena/chainweb-node-client': workspace:*
-      '@kadena/client': workspace:*
+      '@kadena/client': 0.5.0
       '@kadena/cryptography-utils': workspace:*
       '@kadena/pactjs-cli': workspace:*
       '@kadena/types': workspace:*
@@ -1027,7 +1027,7 @@ importers:
       ts-node: ~10.8.2
     dependencies:
       '@kadena/chainweb-node-client': link:../../libs/chainweb-node-client
-      '@kadena/client': link:../../libs/client
+      '@kadena/client': 0.5.0
       '@kadena/cryptography-utils': link:../../libs/cryptography-utils
     devDependencies:
       '@kadena-dev/eslint-config': link:../eslint-config
@@ -6939,6 +6939,61 @@ packages:
   /@juggle/resize-observer/3.4.0:
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
     dev: true
+
+  /@kadena/chainweb-node-client/0.3.3_encoding@0.1.13:
+    resolution: {integrity: sha512-QmJYfRPMWJaMJEPD4Cai+9t1rA4ljACQo8XDr6dZ6WQnOItV968rLIDr43KG3p7FsyrJW2G6W97GqQUXcqVdDQ==}
+    requiresBuild: true
+    dependencies:
+      '@kadena/cryptography-utils': 0.3.3
+      '@kadena/pactjs': 0.2.9
+      '@kadena/types': 0.3.3
+      '@types/isomorphic-fetch': 0.0.36
+      cross-fetch: 3.1.8_encoding@0.1.13
+      node-fetch: 2.6.12_encoding@0.1.13
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@kadena/client/0.5.0:
+    resolution: {integrity: sha512-F3GPdfKBfmto7BGoDd2+gXAZe7IhSIAI1l3VgPUpZgqAz5jiSQp7CNR94nc5YsyZZE05cYsEOsk64odihDQqZQ==}
+    dependencies:
+      '@kadena/chainweb-node-client': 0.3.3_encoding@0.1.13
+      '@kadena/cryptography-utils': 0.3.3
+      '@kadena/pactjs': 0.2.9
+      '@kadena/types': 0.3.3
+      '@walletconnect/sign-client': 2.8.6
+      '@walletconnect/types': 2.8.6
+      cross-fetch: 3.1.8_encoding@0.1.13
+      debug: 4.3.4
+      encoding: 0.1.13
+      yaml: 2.1.3
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
+      - bufferutil
+      - lokijs
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /@kadena/cryptography-utils/0.3.3:
+    resolution: {integrity: sha512-6GYpjXKbMEeVR9TwIPnE2gv1yjIlIxnlMTH6R0fqlgg8AMkk5WwJ1DpKlahEh2ii2shoZISfmlKLa24U8Fkd/g==}
+    dependencies:
+      '@kadena/types': 0.3.3
+      blakejs: 1.2.1
+      buffer: 6.0.3
+      tweetnacl: 1.0.3
+    dev: false
+
+  /@kadena/pactjs/0.2.9:
+    resolution: {integrity: sha512-Y4c9QmcKCHFWOSqAQhQLVN/neFLsNhQRMHNmUvRjnY4BypTX+8PVKVTRWk6y92C709Smkdyh8uzmE6aRfkMHtQ==}
+    dependencies:
+      '@kadena/types': 0.3.3
+      bignumber.js: 9.1.1
+    dev: false
+
+  /@kadena/types/0.3.3:
+    resolution: {integrity: sha512-61ltE1vx81r/OSrrHaEte1m2QixsCVLBT8koBmWu7wmITGltjEzjkIJNNUs/A0d4aZzlUVOa+6tnRq22clQu3w==}
+    dev: false
 
   /@leichtgewicht/ip-codec/2.0.4:
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "1e4f2bf2175f11afc7a4aff38b4ab6689c14ede0",
+  "pnpmShrinkwrapHash": "e68a3b7af82372a7d5a4f18688440d64ce69d1bd",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/apps/transfer/package.json
+++ b/packages/apps/transfer/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@kadena/chainweb-node-client": "workspace:*",
-    "@kadena/client": "workspace:*",
+    "@kadena/client": "0.5.0",
     "@kadena/cryptography-utils": "workspace:*",
     "@kadena/pactjs": "workspace:*",
     "@kadena/react-components": "workspace:*",

--- a/packages/tools/cookbook/package.json
+++ b/packages/tools/cookbook/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@kadena/chainweb-node-client": "workspace:*",
-    "@kadena/client": "workspace:*",
+    "@kadena/client": "0.5.0",
     "@kadena/cryptography-utils": "workspace:*"
   },
   "devDependencies": {

--- a/rush.json
+++ b/rush.json
@@ -428,6 +428,7 @@
       "packageName": "@kadena/transfer",
       "projectFolder": "packages/apps/transfer",
       "reviewCategory": "prototypes",
+      "decoupledLocalDependencies": ["@kadena/client"],
       "skipRushCheck": false,
       "shouldPublish": false
     },
@@ -543,7 +544,7 @@
     {
       "packageName": "@kadena/cookbook",
       "projectFolder": "packages/tools/cookbook",
-      "cyclicDependencyProjects": ["@kadena/cookbook"],
+      "decoupledLocalDependencies": ["@kadena/cookbook", "@kadena/client"],
       "tags": ["tools"],
       "shouldPublish": false
     },
@@ -565,7 +566,7 @@
     {
       "packageName": "@kadena-dev/eslint-plugin",
       "projectFolder": "packages/tools/eslint-plugin",
-      "cyclicDependencyProjects": ["@kadena-dev/eslint-plugin"],
+      "decoupledLocalDependencies": ["@kadena-dev/eslint-plugin"],
       "tags": ["tools"],
       "shouldPublish": true
     },
@@ -633,11 +634,29 @@
     //   "reviewCategory": "production",
     //
     //   /**
-    //    * A list of local projects that appear as devDependencies for this project, but cannot be
-    //    * locally linked because it would create a cyclic dependency; instead, the last published
-    //    * version will be installed in the Common folder.
+    //    * A list of Rush project names that are to be installed from NPM
+    //    * instead of linking to the local project.
+    //    *
+    //    * If a project's package.json specifies a dependency that is another Rush project
+    //    * in the monorepo workspace, normally Rush will locally link its folder instead of
+    //    * installing from NPM.  If you are using PNPM workspaces, this is indicated by
+    //    * a SemVer range such as "workspace:^1.2.3".  To prevent mistakes, Rush reports
+    //    * an error if the "workspace:" protocol is missing.
+    //    *
+    //    * Locally linking ensures that regressions are caught as early as possible and is
+    //    * a key benefit of monorepos.  However there are occasional situations where
+    //    * installing from NPM is needed.  A classic example is a cyclic dependency.
+    //    * Imagine three Rush projects: "my-toolchain" depends on "my-tester", which depends
+    //    * on "my-library".  Suppose that we add "my-toolchain" to the "devDependencies"
+    //    * of "my-library" so it can be built by our toolchain.  This cycle creates
+    //    * a problem -- Rush can't build a project using a not-yet-built dependency.
+    //    * We can solve it by adding "my-toolchain" to the "decoupledLocalDependencies"
+    //    * of "my-library", so it builds using the last published release.  Choose carefully
+    //    * which package to decouple; some choices are much easier to manage than others.
+    //    *
+    //    * (In older Rush releases, this setting was called "cyclicDependencyProjects".)
     //    */
-    //   "cyclicDependencyProjects": [
+    //   "decoupledLocalDependencies": [
     //     // "my-toolchain"
     //   ],
     //


### PR DESCRIPTION
I have added the version to `common-versions.json` to allow discrepancies between versions of @kadena/client, specifically `0.5.0` instead of `workspace:*`