### PR TITLE
feat(client): expose WithCapability type helper

### DIFF
--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -271,6 +271,17 @@ export const readKeyset: ReadKeyset;
 // @alpha (undocumented)
 export const signWithChainweaver: ISignFunction;
 
+// Warning: (ae-forgotten-export) The symbol "ExtractCapabilityType" needs to be exported by the entry point index.d.ts
+//
+// @alpha
+export type WithCapability<TCode extends string & {
+    capability: unknown;
+}> = ExtractCapabilityType<{
+    payload: {
+        funs: [TCode];
+    };
+}>;
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/libs/client/src/commandBuilder/commandBuilder.ts
+++ b/packages/libs/client/src/commandBuilder/commandBuilder.ts
@@ -12,27 +12,17 @@ import {
   setNonce,
 } from '../composePactCommand';
 import { ValidDataTypes } from '../composePactCommand/utils/addData';
-import {
-  IGeneralCapability,
-  UnionToIntersection,
-} from '../composePactCommand/utils/addSigner';
 import { patchCommand } from '../composePactCommand/utils/patchCommand';
 import {
   ICapabilityItem,
   IContinuationPayloadObject,
   IPactCommand,
 } from '../interfaces/IPactCommand';
+import {
+  ExtractCapabilityType,
+  IGeneralCapability,
+} from '../interfaces/type-utilities';
 import { createTransaction } from '../utils/createTransaction';
-
-export type ExtractType<TCommand> = TCommand extends { payload: infer TPayload }
-  ? TPayload extends { funs: infer TFunctions }
-    ? TFunctions extends Array<infer TFunction>
-      ? UnionToIntersection<TFunction> extends { capability: infer TCapability }
-        ? TCapability
-        : IGeneralCapability
-      : IGeneralCapability
-    : IGeneralCapability
-  : IGeneralCapability;
 
 interface IAddSigner<TCommand> {
   /**
@@ -58,7 +48,9 @@ interface IAddSigner<TCommand> {
     first:
       | string
       | { pubKey: string; scheme?: 'ED25519' | 'ETH'; address?: string },
-    capability: (withCapability: ExtractType<TCommand>) => ICapabilityItem[],
+    capability: (
+      withCapability: ExtractCapabilityType<TCommand>,
+    ) => ICapabilityItem[],
   ): IBuilder<TCommand>;
 }
 

--- a/packages/libs/client/src/composePactCommand/utils/addSigner.ts
+++ b/packages/libs/client/src/composePactCommand/utils/addSigner.ts
@@ -1,4 +1,8 @@
 import { ICapabilityItem, IPactCommand } from '../../interfaces/IPactCommand';
+import {
+  ExtractCapabilityType,
+  IGeneralCapability,
+} from '../../interfaces/type-utilities';
 
 import { patchCommand } from './patchCommand';
 
@@ -59,25 +63,8 @@ export const addSigner: IAddSigner = ((
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }) as any;
 
-export type UnionToIntersection<T> = (
-  T extends unknown ? (k: T) => void : never
-) extends (k: infer I) => void
-  ? I
-  : never;
-
-export interface IGeneralCapability {
-  (name: string, ...args: unknown[]): ICapabilityItem;
-  (name: 'coin.GAS'): ICapabilityItem;
-}
-
 type ExtractType<TCmdReducer> = TCmdReducer extends (cmd: {
   payload: infer TPayload;
 }) => unknown
-  ? TPayload extends { funs: infer TFunctions }
-    ? TFunctions extends Array<infer TFunction>
-      ? UnionToIntersection<TFunction> extends { capability: infer TCapability }
-        ? TCapability
-        : IGeneralCapability
-      : IGeneralCapability
-    : IGeneralCapability
+  ? ExtractCapabilityType<{ payload: TPayload }>
   : IGeneralCapability;

--- a/packages/libs/client/src/index.ts
+++ b/packages/libs/client/src/index.ts
@@ -6,6 +6,7 @@ export * from './utils/pact-helpers';
 export * from './client';
 
 export type { IPact, IPactModules } from './pact';
+export type { WithCapability } from './interfaces/type-utilities';
 
 export { Pact } from './pact';
 

--- a/packages/libs/client/src/interfaces/type-utilities.ts
+++ b/packages/libs/client/src/interfaces/type-utilities.ts
@@ -1,0 +1,31 @@
+import { ICapabilityItem } from './IPactCommand';
+
+export type UnionToIntersection<T> = (
+  T extends unknown ? (k: T) => void : never
+) extends (k: infer I) => void
+  ? I
+  : never;
+
+export interface IGeneralCapability {
+  (name: string, ...args: unknown[]): ICapabilityItem;
+  (name: 'coin.GAS'): ICapabilityItem;
+}
+
+/**
+ * @alpha
+ * create withCapability type from a Pact.modules function
+ */
+export type WithCapability<TCode extends string & { capability: unknown }> =
+  ExtractCapabilityType<{ payload: { funs: [TCode] } }>;
+
+export type ExtractCapabilityType<TCommand> = TCommand extends {
+  payload: infer TPayload;
+}
+  ? TPayload extends { funs: infer TFunctions }
+    ? TFunctions extends Array<infer TFunction>
+      ? UnionToIntersection<TFunction> extends { capability: infer TCapability }
+        ? TCapability
+        : IGeneralCapability
+      : IGeneralCapability
+    : IGeneralCapability
+  : IGeneralCapability;

--- a/packages/libs/client/src/signing/ISignFunction.ts
+++ b/packages/libs/client/src/signing/ISignFunction.ts
@@ -2,9 +2,9 @@ import { ICommand, IUnsignedCommand } from '@kadena/types';
 
 export interface ISignFunction {
   (transaction: IUnsignedCommand): Promise<ICommand | IUnsignedCommand>;
-  (transactionList: IUnsignedCommand[]): Promise<
-    (ICommand | IUnsignedCommand)[]
-  >;
+  (
+    transactionList: IUnsignedCommand[],
+  ): Promise<(ICommand | IUnsignedCommand)[]>;
 }
 
 export interface ISignSingleFunction {

--- a/packages/libs/client/src/signing/ISignFunction.ts
+++ b/packages/libs/client/src/signing/ISignFunction.ts
@@ -2,9 +2,9 @@ import { ICommand, IUnsignedCommand } from '@kadena/types';
 
 export interface ISignFunction {
   (transaction: IUnsignedCommand): Promise<ICommand | IUnsignedCommand>;
-  (
-    transactionList: IUnsignedCommand[],
-  ): Promise<(ICommand | IUnsignedCommand)[]>;
+  (transactionList: IUnsignedCommand[]): Promise<
+    (ICommand | IUnsignedCommand)[]
+  >;
 }
 
 export interface ISignSingleFunction {


### PR DESCRIPTION
exposing `WithCapability` type utility for more flexible type supports
With the type utility users can make functions like this
```ts
const myTrWrapper = <T extends string>( pactCode:T, withCapability:WithCapability<T>) =>{
  return Pact.builder.execution(pactCode)....
}

myTrWrapper(
  Pact.modules.coin.transfer(...)
  // this also shows the proper types
  (withCapability)=>[withCapability("coin.GAS"),withCapability("coin.TRANSFER", ...)]
)
```