### PR TITLE
fix(react-ui) producticons

### DIFF
--- a/packages/libs/react-ui/src/components/Icon/IconWrapper.css.ts
+++ b/packages/libs/react-ui/src/components/Icon/IconWrapper.css.ts
@@ -5,6 +5,12 @@ export const iconContainer = style([
   sprinkles({
     display: 'block',
   }),
+  {
+    // transform hack is needed for Safari (and iOS Chrome)
+    // if not the multipy mixBlendMode will not work
+    // the transform will take the icon out of its render layer and will render the icon correctly
+    transform: 'translate3d(0,0,0)',
+  },
 ]);
 
 export const sizeVariants = styleVariants({


### PR DESCRIPTION
the producticons were not rendering correctly in apps, on darkmode
transform hack is needed for Safari (and iOS Chrome)
if not the multipy mixBlendMode will not work
the transform will take the icon out of its render layer and will render the icon correctly