### PR TITLE
fix(pactjs-generator): parse symbols as string

### DIFF
--- a/common/changes/@kadena/client/fix-parser-symbols_2023-07-17-12-27.json
+++ b/common/changes/@kadena/client/fix-parser-symbols_2023-07-17-12-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "update pact parser to parse symbols as string",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/packages/libs/pactjs-generator/src/contract/parsing/utils/parser-utilities/str.ts
+++ b/packages/libs/pactjs-generator/src/contract/parsing/utils/parser-utilities/str.ts
@@ -6,7 +6,7 @@ export const str: IParser<string> = rule((pointer) => {
   const token = pointer.next();
   if (token !== undefined && token.type === 'string')
     return trim(token.value, '"');
-  // for now we only consider symbols as string, we can split this two different parser if there is separate scenario
+  // For now, we are treating symbols as strings. If there is a separate scenario, we can split this parser into two different parsers
   if (token?.type === 'symbol') return trim(token.value, "'");
   return FAILED;
 });

--- a/packages/libs/pactjs-generator/src/contract/parsing/utils/parser-utilities/str.ts
+++ b/packages/libs/pactjs-generator/src/contract/parsing/utils/parser-utilities/str.ts
@@ -4,6 +4,9 @@ import { FAILED, IParser, rule } from './rule';
 
 export const str: IParser<string> = rule((pointer) => {
   const token = pointer.next();
-  if (!token || token.type !== 'string') return FAILED;
-  return trim(token.value, '"');
+  if (token !== undefined && token.type === 'string')
+    return trim(token.value, '"');
+  // for now we only consider symbols as string, we can split this two different parser if there is separate scenario
+  if (token?.type === 'symbol') return trim(token.value, "'");
+  return FAILED;
 });

--- a/packages/libs/pactjs-generator/src/contract/parsing/utils/parser-utilities/tests/str.test.ts
+++ b/packages/libs/pactjs-generator/src/contract/parsing/utils/parser-utilities/tests/str.test.ts
@@ -10,6 +10,13 @@ describe('str parser', () => {
     expect(result).toBe('str_test');
   });
 
+  it("should return a string ('text) value if token type is symbol", () => {
+    const pointer = getPointer("'str_test");
+    const result = str(pointer);
+    // quotation marks are removed
+    expect(result).toBe('str_test');
+  });
+
   it('should return FAILED if token type is not string', () => {
     const pointer = getPointer('test');
     const result = str(pointer);


### PR DESCRIPTION
fixed str parser to parse pact symbols (`'symbol_name`) as string. 
this will fix the issue with finding module namespace
