### PR TITLE
chore(@kadena/react-ui): Update component library packages to be private

### DIFF
--- a/packages/libs/react-components/package.json
+++ b/packages/libs/react-components/package.json
@@ -2,6 +2,7 @@
   "name": "@kadena/react-components",
   "version": "0.0.1",
   "description": "A react component library built on Kadena's Design System",
+  "private": true,
   "license": "ISC",
   "author": "",
   "main": "dist/cjs/index.js",

--- a/packages/libs/react-ui/package.json
+++ b/packages/libs/react-ui/package.json
@@ -2,6 +2,7 @@
   "name": "@kadena/react-ui",
   "version": "0.0.1",
   "description": "A react component library built on Kadena's Design System",
+  "private": true,
   "license": "ISC",
   "author": "",
   "exports": {


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->

Since we are not yet publishing `@kadena/react-ui` and we will not publish `@kadena/react-components`, I've set them to `private` on their package.json files
