### PR TITLE
Feat/reusable chain select component

### DIFF
--- a/packages/apps/transfer/src/components/Global/ChainSelect/index.tsx
+++ b/packages/apps/transfer/src/components/Global/ChainSelect/index.tsx
@@ -1,0 +1,52 @@
+import { CHAINS, ChainwebChainId } from '@kadena/chainweb-node-client';
+import { SystemIcons } from '@kadena/react-components';
+import {
+  type ISelectProps,
+  InputWrapper,
+  Option,
+  Select,
+} from '@kadena/react-ui';
+
+import React, { type FC, type FormEventHandler, useCallback } from 'react';
+
+export type OnChainSelectChange = (value: ChainwebChainId) => void;
+
+const ELEMENT_ID = 'select-chain-id';
+
+const ChainSelect: FC<
+  Omit<ISelectProps, 'children' | 'value' | 'onChange' | 'icon' | 'id'> & {
+    value: ChainwebChainId;
+    onChange: OnChainSelectChange;
+  }
+> = ({ value, onChange, ...rest }) => {
+  const onSelectChange = useCallback<FormEventHandler<HTMLSelectElement>>(
+    (e) => {
+      const chainId = CHAINS.find((chainId) => {
+        return chainId === e.currentTarget.value;
+      });
+
+      onChange(chainId!);
+    },
+    [onChange],
+  );
+
+  const Options = CHAINS.map((chainID) => {
+    return <Option key={`chain-id-${chainID}`}>{chainID}</Option>;
+  });
+
+  return (
+    <InputWrapper label="Chain ID" htmlFor={ELEMENT_ID}>
+      <Select
+        {...rest}
+        id={ELEMENT_ID}
+        onChange={onSelectChange}
+        value={value}
+        icon={() => <SystemIcons.Link />}
+      >
+        {Options}
+      </Select>
+    </InputWrapper>
+  );
+};
+
+export { ChainSelect };

--- a/packages/apps/transfer/src/components/Global/ChainSelect/index.tsx
+++ b/packages/apps/transfer/src/components/Global/ChainSelect/index.tsx
@@ -30,7 +30,7 @@ const ChainSelect: FC<
     [onChange],
   );
 
-  const Options = CHAINS.map((chainID) => {
+  const options = CHAINS.map((chainID) => {
     return <Option key={`chain-id-${chainID}`}>{chainID}</Option>;
   });
 
@@ -43,7 +43,7 @@ const ChainSelect: FC<
         value={value}
         icon={() => <SystemIcons.Link />}
       >
-        {Options}
+        {options}
       </Select>
     </InputWrapper>
   );

--- a/packages/apps/transfer/src/components/Global/index.ts
+++ b/packages/apps/transfer/src/components/Global/index.ts
@@ -4,4 +4,7 @@ export { SidebarMenu } from '@/components/Global/SidebarMenu';
 export { Container } from '@/components/Global/Container';
 export { GridCol, GridRow } from '@/components/Global/Grid';
 export { WalletConnectButton } from '@/components/Global/WalletConnectButton';
-export { ChainSelect } from '@/components/Global/ChainSelect';
+export {
+  ChainSelect,
+  type OnChainSelectChange,
+} from '@/components/Global/ChainSelect';

--- a/packages/apps/transfer/src/components/Global/index.ts
+++ b/packages/apps/transfer/src/components/Global/index.ts
@@ -4,3 +4,4 @@ export { SidebarMenu } from '@/components/Global/SidebarMenu';
 export { Container } from '@/components/Global/Container';
 export { GridCol, GridRow } from '@/components/Global/Grid';
 export { WalletConnectButton } from '@/components/Global/WalletConnectButton';
+export { ChainSelect } from '@/components/Global/ChainSelect';

--- a/packages/apps/transfer/src/context/app-context.tsx
+++ b/packages/apps/transfer/src/context/app-context.tsx
@@ -1,3 +1,5 @@
+import { ChainwebChainId } from '@kadena/chainweb-node-client';
+
 import { Network } from '@/constants/kadena';
 import { useDidUpdateEffect } from '@/hooks';
 import { getItem, setItem } from '@/utils/persist';
@@ -12,12 +14,21 @@ import React, {
 interface INetworkState {
   network: Network;
   setNetwork(network: Network): void;
+  chainID: ChainwebChainId;
+  setChainID(chainID: ChainwebChainId): void;
 }
 
 const AppContext = createContext<INetworkState>({
   network: 'MAINNET',
   setNetwork: () => {},
+  chainID: '1',
+  setChainID: () => {},
 });
+
+const StorageKeys: Record<'NETWORK' | 'CHAIN_ID', string> = {
+  NETWORK: 'network',
+  CHAIN_ID: 'chainID',
+};
 
 const useAppContext = (): INetworkState => {
   const context = useContext(AppContext);
@@ -31,20 +42,27 @@ const useAppContext = (): INetworkState => {
 
 const AppContextProvider = (props: PropsWithChildren): JSX.Element => {
   const [network, setNetwork] = useState<Network>('MAINNET');
+  const [chainID, setChainID] = useState<ChainwebChainId>('1');
 
   useLayoutEffect(() => {
-    const initialNetwork = getItem('network') as Network;
+    const initialNetwork = getItem(StorageKeys.NETWORK) as Network;
     if (initialNetwork) {
       setNetwork(initialNetwork);
+    }
+
+    const initialChainID = getItem(StorageKeys.CHAIN_ID) as ChainwebChainId;
+    if (initialChainID) {
+      setChainID(initialChainID);
     }
   }, []);
 
   useDidUpdateEffect(() => {
-    setItem('network', network);
-  }, [network]);
+    setItem(StorageKeys.NETWORK, network);
+    setItem(StorageKeys.CHAIN_ID, chainID);
+  }, [network, chainID]);
 
   return (
-    <AppContext.Provider value={{ network, setNetwork }}>
+    <AppContext.Provider value={{ network, setNetwork, chainID, setChainID }}>
       {props.children}
     </AppContext.Provider>
   );

--- a/packages/apps/transfer/src/hooks/index.ts
+++ b/packages/apps/transfer/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export { default as useDidUpdateEffect } from './use-did-update-effect';
+export { default as usePersistentChainID } from './use-persistent-chain-id';

--- a/packages/apps/transfer/src/hooks/use-persistent-chain-id.ts
+++ b/packages/apps/transfer/src/hooks/use-persistent-chain-id.ts
@@ -1,0 +1,18 @@
+import { type ChainwebChainId } from '@kadena/chainweb-node-client';
+
+import { type OnChainSelectChange } from '@/components/Global';
+import { useAppContext } from '@/context/app-context';
+import { useCallback } from 'react';
+
+const usePersistentChainID = (): [ChainwebChainId, OnChainSelectChange] => {
+  const { chainID, setChainID } = useAppContext();
+  const onChainSelectChange = useCallback<OnChainSelectChange>(
+    (chainID) => {
+      setChainID(chainID);
+    },
+    [setChainID],
+  );
+  return [chainID, onChainSelectChange];
+};
+
+export default usePersistentChainID;

--- a/packages/apps/transfer/src/pages/faucet/existing/index.tsx
+++ b/packages/apps/transfer/src/pages/faucet/existing/index.tsx
@@ -5,8 +5,7 @@ import { Button, Heading, SystemIcon, TextField } from '@kadena/react-ui';
 import FormStatusNotification from './notification';
 
 import MainLayout from '@/components/Common/Layout/MainLayout';
-import { ChainSelect } from '@/components/Global';
-import { OnChainSelectChange } from '@/components/Global/ChainSelect';
+import { type OnChainSelectChange, ChainSelect } from '@/components/Global';
 import { useAppContext } from '@/context/app-context';
 import {
   StyledAccountForm,

--- a/packages/apps/transfer/src/pages/faucet/existing/index.tsx
+++ b/packages/apps/transfer/src/pages/faucet/existing/index.tsx
@@ -5,8 +5,8 @@ import { Button, Heading, SystemIcon, TextField } from '@kadena/react-ui';
 import FormStatusNotification from './notification';
 
 import MainLayout from '@/components/Common/Layout/MainLayout';
-import { type OnChainSelectChange, ChainSelect } from '@/components/Global';
-import { useAppContext } from '@/context/app-context';
+import { ChainSelect } from '@/components/Global';
+import { usePersistentChainID } from '@/hooks';
 import {
   StyledAccountForm,
   StyledForm,
@@ -31,7 +31,7 @@ const ExistingAccountFaucetPage: FC = () => {
   const { t } = useTranslation('common');
 
   const [accountName, setAccountName] = useState('');
-  const { chainID, setChainID } = useAppContext();
+  const [chainID, onChainSelectChange] = usePersistentChainID();
 
   const [requestStatus, setRequestStatus] = useState<{
     status: RequestStatus;
@@ -94,13 +94,6 @@ const ExistingAccountFaucetPage: FC = () => {
       setAccountName(e.currentTarget.value);
     },
     [],
-  );
-
-  const onChainSelectChange = useCallback<OnChainSelectChange>(
-    (chainID) => {
-      setChainID(chainID);
-    },
-    [setChainID],
   );
 
   return (

--- a/packages/apps/transfer/src/pages/faucet/existing/index.tsx
+++ b/packages/apps/transfer/src/pages/faucet/existing/index.tsx
@@ -5,8 +5,9 @@ import { Button, Heading, SystemIcon, TextField } from '@kadena/react-ui';
 import FormStatusNotification from './notification';
 
 import MainLayout from '@/components/Common/Layout/MainLayout';
-import { Select } from '@/components/Global';
-import { StyledOption } from '@/components/Global/Select/styles';
+import { ChainSelect } from '@/components/Global';
+import { OnChainSelectChange } from '@/components/Global/ChainSelect';
+import { useAppContext } from '@/context/app-context';
 import {
   StyledAccountForm,
   StyledForm,
@@ -25,40 +26,13 @@ import React, {
 // TODO: This needs to be changed to 100, when the contract is redeployed
 const AMOUNT_OF_COINS_FUNDED: number = 20;
 
-// eslint-disable-next-line @kadena-dev/typedef-var
-export const CHAINS = [
-  '0',
-  '1',
-  '2',
-  '3',
-  '4',
-  '5',
-  '6',
-  '7',
-  '8',
-  '9',
-  '10',
-  '11',
-  '12',
-  '13',
-  '14',
-  '15',
-  '16',
-  '17',
-  '18',
-  '19',
-] as const;
-
-export type ChainTuple = typeof CHAINS;
-export type Chain = ChainTuple[number];
-
 export type RequestStatus = 'not started' | 'pending' | 'succeeded' | 'failed';
 
 const ExistingAccountFaucetPage: FC = () => {
   const { t } = useTranslation('common');
 
   const [accountName, setAccountName] = useState('');
-  const [chainID, setChainID] = useState<Chain>('0');
+  const { chainID, setChainID } = useAppContext();
 
   const [requestStatus, setRequestStatus] = useState<{
     status: RequestStatus;
@@ -123,11 +97,11 @@ const ExistingAccountFaucetPage: FC = () => {
     [],
   );
 
-  const onChainSelectChange = useCallback<FormEventHandler<HTMLSelectElement>>(
-    (e) => {
-      setChainID(e.currentTarget.value as Chain);
+  const onChainSelectChange = useCallback<OnChainSelectChange>(
+    (chainID) => {
+      setChainID(chainID);
     },
-    [],
+    [setChainID],
   );
 
   return (
@@ -148,19 +122,7 @@ const ExistingAccountFaucetPage: FC = () => {
               leftIcon: SystemIcon.KIcon,
             }}
           />
-          <Select
-            label={t('Chain ID')}
-            onChange={onChainSelectChange}
-            value={chainID}
-            status="error"
-            leftPanel={SystemIcon.Link}
-          >
-            {CHAINS.map((chainId) => {
-              return (
-                <StyledOption key={`chain-${chainId}`}>{chainId}</StyledOption>
-              );
-            })}
-          </Select>
+          <ChainSelect onChange={onChainSelectChange} value={chainID} />
         </StyledAccountForm>
         <StyledFormButton>
           <Button.Root

--- a/packages/apps/transfer/src/pages/transfer/account-transactions/index.tsx
+++ b/packages/apps/transfer/src/pages/transfer/account-transactions/index.tsx
@@ -2,9 +2,10 @@ import { ChainwebChainId } from '@kadena/chainweb-node-client';
 import { Button, TextField } from '@kadena/react-ui';
 
 import MainLayout from '@/components/Common/Layout/MainLayout';
-import { type OnChainSelectChange, ChainSelect } from '@/components/Global';
+import { ChainSelect } from '@/components/Global';
 import { Network } from '@/constants/kadena';
 import { useAppContext } from '@/context/app-context';
+import { usePersistentChainID } from '@/hooks';
 import {
   StyledContent,
   StyledFormButton,
@@ -47,13 +48,7 @@ const CheckTransactions: FC = () => {
   const [account, setAccount] = useState<string>('');
   const [results, setResults] = useState<ITransaction[]>([]);
   const [hasSearched, setHasSearched] = useState<boolean>(false);
-  const { chainID, setChainID } = useAppContext();
-  const onChainSelectChange = useCallback<OnChainSelectChange>(
-    (chainID) => {
-      setChainID(chainID);
-    },
-    [setChainID],
-  );
+  const [chainID, onChainSelectChange] = usePersistentChainID();
 
   useEffect(() => {
     if (router.isReady) {

--- a/packages/apps/transfer/src/pages/transfer/account-transactions/index.tsx
+++ b/packages/apps/transfer/src/pages/transfer/account-transactions/index.tsx
@@ -2,8 +2,7 @@ import { ChainwebChainId } from '@kadena/chainweb-node-client';
 import { Button, TextField } from '@kadena/react-ui';
 
 import MainLayout from '@/components/Common/Layout/MainLayout';
-import { ChainSelect } from '@/components/Global';
-import { OnChainSelectChange } from '@/components/Global/ChainSelect';
+import { type OnChainSelectChange, ChainSelect } from '@/components/Global';
 import { Network } from '@/constants/kadena';
 import { useAppContext } from '@/context/app-context';
 import {

--- a/packages/apps/transfer/src/pages/transfer/module-explorer/index.tsx
+++ b/packages/apps/transfer/src/pages/transfer/module-explorer/index.tsx
@@ -16,9 +16,10 @@ import {
   StyledResultContainer,
 } from './styles';
 
-import { type OnChainSelectChange, ChainSelect } from '@/components/Global';
+import { ChainSelect } from '@/components/Global';
 import { kadenaConstants } from '@/constants/kadena';
 import { useAppContext } from '@/context/app-context';
+import { usePersistentChainID } from '@/hooks';
 import {
   type IModuleResult,
   describeModule,
@@ -47,13 +48,8 @@ const ModuleExplorer: FC = () => {
   const [modules, setModules] = useState<IModulesResult>({});
   const [results, setResults] = useState<IModuleResult>({});
 
-  const { network, chainID, setChainID } = useAppContext();
-  const onChainSelectChange = useCallback<OnChainSelectChange>(
-    (chainID) => {
-      setChainID(chainID);
-    },
-    [setChainID],
-  );
+  const { network } = useAppContext();
+  const [chainID, onChainSelectChange] = usePersistentChainID();
 
   useEffect(() => {
     const fetchModules = async (): Promise<void> => {

--- a/packages/apps/transfer/src/pages/transfer/module-explorer/index.tsx
+++ b/packages/apps/transfer/src/pages/transfer/module-explorer/index.tsx
@@ -16,8 +16,7 @@ import {
   StyledResultContainer,
 } from './styles';
 
-import { ChainSelect } from '@/components/Global';
-import { OnChainSelectChange } from '@/components/Global/ChainSelect';
+import { type OnChainSelectChange, ChainSelect } from '@/components/Global';
 import { kadenaConstants } from '@/constants/kadena';
 import { useAppContext } from '@/context/app-context';
 import {

--- a/packages/apps/transfer/src/services/accounts/get-transactions.ts
+++ b/packages/apps/transfer/src/services/accounts/get-transactions.ts
@@ -1,3 +1,5 @@
+import { ChainwebChainId } from '@kadena/chainweb-node-client';
+
 import { getKadenaConstantByNetwork, Network } from '@/constants/kadena';
 import Debug from 'debug';
 
@@ -5,21 +7,21 @@ export interface ITransaction {
   fromAccount: string;
   height: number;
   amount: string;
-  crossChainId?: number;
+  crossChainId?: ChainwebChainId;
   toAccount: string;
   blockTime: string;
   requestKey: string;
   token: string;
   blockHash: string;
   idx: number;
-  chain: number;
+  chain: ChainwebChainId;
   crossChainAccount?: string;
 }
 const debug = Debug('kadena-transfer:services:get-transactions');
 
 export async function getTransactions(options: {
   network: Network;
-  chain: string;
+  chain: ChainwebChainId;
   account: string;
 }): Promise<ITransaction[]> {
   debug(getTransactions.name);


### PR DESCRIPTION
This PR is part of a series of PRs aimed to ensure DRY-principle. First up is the reusable chain select component used on multiple pages. After selecting a chain ID, it is persisted (stored in cookies), so the same chain will be chosen (by default) across pages.