### PR TITLE
@kadena/chainweb-stream-client - Changed default export at index to named export

### DIFF
--- a/.changeset/modern-clocks-look.md
+++ b/.changeset/modern-clocks-look.md
@@ -1,0 +1,5 @@
+---
+'@kadena/chainweb-stream-client': minor
+---
+
+Changed default export at index to named export

--- a/.changeset/modern-clocks-look.md
+++ b/.changeset/modern-clocks-look.md
@@ -1,5 +1,5 @@
 ---
-'@kadena/chainweb-stream-client': minor
+'@kadena/chainweb-stream-client': patch
 ---
 
 Changed default export at index to named export

--- a/common/changes/@kadena/chainweb-stream-client/chore-chainweb-stream-client-change-default-export_2023-07-19-12-19.json
+++ b/common/changes/@kadena/chainweb-stream-client/chore-chainweb-stream-client-change-default-export_2023-07-19-12-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-stream-client",
+      "comment": "Changed default export at index to named export",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kadena/chainweb-stream-client"
+}

--- a/packages/libs/chainweb-stream-client/README.md
+++ b/packages/libs/chainweb-stream-client/README.md
@@ -63,17 +63,17 @@ Find more detailed examples under `src/examples`.
 
 ## Constructor Options
 
-| Key               | Required | Description                                                     | Example Values          |           |       |
-| ----------------- | :------: | --------------------------------------------------------------- | ----------------------- | --------- | ----- |
-| network           |   Yes    | Chainweb network                                                | \`mainnet01             | testnet04 | ...\` |
-| type              |   Yes    | Transaction type to stream (event/account)                      | \`event                 | account\` |       |
-| id                |   Yes    | Account ID or module/event name                                 | `k:abcdef01234..`       |           |       |
-| host              |   Yes    | Chainweb-stream backend URL                                     | `http://localhost:4000` |           |       |
-| limit             |    No    | Initial data load limit                                         | 100                     |           |       |
-| connectTimeout    |    No    | Connection timeout in ms                                        | 10_000                  |           |       |
-| heartbeatTimeout  |    No    | Stale connection timeout in ms                                  | 30_000                  |           |       |
-| maxReconnects     |    No    | How many reconnections to attempt before giving up              | 5                       |           |       |
-| confirmationDepth |    No    | How many confirmations for a transaction to be considered final | 6                       |           |       |
+| Key               | Required | Description                                                     | Example Values              |
+| ----------------- | :------: | --------------------------------------------------------------- | --------------------------- |
+| network           | Yes      | Chainweb network                                                | `mainnet01`/`testnet04`/... |
+| type              | Yes      | Transaction type to stream (event/account)                      | `event`/`account`           |
+| id                | Yes      | Account ID or module/event name                                 | `k:abcdef01234..`           |
+| host              | Yes      | Chainweb-stream backend URL                                     | `http://localhost:4000`     |
+| limit             | No       | Initial data load limit                                         | 100                         |
+| connectTimeout    | No       | Connection timeout in ms                                        | 10_000                      |
+| heartbeatTimeout  | No       | Stale connection timeout in ms                                  | 30_000                      |
+| maxReconnects     | No       | How many reconnections to attempt before giving up              | 5                           |
+| confirmationDepth | No       | How many confirmations for a transaction to be considered final | 6                           |
 
 ## Considerations ⚠️
 

--- a/packages/libs/chainweb-stream-client/README.md
+++ b/packages/libs/chainweb-stream-client/README.md
@@ -45,7 +45,7 @@ yarn add @kadena/chainweb-stream-client
 ## Usage
 
 ```js
-import ChainwebStreamClient from '@kadena/chainweb-stream-client';
+import  { ChainwebStreamClient } from '@kadena/chainweb-stream-client';
 
 const client = new ChainwebStreamClient({
   network: 'mainnet01',

--- a/packages/libs/chainweb-stream-client/etc/chainweb-stream-client.api.md
+++ b/packages/libs/chainweb-stream-client/etc/chainweb-stream-client.api.md
@@ -7,7 +7,7 @@
 import EventEmitter from 'eventemitter2';
 
 // @alpha (undocumented)
-class ChainwebStream extends EventEmitter {
+export class ChainwebStreamClient extends EventEmitter {
     constructor({ network, host, type, id, limit, connectTimeout, maxReconnects, heartbeatTimeout, confirmationDepth, }: IChainwebStreamConstructorArgs);
     // (undocumented)
     confirmationDepth: number;
@@ -31,7 +31,6 @@ class ChainwebStream extends EventEmitter {
     // (undocumented)
     type: ChainwebStreamType;
 }
-export default ChainwebStream;
 
 // @alpha (undocumented)
 export type ChainwebStreamType = 'event' | 'account';

--- a/packages/libs/chainweb-stream-client/package.json
+++ b/packages/libs/chainweb-stream-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kadena/chainweb-stream-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Chainweb-stream client for browsers and node.js",
   "keywords": [],
   "repository": {

--- a/packages/libs/chainweb-stream-client/package.json
+++ b/packages/libs/chainweb-stream-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kadena/chainweb-stream-client",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "Chainweb-stream client for browsers and node.js",
   "keywords": [],
   "repository": {

--- a/packages/libs/chainweb-stream-client/src/examples/index.ts
+++ b/packages/libs/chainweb-stream-client/src/examples/index.ts
@@ -1,5 +1,5 @@
 import type { ITransaction } from '../';
-import ChainwebStreamClient from '../';
+import { ChainwebStreamClient } from '../';
 
 const client: ChainwebStreamClient = new ChainwebStreamClient({
   // required

--- a/packages/libs/chainweb-stream-client/src/index.ts
+++ b/packages/libs/chainweb-stream-client/src/index.ts
@@ -34,7 +34,7 @@ const DEFAULT_LIMIT: number = 100;
 /**
  * @alpha
  */
-class ChainwebStream extends EventEmitter {
+export class ChainwebStreamClient extends EventEmitter {
   // chainweb network, e.g. mainnet01
   public network: string;
 
@@ -493,5 +493,3 @@ class ChainwebStream extends EventEmitter {
     this.emit('debug', debugMsg);
   }
 }
-
-export default ChainwebStream;


### PR DESCRIPTION
Default export didn't work with out CJS-targeted output

Also broke the example in the README 