### PR TITLE
feat: align icon to the right by default

### DIFF
--- a/packages/libs/react-ui/src/components/Button/Button.tsx
+++ b/packages/libs/react-ui/src/components/Button/Button.tsx
@@ -30,7 +30,7 @@ export const Button: FC<IButtonProps> = ({
   variant = 'primary',
   href,
   icon,
-  iconAlign,
+  iconAlign = 'right',
   loading,
   onClick,
   target,


### PR DESCRIPTION
Seems like the icon is primarily used like this.