### PR TITLE
bump chainweb-stream-client version

### DIFF
--- a/common/changes/@kadena/chainweb-stream-client/chore-bump-chainweb-stream-version_2023-07-19-05-44.json
+++ b/common/changes/@kadena/chainweb-stream-client/chore-bump-chainweb-stream-version_2023-07-19-05-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-stream-client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainweb-stream-client"
+}

--- a/packages/libs/chainweb-stream-client/package.json
+++ b/packages/libs/chainweb-stream-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kadena/chainweb-stream-client",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Chainweb-stream client for browsers and node.js",
   "keywords": [],
   "repository": {


### PR DESCRIPTION
Bumping chainweb-stream-client version to 0.0.9 for release