### PR TITLE
Add Module resolver to resolve css files with path alias imports

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -897,6 +897,7 @@ importers:
       '@vanilla-extract/recipes': 0.4.0
       '@vanilla-extract/sprinkles': 1.6.0
       '@vanilla-extract/webpack-plugin': 2.2.0
+      babel-plugin-module-resolver: ^5.0.0
       classnames: ^2.3.1
       copyfiles: 2.4.1
       css-loader: ~6.8.1
@@ -965,6 +966,7 @@ importers:
       '@types/testing-library__jest-dom': 5.14.6
       '@vanilla-extract/jest-transform': 1.1.1_@types+node@16.18.38
       '@vanilla-extract/webpack-plugin': 2.2.0_122540af6761bbdfb0b3ddf5bef86411
+      babel-plugin-module-resolver: 5.0.0
       copyfiles: 2.4.1
       eslint: 8.44.0
       eslint-import-resolver-typescript: 3.5.5_e813a63fe0cff7c4281576d9d101cdc8
@@ -12574,6 +12576,17 @@ packages:
       resolve: 1.22.2
     dev: false
 
+  /babel-plugin-module-resolver/5.0.0:
+    resolution: {integrity: sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==}
+    engines: {node: '>= 16'}
+    dependencies:
+      find-babel-config: 2.0.0
+      glob: 8.1.0
+      pkg-up: 3.1.0
+      reselect: 4.1.8
+      resolve: 1.22.2
+    dev: true
+
   /babel-plugin-named-asset-import/0.3.8_@babel+core@7.22.5:
     resolution: {integrity: sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==}
     peerDependencies:
@@ -16196,6 +16209,14 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+
+  /find-babel-config/2.0.0:
+    resolution: {integrity: sha512-dOKT7jvF3hGzlW60Gc3ONox/0rRZ/tz7WCil0bqA1In/3I8f1BctpXahRnEKDySZqci7u+dqq93sZST9fOJpFw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      json5: 2.2.3
+      path-exists: 4.0.0
+    dev: true
 
   /find-cache-dir/2.1.0:
     resolution: {integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==}
@@ -22013,7 +22034,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 3.0.0
-    dev: false
 
   /plur/5.1.0:
     resolution: {integrity: sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==}
@@ -24005,6 +24025,10 @@ packages:
     dependencies:
       lodash: 4.17.21
     dev: false
+
+  /reselect/4.1.8:
+    resolution: {integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==}
+    dev: true
 
   /resolve-cwd/3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "22d55ba2875e96c7b8071e0961fff292cdea73e8",
+  "pnpmShrinkwrapHash": "a54dff8348b0de237b3c0776b3623ad1f1135e42",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/libs/react-ui/.babelrc.json
+++ b/packages/libs/react-ui/.babelrc.json
@@ -12,5 +12,16 @@
     "@babel/preset-typescript",
     "@babel/preset-react"
   ],
-  "plugins": []
+  "plugins": [
+    [
+      "module-resolver",
+      {
+        "root": ["."],
+        "alias": {
+          "@components": "./src/components",
+          "@theme": "./src/styles"
+        }
+      }
+    ]
+  ]
 }

--- a/packages/libs/react-ui/package.json
+++ b/packages/libs/react-ui/package.json
@@ -82,6 +82,7 @@
     "@types/testing-library__jest-dom": "~5.14.6",
     "@vanilla-extract/jest-transform": "1.1.1",
     "@vanilla-extract/webpack-plugin": "2.2.0",
+    "babel-plugin-module-resolver": "^5.0.0",
     "copyfiles": "2.4.1",
     "eslint": "^8.15.0",
     "eslint-import-resolver-typescript": "3.5.5",


### PR DESCRIPTION
After merging https://github.com/kadena-community/kadena.js/pull/530 I realised that css files are not resolved correctly. This PR fixes that by adding and configuring Babel module resolver.