### PR TITLE
Bug: Tooltip Storybook story is erroring

### DIFF
--- a/packages/libs/react-ui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/libs/react-ui/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,7 +1,8 @@
 import { IconButton, SystemIcon } from '..';
 
 import { container } from './stories.css';
-import { ITooltipProps, Tooltip } from '.';
+import { ITooltipProps, Tooltip } from './Tooltip';
+import { tooltipHandler } from './tooltipHandler';
 
 import type { Meta, StoryObj } from '@storybook/react';
 import React, { useRef } from 'react';
@@ -12,6 +13,7 @@ const meta: Meta<
   } & ITooltipProps
 > = {
   title: 'Components/Tooltip',
+  component: Tooltip,
   argTypes: {
     text: {
       control: {
@@ -49,16 +51,16 @@ export const Dynamic: Story = {
           title="hover me"
           icon={SystemIcon.Information}
           onMouseEnter={(e: React.MouseEvent<HTMLElement>) =>
-            Tooltip.handler(e, ref)
+            tooltipHandler(e, ref)
           }
           onMouseLeave={(e: React.MouseEvent<HTMLButtonElement>) =>
-            Tooltip.handler(e, ref)
+            tooltipHandler(e, ref)
           }
         />
 
-        <Tooltip.Root placement={placement} ref={ref}>
+        <Tooltip placement={placement} ref={ref}>
           {text}
-        </Tooltip.Root>
+        </Tooltip>
       </div>
     );
   },

--- a/packages/libs/react-ui/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/libs/react-ui/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,8 +1,7 @@
 import { IconButton, SystemIcon } from '..';
 
 import { container } from './stories.css';
-import { ITooltipProps, Tooltip } from './Tooltip';
-import { tooltipHandler } from './tooltipHandler';
+import { ITooltipProps, Tooltip } from './';
 
 import type { Meta, StoryObj } from '@storybook/react';
 import React, { useRef } from 'react';
@@ -13,7 +12,7 @@ const meta: Meta<
   } & ITooltipProps
 > = {
   title: 'Components/Tooltip',
-  component: Tooltip,
+  component: Tooltip.Root,
   argTypes: {
     text: {
       control: {
@@ -51,16 +50,16 @@ export const Dynamic: Story = {
           title="hover me"
           icon={SystemIcon.Information}
           onMouseEnter={(e: React.MouseEvent<HTMLElement>) =>
-            tooltipHandler(e, ref)
+            Tooltip.handler(e, ref)
           }
           onMouseLeave={(e: React.MouseEvent<HTMLButtonElement>) =>
-            tooltipHandler(e, ref)
+            Tooltip.handler(e, ref)
           }
         />
 
-        <Tooltip placement={placement} ref={ref}>
+        <Tooltip.Root placement={placement} ref={ref}>
           {text}
-        </Tooltip>
+        </Tooltip.Root>
       </div>
     );
   },

--- a/packages/libs/react-ui/src/components/Tooltip/index.ts
+++ b/packages/libs/react-ui/src/components/Tooltip/index.ts
@@ -1,10 +1,12 @@
 import { ITooltipProps, Tooltip as TooltipComponent } from './Tooltip';
-import tooltipHandler from './tooltipHandler';
+import { tooltipHandler } from './tooltipHandler';
 
 export { ITooltipProps };
 
 interface ITooltip {
-  Root: typeof TooltipComponent;
+  Root: React.ForwardRefExoticComponent<
+    Omit<ITooltipProps, 'ref'> & React.RefAttributes<HTMLDivElement>
+  >;
   handler: typeof tooltipHandler;
 }
 

--- a/packages/libs/react-ui/src/components/Tooltip/tooltipHandler.ts
+++ b/packages/libs/react-ui/src/components/Tooltip/tooltipHandler.ts
@@ -2,10 +2,10 @@ import { visibleClass } from './Tooltip.css';
 
 import React from 'react';
 
-export default function tooltipHandler(
+export const tooltipHandler = (
   event: React.MouseEvent<HTMLElement>,
   ref: React.RefObject<HTMLDivElement>,
-): void {
+): void => {
   const target = event.target as HTMLElement;
   const rect = target.getBoundingClientRect();
   const node = ref.current;
@@ -42,4 +42,4 @@ export default function tooltipHandler(
       node.style.left = `${rect.left + rect.width + window.scrollX}px`;
       break;
   }
-}
+};

--- a/packages/libs/react-ui/src/components/index.ts
+++ b/packages/libs/react-ui/src/components/index.ts
@@ -46,7 +46,7 @@ export {
 } from './Breadcrumbs';
 export { Box, IBoxProps } from './Box';
 export { Link, ILinkProps } from './Link';
-export { Tooltip, ITooltipProps } from './Tooltip/Tooltip';
+export { Tooltip, ITooltipProps } from './Tooltip';
 export { MaskedValue, IMaskedValueProps } from './MaskedValue/MaskedValue';
 export { Select, ISelectProps } from './Select/Select';
 export { Option, IOptionProps } from './Select/Option';


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->
- Closes ["Bug: Tooltip Storybook story is erroring"]()
- Seems that the error is related to using `forwardRef` and the imports into storybook
- It works alright when importing the `Tooltip` component and `tooltipHandler` method from their source files, rather than the index