### PR TITLE
JSON parse try/catch

### DIFF
--- a/common/changes/@kadena/chainweb-stream-client/fix-chainweb-stream-json-parse_2023-07-18-17-21.json
+++ b/common/changes/@kadena/chainweb-stream-client/fix-chainweb-stream-json-parse_2023-07-18-17-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-stream-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainweb-stream-client"
+}

--- a/packages/libs/chainweb-stream-client/src/sliding-cache.ts
+++ b/packages/libs/chainweb-stream-client/src/sliding-cache.ts
@@ -75,7 +75,9 @@ export default class SlidingCache<TShape extends ITransaction>
     const retVals = [];
     for (const elem of elems) {
       if (isUndefinedOrNull(elem)) {
-        console.error('Sliding cache: Received null or undefined data element. This should not happen!');
+        console.error(
+          'Sliding cache: Received null or undefined data element. This should not happen!',
+        );
         // do not emit this
         retVals.push(false);
         continue;

--- a/packages/libs/chainweb-stream-client/src/util.ts
+++ b/packages/libs/chainweb-stream-client/src/util.ts
@@ -2,6 +2,11 @@ export function isNotUndefined<T>(value: T | undefined): value is T {
   return value !== undefined;
 }
 
-export function isUndefinedOrNull<T>(value: T | undefined | null): value is null | undefined {
+export function isUndefinedOrNull<T>(
+  // eslint-disable-next-line @rushstack/no-new-null
+  value: T | undefined | null,
+  // eslint-disable-next-line @rushstack/no-new-null
+): value is null | undefined {
+  // eslint-disable-next-line @rushstack/no-new-null
   return value === null || value === undefined;
 }


### PR DESCRIPTION
JSON.parse was not try/caught before

Introduce a lenient json parsing for heights/data (not fatal) but make it fatal for initial event (need this to validate the config)