### PR TITLE
fix(kadena-docs): deep link slugs with numeric values

### DIFF
--- a/packages/apps/docs/src/utils/createSlug.ts
+++ b/packages/apps/docs/src/utils/createSlug.ts
@@ -4,10 +4,12 @@ export const createSlug = (
   parentTitle = 'menu',
 ): string => {
   if (str === undefined) return '';
+
   const normalizedSlug = str
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
-    .replace(/[^\w\s]+/g, '')
+    .replace(/[^\w\-\s]+/g, '')
+    .replace(/\d+(\.\d+)?./g, '') // Remove numbers with dots
     .replace(/ /g, '-')
     .toLowerCase()
     .replace(/^-+|-+$/g, '');


### PR DESCRIPTION
The issue is with id starting with numbers. For some weird reasons, the ids starting with numbers doesn't work as expected with query selector. 

So, removing numbers and numbers with dots in slug  
