### PR TITLE
fix(kadena-docs): improve slug method for special characters + strings ends with special characters

### DIFF
--- a/packages/apps/docs/src/components/Layout/components/Aside/ListItem.tsx
+++ b/packages/apps/docs/src/components/Layout/components/Aside/ListItem.tsx
@@ -12,6 +12,7 @@ interface IProps {
   item: ISubHeaderElement;
   setActiveItem: React.Dispatch<React.SetStateAction<string>>;
   activeItem?: string;
+  index?: number;
 }
 
 export const ListItem: FC<IProps> = ({
@@ -19,11 +20,12 @@ export const ListItem: FC<IProps> = ({
   setActiveItem,
   activeItem,
   scrollArea,
+  index,
 }) => {
   const router = useRouter();
 
   if (item.title === undefined || item.title === '') return null;
-  const slug = `#${createSlug(item.title)}`;
+  const slug = `#${createSlug(item.title, index)}`;
 
   const handleItemClick = (ev: MouseEvent<HTMLAnchorElement>): void => {
     ev.preventDefault();
@@ -53,7 +55,7 @@ export const ListItem: FC<IProps> = ({
     >
       {item.children.length > 0 && (
         <AsideList inner={true}>
-          {item.children.map((innerItem) => {
+          {item.children.map((innerItem, index) => {
             return (
               <ListItem
                 key={innerItem.title}
@@ -61,6 +63,7 @@ export const ListItem: FC<IProps> = ({
                 item={innerItem}
                 activeItem={activeItem}
                 setActiveItem={setActiveItem}
+                index={index + 1}
               />
             );
           })}

--- a/packages/apps/docs/src/components/Layout/components/Aside/ListItem.tsx
+++ b/packages/apps/docs/src/components/Layout/components/Aside/ListItem.tsx
@@ -12,7 +12,6 @@ interface IProps {
   item: ISubHeaderElement;
   setActiveItem: React.Dispatch<React.SetStateAction<string>>;
   activeItem?: string;
-  index?: number;
 }
 
 export const ListItem: FC<IProps> = ({
@@ -20,12 +19,11 @@ export const ListItem: FC<IProps> = ({
   setActiveItem,
   activeItem,
   scrollArea,
-  index,
 }) => {
   const router = useRouter();
 
   if (item.title === undefined || item.title === '') return null;
-  const slug = `#${createSlug(item.title, index)}`;
+  const slug = `#${createSlug(item.title, item.index, item.pageTitle)}`;
 
   const handleItemClick = (ev: MouseEvent<HTMLAnchorElement>): void => {
     ev.preventDefault();
@@ -55,7 +53,7 @@ export const ListItem: FC<IProps> = ({
     >
       {item.children.length > 0 && (
         <AsideList inner={true}>
-          {item.children.map((innerItem, index) => {
+          {item.children.map((innerItem) => {
             return (
               <ListItem
                 key={innerItem.title}
@@ -63,7 +61,6 @@ export const ListItem: FC<IProps> = ({
                 item={innerItem}
                 activeItem={activeItem}
                 setActiveItem={setActiveItem}
-                index={index + 1}
               />
             );
           })}

--- a/packages/apps/docs/src/components/Layout/components/Aside/ListItem.tsx
+++ b/packages/apps/docs/src/components/Layout/components/Aside/ListItem.tsx
@@ -23,7 +23,7 @@ export const ListItem: FC<IProps> = ({
   const router = useRouter();
 
   if (item.title === undefined || item.title === '') return null;
-  const slug = `#${createSlug(item.title, item.index, item.pageTitle)}`;
+  const slug = `#${createSlug(item.title, item.index, item.parentTitle)}`;
 
   const handleItemClick = (ev: MouseEvent<HTMLAnchorElement>): void => {
     ev.preventDefault();

--- a/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
+++ b/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
@@ -14,6 +14,7 @@ interface IProp {
   variant?: TagType;
   children: string;
   index?: number;
+  pageTitle?: string;
 }
 
 export interface IHeader {
@@ -70,8 +71,14 @@ const StyledLinkIcon = styled('a', {
   scrollSnapMarginTop: '$20',
 });
 
-export const TaggedHeading: FC<IProp> = ({ children, as, variant, index }) => {
-  const slug = createSlug(children, index);
+export const TaggedHeading: FC<IProp> = ({
+  children,
+  as,
+  variant,
+  index,
+  pageTitle,
+}) => {
+  const slug = createSlug(children, index, pageTitle);
 
   return (
     <StyledHeader as={as} variant={variant ?? as}>

--- a/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
+++ b/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
@@ -14,7 +14,7 @@ interface IProp {
   variant?: TagType;
   children: string;
   index?: number;
-  pageTitle?: string;
+  parentTitle?: string;
 }
 
 export interface IHeader {
@@ -76,9 +76,9 @@ export const TaggedHeading: FC<IProp> = ({
   as,
   variant,
   index,
-  pageTitle,
+  parentTitle,
 }) => {
-  const slug = createSlug(children, index, pageTitle);
+  const slug = createSlug(children, index, parentTitle);
 
   return (
     <StyledHeader as={as} variant={variant ?? as}>

--- a/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
+++ b/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
@@ -13,6 +13,7 @@ interface IProp {
   as: TagType;
   variant?: TagType;
   children: string;
+  index?: number;
 }
 
 export interface IHeader {
@@ -69,8 +70,8 @@ const StyledLinkIcon = styled('a', {
   scrollSnapMarginTop: '$20',
 });
 
-export const TaggedHeading: FC<IProp> = ({ children, as, variant }) => {
-  const slug = createSlug(children);
+export const TaggedHeading: FC<IProp> = ({ children, as, variant, index }) => {
+  const slug = createSlug(children, index);
 
   return (
     <StyledHeader as={as} variant={variant ?? as}>

--- a/packages/apps/docs/src/components/Markdown/Heading/Heading1.tsx
+++ b/packages/apps/docs/src/components/Markdown/Heading/Heading1.tsx
@@ -2,6 +2,10 @@ import { IHeader, TaggedHeading } from './Heading';
 
 import React, { FC } from 'react';
 
-export const Heading1: FC<IHeader> = ({ children }) => {
-  return <TaggedHeading as="h1">{children}</TaggedHeading>;
+export const Heading1: FC<IHeader> = ({ children, ...rest }) => {
+  return (
+    <TaggedHeading as="h1" {...rest}>
+      {children}
+    </TaggedHeading>
+  );
 };

--- a/packages/apps/docs/src/components/Markdown/Heading/Heading2.tsx
+++ b/packages/apps/docs/src/components/Markdown/Heading/Heading2.tsx
@@ -2,6 +2,10 @@ import { IHeader, TaggedHeading } from './Heading';
 
 import React, { FC } from 'react';
 
-export const Heading2: FC<IHeader> = ({ children }) => {
-  return <TaggedHeading as="h2">{children}</TaggedHeading>;
+export const Heading2: FC<IHeader> = ({ children, ...rest }) => {
+  return (
+    <TaggedHeading as="h2" {...rest}>
+      {children}
+    </TaggedHeading>
+  );
 };

--- a/packages/apps/docs/src/components/Markdown/Heading/Heading3.tsx
+++ b/packages/apps/docs/src/components/Markdown/Heading/Heading3.tsx
@@ -2,6 +2,10 @@ import { IHeader, TaggedHeading } from './Heading';
 
 import React, { FC } from 'react';
 
-export const Heading3: FC<IHeader> = ({ children }) => {
-  return <TaggedHeading as="h3">{children}</TaggedHeading>;
+export const Heading3: FC<IHeader> = ({ children, ...rest }) => {
+  return (
+    <TaggedHeading as="h3" {...rest}>
+      {children}
+    </TaggedHeading>
+  );
 };

--- a/packages/apps/docs/src/scripts/remarkHeadersToProps.mjs
+++ b/packages/apps/docs/src/scripts/remarkHeadersToProps.mjs
@@ -40,15 +40,15 @@ const remarkHeadersToProps = () => {
 
     headers.forEach((item, index) => {
       const parent = lastHeading(startArray[0], item);
-      const pageTitle = parent.title ?? '';
+      const parentTitle = parent.title ?? '';
 
-      // Heading3 component needs index and page title as a props
+      // Heading3 component needs index and parent title as a props
       // to generate the unique anchor link to match with the sidebar menu
       // for any special characters
       item.data = {
         hProperties: {
           index,
-          pageTitle,
+          parentTitle,
         },
       };
 
@@ -57,10 +57,10 @@ const remarkHeadersToProps = () => {
         tag: getTagName(item.depth),
         title: toString(item) ?? '',
         children: [],
-        // index and page title is used to generate
+        // index and parent title is used to generate
         // the unique anchor link for special characters in sidebar menu
         index,
-        pageTitle,
+        parentTitle,
       };
       parent.children.push(elm);
     });

--- a/packages/apps/docs/src/scripts/remarkHeadersToProps.mjs
+++ b/packages/apps/docs/src/scripts/remarkHeadersToProps.mjs
@@ -40,10 +40,15 @@ const remarkHeadersToProps = () => {
 
     headers.forEach((item, index) => {
       const parent = lastHeading(startArray[0], item);
+      const pageTitle = parent.title ?? '';
 
+      // Heading3 component needs index and page title as a props
+      // to generate the unique anchor link to match with the sidebar menu
+      // for any special characters
       item.data = {
         hProperties: {
           index,
+          pageTitle,
         },
       };
 
@@ -52,6 +57,10 @@ const remarkHeadersToProps = () => {
         tag: getTagName(item.depth),
         title: toString(item) ?? '',
         children: [],
+        // index and page title is used to generate
+        // the unique anchor link for special characters in sidebar menu
+        index,
+        pageTitle,
       };
       parent.children.push(elm);
     });

--- a/packages/apps/docs/src/scripts/remarkHeadersToProps.mjs
+++ b/packages/apps/docs/src/scripts/remarkHeadersToProps.mjs
@@ -38,8 +38,14 @@ const remarkHeadersToProps = () => {
       },
     ];
 
-    headers.forEach((item) => {
+    headers.forEach((item, index) => {
       const parent = lastHeading(startArray[0], item);
+
+      item.data = {
+        hProperties: {
+          index: index,
+        },
+      }
 
       const elm = {
         depth: item.depth,

--- a/packages/apps/docs/src/scripts/remarkHeadersToProps.mjs
+++ b/packages/apps/docs/src/scripts/remarkHeadersToProps.mjs
@@ -43,9 +43,9 @@ const remarkHeadersToProps = () => {
 
       item.data = {
         hProperties: {
-          index: index,
+          index,
         },
-      }
+      };
 
       const elm = {
         depth: item.depth,

--- a/packages/apps/docs/src/types/Layout.ts
+++ b/packages/apps/docs/src/types/Layout.ts
@@ -13,7 +13,7 @@ export interface ISubHeaderElement {
   slug?: string;
   children: ISubHeaderElement[];
   index?: number;
-  pageTitle?: string;
+  parentTitle?: string;
 }
 
 export interface INavigation {

--- a/packages/apps/docs/src/types/Layout.ts
+++ b/packages/apps/docs/src/types/Layout.ts
@@ -12,6 +12,8 @@ export interface ISubHeaderElement {
   title?: string;
   slug?: string;
   children: ISubHeaderElement[];
+  index?: number;
+  pageTitle?: string;
 }
 
 export interface INavigation {

--- a/packages/apps/docs/src/utils/createSlug.ts
+++ b/packages/apps/docs/src/utils/createSlug.ts
@@ -1,4 +1,8 @@
-export const createSlug = (str?: string, index?: number): string => {
+export const createSlug = (
+  str?: string,
+  index?: number,
+  pageTitle = 'menu',
+): string => {
   if (str === undefined) return '';
   const normalizedSlug = str
     .normalize('NFD')
@@ -8,9 +12,12 @@ export const createSlug = (str?: string, index?: number): string => {
     .toLowerCase()
     .replace(/^-+|-+$/g, '');
 
-  if (normalizedSlug === '' && index !== undefined) return `operator-${index}`;
+  const normalizedPageTitle = pageTitle.toLowerCase().replace(/ /g, '-');
 
-  if (index === undefined) return normalizedSlug;
+  if (normalizedSlug === '' && index !== undefined)
+    return `${normalizedPageTitle}-${index}`;
+
+  if (normalizedSlug === '') return normalizedPageTitle;
 
   // To check any special character at the end of the string
   const regex = /^.*[!@#$%^&*?]{1}$/;

--- a/packages/apps/docs/src/utils/createSlug.ts
+++ b/packages/apps/docs/src/utils/createSlug.ts
@@ -12,5 +12,10 @@ export const createSlug = (str?: string, index?: number): string => {
 
   if (index === undefined) return normalizedSlug;
 
-  return `${normalizedSlug}-${index}`;
+  // To check any special character at the end of the string
+  const regex = /^.*[!@#$%^&*?]{1}$/;
+
+  if (str.match(regex)) return `${normalizedSlug}-${index}`;
+
+  return normalizedSlug;
 };

--- a/packages/apps/docs/src/utils/createSlug.ts
+++ b/packages/apps/docs/src/utils/createSlug.ts
@@ -1,7 +1,7 @@
 export const createSlug = (
   str?: string,
   index?: number,
-  pageTitle = 'menu',
+  parentTitle = 'menu',
 ): string => {
   if (str === undefined) return '';
   const normalizedSlug = str
@@ -12,12 +12,12 @@ export const createSlug = (
     .toLowerCase()
     .replace(/^-+|-+$/g, '');
 
-  const normalizedPageTitle = pageTitle.toLowerCase().replace(/ /g, '-');
+  const normalizedParentTitle = parentTitle.toLowerCase().replace(/ /g, '-');
 
   if (normalizedSlug === '' && index !== undefined)
-    return `${normalizedPageTitle}-${index}`;
+    return `${normalizedParentTitle}-${index}`;
 
-  if (normalizedSlug === '') return normalizedPageTitle;
+  if (normalizedSlug === '') return normalizedParentTitle;
 
   // To check any special character at the end of the string
   const regex = /^.*[!@#$%^&*?]{1}$/;

--- a/packages/apps/docs/src/utils/createSlug.ts
+++ b/packages/apps/docs/src/utils/createSlug.ts
@@ -1,10 +1,16 @@
-export const createSlug = (str?: string): string => {
+export const createSlug = (str?: string, index?: number): string => {
   if (str === undefined) return '';
-  return str
+  const normalizedSlug = str
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
     .replace(/[^\w\s]+/g, '')
     .replace(/ /g, '-')
     .toLowerCase()
     .replace(/^-+|-+$/g, '');
+
+  if (normalizedSlug === '' && index !== undefined) return `operator-${index}`;
+
+  if (index === undefined) return normalizedSlug;
+
+  return `${normalizedSlug}-${index}`;
 };

--- a/packages/apps/docs/src/utils/tests/createSlug.test.ts
+++ b/packages/apps/docs/src/utils/tests/createSlug.test.ts
@@ -10,11 +10,20 @@ describe('utils createSlug', () => {
     );
   });
 
-  it('should return a slug from given string with index', () => {
-    expect(createSlug('By the power of grayskull!', 1)).toEqual(
-      'by-the-power-of-grayskull-1',
+  it('should ignore index if slug is not empty and not having any special characters', () => {
+    expect(createSlug('By the power of grayskull', 1)).toEqual(
+      'by-the-power-of-grayskull',
     );
     expect(createSlug('here comes spëcíāl characters', 2)).toEqual(
+      'here-comes-special-characters',
+    );
+  });
+
+  it('should return a slug from given string with index', () => {
+    expect(createSlug('By the power of grayskull?', 1)).toEqual(
+      'by-the-power-of-grayskull-1',
+    );
+    expect(createSlug('here comes spëcíāl characters!', 2)).toEqual(
       'here-comes-special-characters-2',
     );
   });

--- a/packages/apps/docs/src/utils/tests/createSlug.test.ts
+++ b/packages/apps/docs/src/utils/tests/createSlug.test.ts
@@ -1,12 +1,29 @@
 import { createSlug } from '..';
 
 describe('utils createSlug', () => {
-  test('should return a slug from given string"', () => {
+  it('should return a slug from given string"', () => {
     expect(createSlug('By the power of grayskull!')).toEqual(
       'by-the-power-of-grayskull',
     );
     expect(createSlug('here comes spëcíāl characters')).toEqual(
       'here-comes-special-characters',
     );
+  });
+
+  it('should return a slug from given string with index', () => {
+    expect(createSlug('By the power of grayskull!', 1)).toEqual(
+      'by-the-power-of-grayskull-1',
+    );
+    expect(createSlug('here comes spëcíāl characters', 2)).toEqual(
+      'here-comes-special-characters-2',
+    );
+  });
+
+  it('should return operator-{index} if slug is empty', () => {
+    expect(createSlug('', 1)).toEqual('operator-1');
+  });
+
+  it('should return empty string if slug is empty and no index is given', () => {
+    expect(createSlug('')).toEqual('');
   });
 });

--- a/packages/apps/docs/src/utils/tests/createSlug.test.ts
+++ b/packages/apps/docs/src/utils/tests/createSlug.test.ts
@@ -28,8 +28,12 @@ describe('utils createSlug', () => {
     );
   });
 
-  it('should return operator-{index} if slug is empty', () => {
+  it('should return menu-{index} if slug and page title is empty ', () => {
     expect(createSlug('', 1)).toEqual('operator-1');
+  });
+
+  it('should return page title when slug and index is empty ', () => {
+    expect(createSlug('?', undefined, 'page Title')).toEqual('page-title-1');
   });
 
   it('should return empty string if slug is empty and no index is given', () => {


### PR DESCRIPTION
- Updated a createSlug method to pass `index`
- Append `index` values only if string has any special characters at the end. To avoid a use case like `not` and `not?`  to have same link reference
- if string contains only special characters then it replaced with `operator-${index}`
- Update components to pass `index` props