### PR TITLE
Use `--to` AND `--from` to determine affected packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   AFFECTED_OR_ALL: |
-    ${{ github.ref_name == 'main' && ' ' || format('--to git:origin/{0}', github.base_ref)  }}
+    ${{ github.ref_name == 'main' && ' ' || format('--to git:origin/{0} --from git:origin/{0}', github.base_ref)  }}
 
 jobs:
   build:


### PR DESCRIPTION
Packages depending on modified packages are not covered in the CI run, resulting in occasional issues only detected in the `main` branch where everything is covered.