### PR TITLE
Move sort-package-json to eslint plugin + fix some issues

### DIFF
--- a/common/autoinstallers/rush-command-packages/package.json
+++ b/common/autoinstallers/rush-command-packages/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "prettier": "^2.7.1",
-    "prettier-quick": "^0.0.5",
-    "sort-package-json": "^1.57.0"
+    "prettier-quick": "^0.0.5"
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -72,7 +72,6 @@ importers:
       remark-frontmatter: ~4.0.1
       remark-gfm: ~3.0.1
       shiki: ~0.14.2
-      sort-package-json: ~2.5.1
       start-server-and-test: ~2.0.0
       storybook: ^7.1.0
       storybook-addon-next-router: ~4.0.2
@@ -147,7 +146,6 @@ importers:
       micromark-extension-frontmatter: 1.1.1
       openapi-types: 12.1.3
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       start-server-and-test: 2.0.0
       storybook: 7.1.1
       storybook-addon-next-router: 4.0.2_0ca6ca25c5ea2ad27b6486771f5b5a10
@@ -178,7 +176,6 @@ importers:
       json-bigint-patch: ~0.0.8
       prettier: ~3.0.0
       prisma: ^4.7.1
-      sort-package-json: ~2.5.1
     dependencies:
       '@pothos/core': 3.24.1_graphql@16.6.0
       '@pothos/plugin-prisma': 3.39.0_35c94ca9266326f27acb70dd7a773b89
@@ -203,7 +200,6 @@ importers:
       '@types/node': 16.18.39
       embedded-postgres: 15.1.0-beta.6
       prettier: 3.0.0
-      sort-package-json: 2.5.1
 
   ../../packages/apps/graph-client:
     specifiers:
@@ -234,7 +230,6 @@ importers:
       prettier: ~3.0.0
       react: ^18.2.0
       react-dom: ^18.2.0
-      sort-package-json: ~2.5.1
       ts-node: ~10.8.2
       typescript: 5.1.6
     dependencies:
@@ -267,7 +262,6 @@ importers:
       '@types/node': 16.18.39
       concurrently: 7.6.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       ts-node: 10.8.2_bee6d155ee52407d1d9e0dd2c7ed07f0
 
   ../../packages/apps/immutable-records:
@@ -276,6 +270,7 @@ importers:
       '@kadena-dev/heft-rig': workspace:*
       '@kadena-dev/markdown': workspace:*
       '@kadena/react-ui': workspace:*
+      '@rushstack/eslint-config': ~3.3.0
       '@types/gtag.js': ~0.0.12
       '@types/heft-jest': ~1.0.3
       '@types/node': ^16.0.0
@@ -289,13 +284,10 @@ importers:
       prettier: ~3.0.0
       react: ^18.2.0
       react-dom: ^18.2.0
-      sort-package-json: ~2.5.1
       typescript: 5.1.6
     dependencies:
       '@kadena/react-ui': link:../../libs/react-ui
       '@vanilla-extract/css': 1.12.0
-      eslint: 8.45.0
-      eslint-config-next: 13.4.5_eslint@8.45.0+typescript@5.1.6
       next: 13.4.5_react-dom@18.2.0+react@18.2.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -303,14 +295,16 @@ importers:
       '@kadena-dev/eslint-config': link:../../tools/eslint-config
       '@kadena-dev/heft-rig': link:../../tools/heft-rig
       '@kadena-dev/markdown': link:../../tools/remark-plugins
+      '@rushstack/eslint-config': 3.3.2_eslint@8.45.0+typescript@5.1.6
       '@types/gtag.js': 0.0.12
       '@types/heft-jest': 1.0.3
       '@types/node': 16.18.39
       '@types/react': 18.2.17
       '@types/react-dom': 18.2.7
       '@vanilla-extract/next-plugin': 2.1.2_@types+node@16.18.39+next@13.4.5
+      eslint: 8.45.0
+      eslint-config-next: 13.4.5_eslint@8.45.0+typescript@5.1.6
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       typescript: 5.1.6
 
   ../../packages/apps/tools:
@@ -371,7 +365,6 @@ importers:
       react-dom: ^18.2.0
       react-hook-form: ~7.45.0
       react-scripts: 5.0.1
-      sort-package-json: ~2.5.1
       typescript: 5.1.6
       zod: ~3.18.0
     dependencies:
@@ -433,7 +426,6 @@ importers:
       jest-environment-jsdom: 29.6.2
       next-translate-plugin: 2.0.5_next-translate@2.0.6
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       typescript: 5.1.6
 
   ../../packages/libs/bootstrap-lib:
@@ -453,7 +445,6 @@ importers:
       eslint: ^8.45.0
       node-fetch: ~2.6.2
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
     dependencies:
       '@kadena/cryptography-utils': link:../cryptography-utils
       '@kadena/pactjs': link:../pactjs
@@ -471,7 +462,6 @@ importers:
       '@types/node': 16.18.39
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
 
   ../../packages/libs/chainweb-node-client:
     specifiers:
@@ -490,7 +480,6 @@ importers:
       eslint: ^8.45.0
       node-fetch: ~2.6.2
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
     dependencies:
       '@kadena/cryptography-utils': link:../cryptography-utils
       '@kadena/pactjs': link:../pactjs
@@ -508,7 +497,6 @@ importers:
       '@types/node': 16.18.39
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
 
   ../../packages/libs/chainweb-stream-client:
     specifiers:
@@ -524,7 +512,6 @@ importers:
       eventemitter2: ~6.4.9
       eventsource: ~2.0.2
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
     dependencies:
       eventemitter2: 6.4.9
       eventsource: 2.0.2
@@ -539,7 +526,6 @@ importers:
       '@types/node': 16.18.39
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
 
   ../../packages/libs/chainwebjs:
     specifiers:
@@ -558,7 +544,6 @@ importers:
       node-fetch: ~2.6.2
       p-retry: ^4.5.0
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
       typescript: 5.1.6
     dependencies:
       base64url: 3.0.1
@@ -577,7 +562,6 @@ importers:
       '@types/node': 16.18.39
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       typescript: 5.1.6
 
   ../../packages/libs/client:
@@ -602,7 +586,6 @@ importers:
       encoding: ~0.1.13
       eslint: ^8.45.0
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
       ts-node: ~10.8.2
       yaml: ~2.1.1
     dependencies:
@@ -628,7 +611,6 @@ importers:
       '@types/node': 16.18.39
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       ts-node: 10.8.2_@types+node@16.18.39
 
   ../../packages/libs/client-examples:
@@ -652,7 +634,6 @@ importers:
       node-fetch: ~2.6.2
       npm-run-all: ~4.1.5
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
       ts-node: ~10.8.2
       typescript: 5.1.6
     dependencies:
@@ -676,7 +657,6 @@ importers:
       node-fetch: 2.6.12
       npm-run-all: 4.1.5
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       ts-node: 10.8.2_bee6d155ee52407d1d9e0dd2c7ed07f0
       typescript: 5.1.6
 
@@ -694,7 +674,6 @@ importers:
       buffer: ^6.0.3
       eslint: ^8.45.0
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
       tweetnacl: ^1.0.3
     dependencies:
       '@kadena/types': link:../types
@@ -711,7 +690,6 @@ importers:
       '@types/node': 16.18.39
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
 
   ../../packages/libs/kadena.js:
     specifiers:
@@ -730,7 +708,6 @@ importers:
       node-fetch: ~2.6.2
       prettier: ~3.0.0
       serve: ^13.0.2
-      sort-package-json: ~2.5.1
       ts-loader: ^9.3.0
       tweetnacl: ^1.0.3
       webpack: ~5.88.2
@@ -754,7 +731,6 @@ importers:
       eslint: 8.45.0
       prettier: 3.0.0
       serve: 13.0.4
-      sort-package-json: 2.5.1
       ts-loader: 9.4.4_webpack@5.88.2
       webpack-cli: 4.10.0_webpack@5.88.2
 
@@ -771,7 +747,6 @@ importers:
       bignumber.js: ^9.0.2
       eslint: ^8.45.0
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
     dependencies:
       '@kadena/types': link:../types
       bignumber.js: 9.1.1
@@ -785,7 +760,6 @@ importers:
       '@types/node': 16.18.39
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
 
   ../../packages/libs/pactjs-generator:
     specifiers:
@@ -807,7 +781,6 @@ importers:
       node-fetch: ~2.6.2
       npm-run-all: ~4.1.5
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
       ts-node: ~10.8.2
       typescript: 5.1.6
       yaml: ~2.1.1
@@ -832,7 +805,6 @@ importers:
       node-fetch: 2.6.12
       npm-run-all: 4.1.5
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       ts-node: 10.8.2_bee6d155ee52407d1d9e0dd2c7ed07f0
       typescript: 5.1.6
 
@@ -867,7 +839,6 @@ importers:
       prettier: ~3.0.0
       react: ^18.2.0
       react-dom: ^18.2.0
-      sort-package-json: ~2.5.1
       storybook: ^7.1.0
       storybook-dark-mode: ^3.0.0
       typescript: 5.1.6
@@ -902,7 +873,6 @@ importers:
       '@types/react': 18.2.17
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       storybook: 7.1.1
       storybook-dark-mode: 3.0.1_react-dom@18.2.0+react@18.2.0
       typescript: 5.1.6
@@ -966,7 +936,6 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       rimraf: ~5.0.1
-      sort-package-json: ~2.5.1
       storybook: ^7.1.0
       storybook-dark-mode: ^3.0.0
       ts-jest: ~29.1.0
@@ -1033,7 +1002,6 @@ importers:
       prettier: 3.0.0
       prop-types: 15.8.1
       rimraf: 5.0.1
-      sort-package-json: 2.5.1
       storybook: 7.1.1
       storybook-dark-mode: 3.0.1_react-dom@18.2.0+react@18.2.0
       ts-jest: 29.1.1_7df7dfaee045968e110d7bd13ce2d718
@@ -1052,7 +1020,6 @@ importers:
       '@types/heft-jest': ~1.0.3
       eslint: ^8.45.0
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
       typescript: 5.1.6
     devDependencies:
       '@kadena-dev/eslint-config': link:../../tools/eslint-config
@@ -1063,7 +1030,6 @@ importers:
       '@types/heft-jest': 1.0.3
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       typescript: 5.1.6
 
   ../../packages/tools/cookbook:
@@ -1082,7 +1048,6 @@ importers:
       '@types/node': ^16.0.0
       eslint: ^8.45.0
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
       ts-node: ~10.8.2
     dependencies:
       '@kadena/chainweb-node-client': link:../../libs/chainweb-node-client
@@ -1100,7 +1065,6 @@ importers:
       '@types/node': 16.18.39
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       ts-node: 10.8.2_@types+node@16.18.39
 
   ../../packages/tools/create-kadena-app:
@@ -1123,7 +1087,6 @@ importers:
       eslint: ^8.45.0
       prettier: ~3.0.0
       rimraf: ~5.0.1
-      sort-package-json: ~2.5.1
       ts-node: ~10.8.2
       yaml: ~2.1.1
     dependencies:
@@ -1147,7 +1110,6 @@ importers:
       eslint: 8.45.0
       prettier: 3.0.0
       rimraf: 5.0.1
-      sort-package-json: 2.5.1
       ts-node: 10.8.2_@types+node@16.18.39
 
   ../../packages/tools/eslint-config:
@@ -1162,13 +1124,13 @@ importers:
       eslint-config-prettier: ~8.8.0
       eslint-import-resolver-typescript: 3.5.5
       eslint-plugin-import: ~2.27.5
+      eslint-plugin-json-files: ~3.0.0
       eslint-plugin-jsx-a11y: ~6.7.1
       eslint-plugin-prettier: 5.0.0
       eslint-plugin-react: ~7.31.11
       eslint-plugin-simple-import-sort: ~7.0.0
       prettier: ~3.0.0
       prettier-eslint: ~12.0.0
-      sort-package-json: ~2.5.1
       typescript: 5.1.6
     dependencies:
       '@kadena-dev/eslint-plugin': link:../eslint-plugin
@@ -1181,6 +1143,7 @@ importers:
       eslint-config-prettier: 8.8.0_eslint@8.45.0
       eslint-import-resolver-typescript: 3.5.5_59236bfd07d3fab2f40480f5c7b98a36
       eslint-plugin-import: 2.27.5_eslint@8.45.0
+      eslint-plugin-json-files: 3.0.0_eslint@8.45.0
       eslint-plugin-jsx-a11y: 6.7.1_eslint@8.45.0
       eslint-plugin-prettier: 5.0.0_c24cc8714b409a32d52e473ae12ac757
       eslint-plugin-react: 7.31.11_eslint@8.45.0
@@ -1188,7 +1151,6 @@ importers:
       prettier: 3.0.0
       prettier-eslint: 12.0.0
     devDependencies:
-      sort-package-json: 2.5.1
       typescript: 5.1.6
 
   ../../packages/tools/eslint-plugin:
@@ -1198,7 +1160,6 @@ importers:
       '@typescript-eslint/experimental-utils': ~5.53.0
       eslint: ^8.45.0
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
       typescript: 5.1.6
     dependencies:
       '@rushstack/eslint-plugin': 0.11.0_eslint@8.45.0+typescript@5.1.6
@@ -1207,7 +1168,6 @@ importers:
     devDependencies:
       '@rushstack/heft': 0.50.7
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       typescript: 5.1.6
 
   ../../packages/tools/heft-rig:
@@ -1222,7 +1182,6 @@ importers:
       eslint: ^8.45.0
       jest-environment-node: ~27.4.2
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
       typescript: 5.1.6
     dependencies:
       '@microsoft/api-extractor': 7.35.4
@@ -1237,7 +1196,6 @@ importers:
       '@types/heft-jest': 1.0.3
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
 
   ../../packages/tools/integration-tests:
     specifiers:
@@ -1255,7 +1213,6 @@ importers:
       exponential-backoff: ^3.1.0
       kadena.js: workspace:*
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
     dependencies:
       '@kadena/chainweb-node-client': link:../../libs/chainweb-node-client
       '@kadena/pactjs': link:../../libs/pactjs
@@ -1272,7 +1229,6 @@ importers:
       concurrently: 7.6.0
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
 
   ../../packages/tools/kda-cli:
     specifiers:
@@ -1296,7 +1252,6 @@ importers:
       meow: ^11.0.0
       prettier: ~3.0.0
       react: ^18.2.0
-      sort-package-json: ~2.5.1
       ts-node: ~10.8.2
       typescript: 5.1.6
       yaml: ~2.1.1
@@ -1323,7 +1278,6 @@ importers:
       eslint: 8.45.0
       ink-testing-library: 3.0.0_@types+react@18.2.17
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       ts-node: 10.8.2_bee6d155ee52407d1d9e0dd2c7ed07f0
       typescript: 5.1.6
 
@@ -1347,7 +1301,6 @@ importers:
       mkdirp: ~1.0.4
       prettier: ~3.0.0
       rimraf: ~5.0.1
-      sort-package-json: ~2.5.1
       yaml: ~2.1.1
       zod: ~3.18.0
     dependencies:
@@ -1372,7 +1325,6 @@ importers:
       '@types/rimraf': 3.0.2
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
 
   ../../packages/tools/remark-plugins:
     specifiers:
@@ -1392,7 +1344,6 @@ importers:
       remark-parse: ^10.0.2
       remark-prettier: ^2.0.0
       remark-reference-links: ^6.0.1
-      sort-package-json: ~2.5.1
       strip-json-comments: ^5.0.0
       typescript: 5.1.6
       unified: ^10.1.2
@@ -1418,7 +1369,6 @@ importers:
       '@types/node': 16.18.39
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
       typescript: 5.1.6
       unified: 10.1.2
       vfile: 5.3.7
@@ -1437,7 +1387,6 @@ importers:
       inquirer: ^9.2.6
       jsonc-parser: ~3.2.0
       prettier: ~3.0.0
-      sort-package-json: ~2.5.1
     dependencies:
       execa: 7.2.0
       inquirer: 9.2.8
@@ -1452,7 +1401,6 @@ importers:
       '@types/node': 16.18.39
       eslint: 8.45.0
       prettier: 3.0.0
-      sort-package-json: 2.5.1
 
 packages:
 
@@ -5482,6 +5430,11 @@ packages:
   /@humanwhocodes/module-importer/1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
+
+  /@humanwhocodes/momoa/2.0.4:
+    resolution: {integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==}
+    engines: {node: '>=10.10.0'}
+    dev: false
 
   /@humanwhocodes/object-schema/1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
@@ -9669,6 +9622,13 @@ packages:
     resolution: {integrity: sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==}
     dev: true
 
+  /@types/glob/7.2.0:
+    resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
+    dependencies:
+      '@types/minimatch': 5.1.2
+      '@types/node': 16.18.39
+    dev: false
+
   /@types/glob/8.1.0:
     resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
@@ -12221,6 +12181,20 @@ packages:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
     dev: true
 
+  /better-ajv-errors/1.2.0_ajv@8.12.0:
+    resolution: {integrity: sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA==}
+    engines: {node: '>= 12.13.0'}
+    peerDependencies:
+      ajv: 4.11.8 - 8
+    dependencies:
+      '@babel/code-frame': 7.22.5
+      '@humanwhocodes/momoa': 2.0.4
+      ajv: 8.12.0
+      chalk: 4.1.2
+      jsonpointer: 5.0.1
+      leven: 3.1.0
+    dev: false
+
   /better-opn/3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
@@ -14008,12 +13982,6 @@ packages:
   /detect-indent/6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
-    dev: true
-
-  /detect-indent/7.0.1:
-    resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
-    engines: {node: '>=12.20'}
-    dev: true
 
   /detect-libc/2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
@@ -14024,11 +13992,6 @@ packages:
   /detect-newline/3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
-
-  /detect-newline/4.0.0:
-    resolution: {integrity: sha512-1aXUEPdfGdzVPFpzGJJNgq9o81bGg1s09uxTWsqBlo9PI332uyJRQq13+LK/UN4JfxJbFdCXonUFQ9R/p7yCtw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: true
 
   /detect-node/2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
@@ -14828,6 +14791,20 @@ packages:
       - supports-color
       - typescript
     dev: true
+
+  /eslint-plugin-json-files/3.0.0_eslint@8.45.0:
+    resolution: {integrity: sha512-sv9ma6T1i9VxB6WqciiO9mzHxToF+hxeN4rwxGtew75uPTiSAI0E9Zyw4YsCz6p7WJD5XeRpV0JeG7YokI6MOg==}
+    engines: {node: '>=16.13'}
+    peerDependencies:
+      eslint: '>=5'
+    dependencies:
+      ajv: 8.12.0
+      better-ajv-errors: 1.2.0_ajv@8.12.0
+      eslint: 8.45.0
+      requireindex: 1.2.0
+      semver: 7.5.4
+      sort-package-json: 1.57.0
+    dev: false
 
   /eslint-plugin-jsx-a11y/6.7.1_eslint@8.45.0:
     resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
@@ -16106,11 +16083,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /get-stdin/9.0.0:
-    resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
-    engines: {node: '>=12'}
-    dev: true
-
   /get-stream/4.1.0:
     resolution: {integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==}
     engines: {node: '>=6'}
@@ -16168,9 +16140,9 @@ packages:
       - supports-color
     dev: true
 
-  /git-hooks-list/3.1.0:
-    resolution: {integrity: sha512-LF8VeHeR7v+wAbXqfgRlTSX/1BJR9Q1vEMR8JAz1cEg6GX07+zyj3sAdDvYjj/xnlIfVuGgj4qBei1K3hKH+PA==}
-    dev: true
+  /git-hooks-list/1.0.3:
+    resolution: {integrity: sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==}
+    dev: false
 
   /github-slugger/1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
@@ -16297,6 +16269,20 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       define-properties: 1.2.0
+
+  /globby/10.0.0:
+    resolution: {integrity: sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/glob': 7.2.0
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.1
+      glob: 7.2.3
+      ignore: 5.2.4
+      merge2: 1.4.1
+      slash: 3.0.0
+    dev: false
 
   /globby/11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -17397,6 +17383,11 @@ packages:
   /is-plain-obj/1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /is-plain-obj/2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
     dev: false
 
   /is-plain-obj/3.0.0:
@@ -23643,7 +23634,6 @@ packages:
   /requireindex/1.2.0:
     resolution: {integrity: sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==}
     engines: {node: '>=0.10.5'}
-    dev: true
 
   /requires-port/1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -24347,20 +24337,19 @@ packages:
 
   /sort-object-keys/1.1.3:
     resolution: {integrity: sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==}
-    dev: true
+    dev: false
 
-  /sort-package-json/2.5.1:
-    resolution: {integrity: sha512-vx/KoZxm8YNMUqdlw7SGTfqR5pqZ/sUfgOuRtDILiOy/3AvzhAibyUe2cY3OpLs3oRSow9up4yLVtQaM24rbDQ==}
+  /sort-package-json/1.57.0:
+    resolution: {integrity: sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==}
     hasBin: true
     dependencies:
-      detect-indent: 7.0.1
-      detect-newline: 4.0.0
-      get-stdin: 9.0.0
-      git-hooks-list: 3.1.0
-      globby: 13.2.2
-      is-plain-obj: 4.1.0
+      detect-indent: 6.1.0
+      detect-newline: 3.1.0
+      git-hooks-list: 1.0.3
+      globby: 10.0.0
+      is-plain-obj: 2.1.0
       sort-object-keys: 1.1.3
-    dev: true
+    dev: false
 
   /source-list-map/2.0.1:
     resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "6ec749d9e201c95271b6770de6938adc98d3d5c3",
+  "pnpmShrinkwrapHash": "59446cd98644173d72e58aba24efc5c9e3ced2fc",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/apps/docs/package.json
+++ b/packages/apps/docs/package.json
@@ -20,9 +20,8 @@
     "dev": "npm run build:scripts && next dev",
     "format": "npm run format:pkg && npm run format:src",
     "format:ci": "prettier config cypress src --check",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config cypress src --write",
-    "lint": "eslint ./src --ext .js,.ts,.jsx,.tsx,.mjs --fix",
+    "lint": "eslint package.json src --ext .js,.ts,.jsx,.tsx,.mjs --fix",
     "start": "next start",
     "storybook": "storybook dev -p 6006",
     "test": "echo 'No tests, until there is time to debug the build'"
@@ -96,7 +95,6 @@
     "micromark-extension-frontmatter": "~1.1.0",
     "openapi-types": "~12.1.3",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "start-server-and-test": "~2.0.0",
     "storybook": "^7.1.0",
     "storybook-addon-next-router": "~4.0.2",

--- a/packages/apps/graph-client/package.json
+++ b/packages/apps/graph-client/package.json
@@ -8,11 +8,10 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
     "generate:sdk": "graphql-codegen --config codegen-sdk.yml",
     "postinstall": "npm run generate:sdk",
-    "lint": "eslint ./src --fix",
+    "lint": "eslint package.json src --fix",
     "next:dev": "next dev",
     "start": "next start",
     "start:graph": "cd ../graph && rushx start",
@@ -49,7 +48,6 @@
     "@types/node": "^16.0.0",
     "concurrently": "^7.2.2",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "ts-node": "~10.8.2"
   }
 }

--- a/packages/apps/graph/package.json
+++ b/packages/apps/graph/package.json
@@ -10,9 +10,8 @@
     "build": "",
     "format": "npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "prisma:generate": "prisma generate",
     "prisma:pull": "prisma db pull",
     "start": "npm run prisma:generate && npx ts-node-dev --respawn --no-notify --exit-child src/index.ts",
@@ -42,7 +41,6 @@
     "@types/heft-jest": "~1.0.3",
     "@types/node": "^16.0.0",
     "embedded-postgres": "~15.1.0-beta.6",
-    "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1"
+    "prettier": "~3.0.0"
   }
 }

--- a/packages/apps/immutable-records/package.json
+++ b/packages/apps/immutable-records/package.json
@@ -8,19 +8,15 @@
     "format": "npm run format:pkg && npm run format:src && npm run format:md",
     "format:ci": "prettier src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier src --write",
-    "lint": "next lint",
+    "lint": "eslint package.json src --ext .ts,.tsx, --fix",
     "next_build": "next build",
-    "precommit": "rush update && rush lint -t @kadena/immutable-records && rush build -t @kadena/immutable-records",
     "start": "next start",
     "test": "echo 'boilerplate'"
   },
   "dependencies": {
-    "@vanilla-extract/css": "1.12.0",
-    "eslint": "^8.45.0",
-    "eslint-config-next": "13.4.5",
     "@kadena/react-ui": "workspace:*",
+    "@vanilla-extract/css": "1.12.0",
     "next": "13.4.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -29,14 +25,16 @@
     "@kadena-dev/eslint-config": "workspace:*",
     "@kadena-dev/heft-rig": "workspace:*",
     "@kadena-dev/markdown": "workspace:*",
+    "@rushstack/eslint-config": "~3.3.0",
     "@types/gtag.js": "~0.0.12",
     "@types/heft-jest": "~1.0.3",
     "@types/node": "^16.0.0",
     "@types/react": "^18.2.15",
     "@types/react-dom": "18.2.7",
     "@vanilla-extract/next-plugin": "2.1.2",
+    "eslint": "^8.45.0",
+    "eslint-config-next": "13.4.5",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "typescript": "5.1.6"
   }
 }

--- a/packages/apps/tools/package.json
+++ b/packages/apps/tools/package.json
@@ -9,17 +9,17 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier locales src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier locales src --write",
     "generate:coin:contract": "npx @kadena/pactjs-cli contract-generate --contract coin --api https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/1/pact --chain 1 --network testnet",
     "generate:contracts": "npm run generate:coin:contract && npm run generate:faucet:contract",
     "generate:faucet:contract": "npx @kadena/pactjs-cli contract-generate --contract user.coin-faucet --api https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/1/pact --chain 1 --network testnet",
     "generate:icons": "npx @svgr/cli --typescript --out-dir src/resources/svg/generated -- src/resources/svg",
-    "lint": "eslint ./src --fix",
+    "lint": "eslint package.json src --ext .ts,.tsx, --fix",
     "start": "next start",
     "test": "jest --silent"
   },
   "dependencies": {
+    "@hookform/resolvers": "~3.1.1",
     "@kadena/chainweb-node-client": "0.4.1",
     "@kadena/client": "0.6.1",
     "@kadena/cryptography-utils": "workspace:*",
@@ -29,6 +29,7 @@
     "@radix-ui/colors": "~0.1.8",
     "@stitches/react": "1.3.1-1",
     "ace-builds": "~1.22.1",
+    "classnames": "^2.3.1",
     "jest-standard-reporter": "~2.0.0",
     "js-cookie": "~3.0.5",
     "next": "13.4.5",
@@ -37,12 +38,9 @@
     "react": "^18.2.0",
     "react-ace": "~10.1.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1",
     "react-hook-form": "~7.45.0",
-    "@hookform/resolvers": "~3.1.1",
-    "zod": "~3.18.0",
     "react-scripts": "5.0.1",
-    "classnames": "^2.3.1"
+    "zod": "~3.18.0"
   },
   "devDependencies": {
     "@jest/reporters": "~29.5.0",
@@ -80,7 +78,6 @@
     "jest-environment-jsdom": "~29.6.1",
     "next-translate-plugin": "~2.0.5",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "typescript": "5.1.6"
   },
   "volta": {

--- a/packages/apps/tools/src/components/Common/Layout/partials/Sidebar/MenuButton.tsx
+++ b/packages/apps/tools/src/components/Common/Layout/partials/Sidebar/MenuButton.tsx
@@ -4,8 +4,7 @@ import { gridMiniMenuListButtonStyle } from './styles.css';
 
 import classNames from 'classnames';
 import Link from 'next/link';
-import React, { FC, useRef } from 'react';
-import { ButtonHTMLAttributes } from 'react/index';
+import React, { ButtonHTMLAttributes, FC, useRef } from 'react';
 
 export interface IMenuButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {

--- a/packages/libs/bootstrap-lib/package.json
+++ b/packages/libs/bootstrap-lib/package.json
@@ -34,9 +34,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "test": "heft test"
   },
   "dependencies": {
@@ -56,7 +55,6 @@
     "@types/heft-jest": "~1.0.3",
     "@types/node": "^16.0.0",
     "eslint": "^8.45.0",
-    "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1"
+    "prettier": "~3.0.0"
   }
 }

--- a/packages/libs/chainweb-node-client/package.json
+++ b/packages/libs/chainweb-node-client/package.json
@@ -34,11 +34,10 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config openapi src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config openapi src --write",
     "generate:openapi-types": "echo 'openapi specs needs fixes' # openapi-typescript \"./openapi/*.json\" --output ./src/openapi",
     "postinstall": "npm run generate:openapi-types",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "test": "heft test"
   },
   "dependencies": {
@@ -58,7 +57,6 @@
     "@types/heft-jest": "~1.0.3",
     "@types/node": "^16.0.0",
     "eslint": "^8.45.0",
-    "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1"
+    "prettier": "~3.0.0"
   }
 }

--- a/packages/libs/chainweb-stream-client/package.json
+++ b/packages/libs/chainweb-stream-client/package.json
@@ -28,9 +28,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "test": "heft test"
   },
   "dependencies": {
@@ -47,7 +46,6 @@
     "@types/heft-jest": "~1.0.3",
     "@types/node": "^16.0.0",
     "eslint": "^8.45.0",
-    "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1"
+    "prettier": "~3.0.0"
   }
 }

--- a/packages/libs/chainwebjs/package.json
+++ b/packages/libs/chainwebjs/package.json
@@ -52,10 +52,9 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
     "preinstall": "npx only-allow pnpm",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "test": "heft test"
   },
   "dependencies": {
@@ -76,7 +75,6 @@
     "@types/node": "^16.0.0",
     "eslint": "^8.45.0",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "typescript": "5.1.6"
   }
 }

--- a/packages/libs/client-examples/package.json
+++ b/packages/libs/client-examples/package.json
@@ -17,9 +17,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts,.json --fix",
     "pactjs:generate:contract:file": "pactjs contract-generate --file src/example-contract/coin.contract.pact && pactjs contract-generate --file src/example-contract/marmalade.module.pact",
     "pactjs:generate:contract:chain": "pactjs contract-generate --contract coin --api https://api.chainweb.com/chainweb/0.0/mainnet01/chain/0/pact;",
     "pactjs:generate:contract:crowdfund": "pactjs contract-generate --contract=free.crowdfund --api=https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/0/pact",
@@ -47,7 +46,6 @@
     "node-fetch": "~2.6.2",
     "npm-run-all": "~4.1.5",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "ts-node": "~10.8.2",
     "typescript": "5.1.6"
   }

--- a/packages/libs/client/package.json
+++ b/packages/libs/client/package.json
@@ -25,9 +25,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "pactjs:generate:contract": "pactjs contract-generate --file contracts/coin.contract.pact",
     "pactjs:retrieve:contract": "pactjs retrieve-contract --out contracts/coin.contract.pact --module coin",
     "start": "ts-node --transpile-only src/index.ts",
@@ -57,7 +56,6 @@
     "@types/node": "^16.0.0",
     "eslint": "^8.45.0",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "ts-node": "~10.8.2"
   }
 }

--- a/packages/libs/cryptography-utils/package.json
+++ b/packages/libs/cryptography-utils/package.json
@@ -34,9 +34,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "test": "heft test"
   },
   "dependencies": {
@@ -55,7 +54,6 @@
     "@types/heft-jest": "~1.0.3",
     "@types/node": "^16.0.0",
     "eslint": "^8.45.0",
-    "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1"
+    "prettier": "~3.0.0"
   }
 }

--- a/packages/libs/kadena.js/package.json
+++ b/packages/libs/kadena.js/package.json
@@ -47,9 +47,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "serve-coverage": "python -m SimpleHTTPServer",
     "test": "heft test"
   },
@@ -73,7 +72,6 @@
     "eslint": "^8.45.0",
     "prettier": "~3.0.0",
     "serve": "^13.0.2",
-    "sort-package-json": "~2.5.1",
     "ts-loader": "^9.3.0",
     "webpack-cli": "^4.9.2"
   },

--- a/packages/libs/pactjs-generator/package.json
+++ b/packages/libs/pactjs-generator/package.json
@@ -26,9 +26,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "start": "ts-node --transpile-only src/index.ts",
     "test": "heft test"
   },
@@ -54,7 +53,6 @@
     "node-fetch": "~2.6.2",
     "npm-run-all": "~4.1.5",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "ts-node": "~10.8.2",
     "typescript": "5.1.6"
   }

--- a/packages/libs/pactjs/package.json
+++ b/packages/libs/pactjs/package.json
@@ -34,9 +34,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "test": "heft test"
   },
   "dependencies": {
@@ -52,7 +51,6 @@
     "@types/heft-jest": "~1.0.3",
     "@types/node": "^16.0.0",
     "eslint": "^8.45.0",
-    "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1"
+    "prettier": "~3.0.0"
   }
 }

--- a/packages/libs/react-components/package.json
+++ b/packages/libs/react-components/package.json
@@ -18,9 +18,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts,.tsx --fix",
+    "lint": "eslint package.json src --ext .js,.ts,.tsx --fix",
     "storybook": "storybook dev -p 6006",
     "test": "rushx build:test && heft test"
   },
@@ -56,7 +55,6 @@
     "@types/react": "^18.2.15",
     "eslint": "^8.45.0",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "storybook": "^7.1.0",
     "storybook-dark-mode": "^3.0.0",
     "typescript": "5.1.6"

--- a/packages/libs/react-ui/package.json
+++ b/packages/libs/react-ui/package.json
@@ -31,9 +31,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier src --write",
-    "lint": "eslint ./src --ext .js,.ts,.tsx --fix",
+    "lint": "eslint package.json src --ext .js,.ts,.tsx --fix",
     "storybook": "storybook dev -p 6006",
     "test": "jest --silent"
   },
@@ -97,7 +96,6 @@
     "prettier": "~3.0.0",
     "prop-types": "^15.8.1",
     "rimraf": "~5.0.1",
-    "sort-package-json": "~2.5.1",
     "storybook": "^7.1.0",
     "storybook-dark-mode": "^3.0.0",
     "ts-jest": "~29.1.0",

--- a/packages/libs/types/package.json
+++ b/packages/libs/types/package.json
@@ -34,9 +34,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "test": "heft test"
   },
   "devDependencies": {
@@ -48,7 +47,6 @@
     "@types/heft-jest": "~1.0.3",
     "eslint": "^8.45.0",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "typescript": "5.1.6"
   }
 }

--- a/packages/tools/cookbook/package.json
+++ b/packages/tools/cookbook/package.json
@@ -13,9 +13,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts,.json --fix",
     "pactjs:generate:contract": "pactjs contract-generate --file contracts/coin.contract.pact",
     "pactjs:retrieve:contract": "pactjs retrieve-contract --out contracts/coin.contract.pact --module coin",
     "test": ""
@@ -37,7 +36,6 @@
     "@types/node": "^16.0.0",
     "eslint": "^8.45.0",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "ts-node": "~10.8.2"
   }
 }

--- a/packages/tools/create-kadena-app/package.json
+++ b/packages/tools/create-kadena-app/package.json
@@ -20,9 +20,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src templates --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src templates --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "start": "ts-node --transpile-only src/index.ts",
     "test": "rimraf test-* && heft test && cross-env NG_CLI_ANALYTICS=false ./scripts/generate-test.sh"
   },
@@ -48,7 +47,6 @@
     "eslint": "^8.45.0",
     "prettier": "~3.0.0",
     "rimraf": "~5.0.1",
-    "sort-package-json": "~2.5.1",
     "ts-node": "~10.8.2"
   }
 }

--- a/packages/tools/eslint-config/package.json
+++ b/packages/tools/eslint-config/package.json
@@ -11,7 +11,6 @@
     "build": "",
     "format": "npm run format:pkg && npm run format:src",
     "format:ci": "prettier mixins profile --check",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier mixins profile --write",
     "lint": "eslint ./mixins ./profile --ext .js,.ts --fix",
     "test": ""
@@ -32,10 +31,10 @@
     "eslint-plugin-react": "~7.31.11",
     "eslint-plugin-simple-import-sort": "~7.0.0",
     "prettier": "~3.0.0",
-    "prettier-eslint": "~12.0.0"
+    "prettier-eslint": "~12.0.0",
+    "eslint-plugin-json-files": "~3.0.0"
   },
   "devDependencies": {
-    "sort-package-json": "~2.5.1",
     "typescript": "5.1.6"
   }
 }

--- a/packages/tools/eslint-config/profile/lib.js
+++ b/packages/tools/eslint-config/profile/lib.js
@@ -30,6 +30,7 @@ module.exports = {
     'import',
     'simple-import-sort',
     'prettier',
+    'json-files',
   ],
   rules: {
     '@kadena-dev/no-eslint-disable': 'error',
@@ -37,6 +38,7 @@ module.exports = {
     'prefer-template': 'warn',
     'import/newline-after-import': 'error',
     'import/no-unresolved': 'error',
+    'json-files/sort-package-json': 'error',
   },
   settings: {
     'import/parsers': {

--- a/packages/tools/eslint-plugin/package.json
+++ b/packages/tools/eslint-plugin/package.json
@@ -9,7 +9,6 @@
     "build": "heft build --clean",
     "format": "npm run format:pkg && npm run format:src",
     "format:ci": "prettier src --check",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier src --write",
     "test": "heft test"
   },
@@ -21,7 +20,6 @@
   "devDependencies": {
     "@rushstack/heft": "~0.50.6",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "typescript": "5.1.6"
   }
 }

--- a/packages/tools/heft-rig/package.json
+++ b/packages/tools/heft-rig/package.json
@@ -11,7 +11,6 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier profiles --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier profiles --write",
     "test": ""
   },
@@ -28,8 +27,7 @@
     "@rushstack/heft": "~0.50.6",
     "@types/heft-jest": "~1.0.3",
     "eslint": "^8.45.0",
-    "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1"
+    "prettier": "~3.0.0"
   },
   "peerDependencies": {
     "@rushstack/heft": "^0.46.1"

--- a/packages/tools/integration-tests/package.json
+++ b/packages/tools/integration-tests/package.json
@@ -25,9 +25,8 @@
     "build": "heft build --clean",
     "format": "npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "precommit": "pnpm run test --silent",
     "start:pact": "rm -Rf ./log && mkdir log && pact --serve src/tests/pact-server.conf",
     "test": "",
@@ -50,7 +49,6 @@
     "@types/node": "^16.0.0",
     "concurrently": "^7.2.2",
     "eslint": "^8.45.0",
-    "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1"
+    "prettier": "~3.0.0"
   }
 }

--- a/packages/tools/kda-cli/package.json
+++ b/packages/tools/kda-cli/package.json
@@ -24,10 +24,9 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
     "kda": "node lib/index.js",
-    "lint": "eslint ./src --ext .js,.ts,.tsx --fix",
+    "lint": "eslint package.json src --ext .js,.ts,.tsx --fix",
     "test": "ava"
   },
   "ava": {
@@ -67,7 +66,6 @@
     "eslint": "^8.45.0",
     "ink-testing-library": "^3.0.0",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "ts-node": "~10.8.2",
     "typescript": "5.1.6"
   },

--- a/packages/tools/pactjs-cli/package.json
+++ b/packages/tools/pactjs-cli/package.json
@@ -20,9 +20,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "test": "heft test"
   },
   "dependencies": {
@@ -47,7 +46,6 @@
     "@types/node": "^16.0.0",
     "@types/rimraf": "~3.0.2",
     "eslint": "^8.45.0",
-    "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1"
+    "prettier": "~3.0.0"
   }
 }

--- a/packages/tools/remark-plugins/package.json
+++ b/packages/tools/remark-plugins/package.json
@@ -14,9 +14,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier src --check",
     "format:md": "remark README.md -o --use ./lib/index.js",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier src --write",
-    "lint": "eslint ./src --ext .ts --fix",
+    "lint": "eslint package.json src --ext .ts --fix",
     "test": ""
   },
   "dependencies": {
@@ -40,7 +39,6 @@
     "@types/node": "^16.0.0",
     "eslint": "^8.45.0",
     "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1",
     "typescript": "5.1.6",
     "unified": "^10.1.2",
     "vfile": "5.3.7"

--- a/packages/tools/rush-fix-versions/package.json
+++ b/packages/tools/rush-fix-versions/package.json
@@ -21,9 +21,8 @@
     "format": "npm run format:md && npm run format:pkg && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
-    "format:pkg": "sort-package-json",
     "format:src": "prettier config src --write",
-    "lint": "eslint ./src --ext .js,.ts --fix",
+    "lint": "eslint package.json src --ext .js,.ts --fix",
     "test": ""
   },
   "dependencies": {
@@ -40,7 +39,6 @@
     "@types/inquirer": "^9.0.3",
     "@types/node": "^16.0.0",
     "eslint": "^8.45.0",
-    "prettier": "~3.0.0",
-    "sort-package-json": "~2.5.1"
+    "prettier": "~3.0.0"
   }
 }


### PR DESCRIPTION
Big advantage here is that is included in `rush lint` including `--fix`, no separate npm script.