### PR TITLE
chore(@kadena/react-ui): Update NavFooter darkmode configuration

### DIFF
--- a/packages/apps/tools/src/components/Common/Layout/partials/Footer/Footer.tsx
+++ b/packages/apps/tools/src/components/Common/Layout/partials/Footer/Footer.tsx
@@ -46,11 +46,11 @@ const FooterWrapper: FC = () => {
   ];
 
   return (
-    <NavFooter.Root variant="dark">
+    <NavFooter.Root darkMode>
       <NavFooter.Panel>
         {links.map((item, index) => {
           return (
-            <NavFooter.Link key={index} variant="dark">
+            <NavFooter.Link key={index}>
               {item.href !== undefined ? (
                 <Link
                   className={linkClass}
@@ -69,17 +69,14 @@ const FooterWrapper: FC = () => {
       </NavFooter.Panel>
       <NavFooter.Panel>
         <NavFooter.IconButton
-          variant="dark"
           icon={SystemIcon.ApplicationBrackets}
           onClick={() => openModal()}
         />
         <NavFooter.IconButton
-          variant="dark"
           icon={SystemIcon.ThemeLightDark}
           onClick={() => toggleTheme()}
         />
         <NavFooter.IconButton
-          variant="dark"
           icon={SystemIcon.ApplicationBrackets}
           text="English"
         />

--- a/packages/libs/react-ui/src/components/NavFooter/Footer.css.ts
+++ b/packages/libs/react-ui/src/components/NavFooter/Footer.css.ts
@@ -1,21 +1,7 @@
 import { sprinkles } from '@theme/sprinkles.css';
 import { vars } from '@theme/vars.css';
-import { style, styleVariants } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 
-export const footerVariants = styleVariants({
-  dynamic: [
-    sprinkles({
-      backgroundColor: '$layoutSurfaceSubtle',
-      color: '$gray40',
-    }),
-  ],
-  dark: [
-    sprinkles({
-      backgroundColor: '$gray90',
-      color: '$gray40',
-    }),
-  ],
-});
 export const containerClass = style([
   sprinkles({
     maxWidth: { xs: 'maxContent', sm: '100%' },
@@ -28,6 +14,8 @@ export const containerClass = style([
     },
     justifyContent: 'space-between',
     overflow: 'hidden',
+    backgroundColor: '$layoutSurfaceSubtle',
+    color: '$gray40',
   }),
   {
     selectors: {
@@ -98,6 +86,7 @@ export const iconButtonClass = style([
     whiteSpace: 'nowrap',
     border: 'none',
     cursor: 'pointer',
+    color: '$gray40',
   }),
 ]);
 

--- a/packages/libs/react-ui/src/components/NavFooter/Footer.stories.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/Footer.stories.tsx
@@ -5,18 +5,16 @@ import { IFooterLinkProps, Target } from '@components/NavFooter/FooterLink';
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-const meta: Meta<
-  {
-    linksCount: number;
-    iconsCount: number;
-  } & IFooterLinkProps
-> = {
+const meta: Meta<{
+  linksCount: number;
+  iconsCount: number;
+  darkMode: boolean;
+}> = {
   title: 'Navigation/Footer',
   argTypes: {
-    variant: {
-      options: ['dynamic', 'dark'],
+    darkMode: {
       control: {
-        type: 'select',
+        type: 'boolean',
       },
     },
     linksCount: {
@@ -82,30 +80,29 @@ const icons: (
 ];
 
 export default meta;
-type Story = StoryObj<
-  {
-    linksCount: number;
-    iconsCount: number;
-  } & IFooterLinkProps
->;
+type Story = StoryObj<{
+  linksCount: number;
+  iconsCount: number;
+  darkMode: boolean;
+}>;
 
 export const Primary: Story = {
   name: 'Footer',
   args: {
     linksCount: 4,
     iconsCount: 3,
-    variant: 'dynamic',
+    darkMode: false,
   },
-  render: ({ linksCount, iconsCount, variant }) => {
+  render: ({ linksCount, iconsCount, darkMode }) => {
     const linkItems = links.slice(0, linksCount);
     const iconButtons = icons.slice(0, iconsCount);
 
     return (
-      <NavFooter.Root variant={variant}>
+      <NavFooter.Root darkMode={darkMode}>
         <NavFooter.Panel>
           {linkItems.map((item, index) => {
             return (
-              <NavFooter.Link key={index} variant={variant}>
+              <NavFooter.Link key={index}>
                 {item.href !== undefined ? (
                   <a href={item.href} target={item.target}>
                     {item.title}
@@ -121,7 +118,6 @@ export const Primary: Story = {
           {iconButtons.map((item, index) => {
             return (
               <NavFooter.IconButton
-                variant={variant}
                 key={index}
                 icon={item.icon}
                 text={item.text}

--- a/packages/libs/react-ui/src/components/NavFooter/Footer.test.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/Footer.test.tsx
@@ -31,7 +31,7 @@ describe('Footer', () => {
         <NavFooter.Panel>
           {menuLinks.map((item, index) => {
             return (
-              <NavFooter.Link key={index} variant="dynamic">
+              <NavFooter.Link key={index}>
                 <a href={item.href}>{item.title}</a>
               </NavFooter.Link>
             );
@@ -41,7 +41,6 @@ describe('Footer', () => {
           {icons.map((item, index) => {
             return (
               <NavFooter.IconButton
-                variant="dynamic"
                 key={index}
                 icon={item.icon}
                 text={item.text}
@@ -83,7 +82,7 @@ describe('Footer', () => {
         <NavFooter.Panel>
           {menuLinks.map((item, index) => {
             return (
-              <NavFooter.Link key={index} variant="dynamic">
+              <NavFooter.Link key={index}>
                 <a href={item.href}>{item.title}</a>
               </NavFooter.Link>
             );
@@ -93,7 +92,6 @@ describe('Footer', () => {
           {icons.map((item, index) => {
             return (
               <NavFooter.IconButton
-                variant="dynamic"
                 key={index}
                 icon={item.icon}
                 text={item.text}

--- a/packages/libs/react-ui/src/components/NavFooter/Footer.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/Footer.tsx
@@ -1,21 +1,29 @@
-import { containerClass, footerVariants } from './Footer.css';
+import { darkThemeClass } from '@theme/vars.css';
+import { containerClass } from './Footer.css';
 
-import classNames from 'classnames';
 import React, { FC } from 'react';
 
 export interface IFooterProps {
-  variant?: keyof typeof footerVariants;
   children: React.ReactNode;
+  darkMode?: boolean;
 }
 
 export const FooterContainer: FC<IFooterProps> = ({
   children,
-  variant = 'dynamic',
+  darkMode = false,
 }) => {
-  const classList = classNames(containerClass, footerVariants[variant]);
-  return (
-    <footer className={classList} data-testid="kda-footer">
-      {children}
-    </footer>
-  );
+
+  const footerContent = (    <footer className={containerClass} data-testid="kda-footer">
+  {children}
+</footer>)
+
+  if (darkMode) {
+    return (
+      <div className={darkThemeClass}>
+           {footerContent}
+      </div>
+    )
+  }
+
+  return footerContent;
 };

--- a/packages/libs/react-ui/src/components/NavFooter/Footer.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/Footer.tsx
@@ -13,14 +13,16 @@ export const FooterContainer: FC<IFooterProps> = ({
   darkMode = false,
 }) => {
 
-  const footerContent = (    <footer className={containerClass} data-testid="kda-footer">
-  {children}
-</footer>)
+  const footerContent = (    
+    <footer className={containerClass} data-testid="kda-footer">
+      {children}
+    </footer>
+  )
 
   if (darkMode) {
     return (
       <div className={darkThemeClass}>
-           {footerContent}
+        {footerContent}
       </div>
     )
   }

--- a/packages/libs/react-ui/src/components/NavFooter/Footer.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/Footer.tsx
@@ -12,19 +12,14 @@ export const FooterContainer: FC<IFooterProps> = ({
   children,
   darkMode = false,
 }) => {
-
-  const footerContent = (    
+  const footerContent = (
     <footer className={containerClass} data-testid="kda-footer">
       {children}
     </footer>
-  )
+  );
 
   if (darkMode) {
-    return (
-      <div className={darkThemeClass}>
-        {footerContent}
-      </div>
-    )
+    return <div className={darkThemeClass}>{footerContent}</div>;
   }
 
   return footerContent;

--- a/packages/libs/react-ui/src/components/NavFooter/FooterIconButton.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/FooterIconButton.tsx
@@ -2,7 +2,6 @@ import { SystemIcon } from '..';
 
 import { iconButtonClass, iconTextClass } from './Footer.css';
 
-import classNames from 'classnames';
 import React, { FC } from 'react';
 
 export interface IFooterIconButtonProps
@@ -19,17 +18,14 @@ export const FooterIconButton: FC<IFooterIconButtonProps> = ({
 }) => {
   const Icon = icon;
 
-  const buttonClassList = classNames(iconButtonClass);
-  const textClassList = classNames(iconTextClass);
-
   return (
     <button
-      className={buttonClassList}
+      className={iconButtonClass}
       onClick={onClick}
       data-testid="kda-footer-icon-item"
     >
       {text !== undefined ? (
-        <span className={textClassList}>{text}</span>
+        <span className={iconTextClass}>{text}</span>
       ) : null}
       <Icon size="sm" color="inherit" />
     </button>

--- a/packages/libs/react-ui/src/components/NavFooter/FooterIconButton.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/FooterIconButton.tsx
@@ -1,6 +1,6 @@
 import { SystemIcon } from '..';
 
-import { footerVariants, iconButtonClass, iconTextClass } from './Footer.css';
+import { iconButtonClass, iconTextClass } from './Footer.css';
 
 import classNames from 'classnames';
 import React, { FC } from 'react';
@@ -10,19 +10,17 @@ export interface IFooterIconButtonProps
   icon: (typeof SystemIcon)[keyof typeof SystemIcon];
   onClick?: React.MouseEventHandler;
   text?: string;
-  variant?: keyof typeof footerVariants;
 }
 
 export const FooterIconButton: FC<IFooterIconButtonProps> = ({
   icon,
   onClick,
   text,
-  variant = 'dynamic',
 }) => {
   const Icon = icon;
 
-  const buttonClassList = classNames(iconButtonClass, footerVariants[variant]);
-  const textClassList = classNames(iconTextClass, footerVariants[variant]);
+  const buttonClassList = classNames(iconButtonClass);
+  const textClassList = classNames(iconTextClass);
 
   return (
     <button

--- a/packages/libs/react-ui/src/components/NavFooter/FooterLink.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/FooterLink.tsx
@@ -1,4 +1,4 @@
-import {  linkBoxClass, linkClass } from './Footer.css';
+import { linkBoxClass, linkClass } from './Footer.css';
 
 import React, { FC } from 'react';
 
@@ -7,9 +7,7 @@ export interface IFooterLinkProps {
   children: React.ReactNode;
 }
 
-export const FooterLink: FC<IFooterLinkProps> = ({
-  children,
-}) => {
+export const FooterLink: FC<IFooterLinkProps> = ({ children }) => {
   const colorStyles = {
     color: 'inherit',
     textDecorationColor: 'inherit',
@@ -22,7 +20,6 @@ export const FooterLink: FC<IFooterLinkProps> = ({
       style: colorStyles,
     });
   });
-
 
   return (
     <div className={linkBoxClass} data-testid="kda-footer-link-item">

--- a/packages/libs/react-ui/src/components/NavFooter/FooterLink.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/FooterLink.tsx
@@ -1,4 +1,4 @@
-import { footerVariants, linkBoxClass, linkClass } from './Footer.css';
+import {  linkBoxClass, linkClass } from './Footer.css';
 
 import classNames from 'classnames';
 import React, { FC } from 'react';
@@ -6,12 +6,10 @@ import React, { FC } from 'react';
 export type Target = '_self' | '_blank';
 export interface IFooterLinkProps {
   children: React.ReactNode;
-  variant?: keyof typeof footerVariants;
 }
 
 export const FooterLink: FC<IFooterLinkProps> = ({
   children,
-  variant = 'dynamic',
 }) => {
   const colorStyles = {
     color: 'inherit',
@@ -21,12 +19,12 @@ export const FooterLink: FC<IFooterLinkProps> = ({
   const clones = React.Children.map(children, (child) => {
     // @ts-ignore
     return React.cloneElement(child, {
-      classNames: [linkClass, footerVariants[variant]],
+      classNames: [linkClass],
       style: colorStyles,
     });
   });
 
-  const classList = classNames(linkBoxClass, footerVariants[variant]);
+  const classList = classNames(linkBoxClass);
 
   return (
     <div className={classList} data-testid="kda-footer-link-item">

--- a/packages/libs/react-ui/src/components/NavFooter/FooterLink.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/FooterLink.tsx
@@ -1,6 +1,5 @@
 import {  linkBoxClass, linkClass } from './Footer.css';
 
-import classNames from 'classnames';
 import React, { FC } from 'react';
 
 export type Target = '_self' | '_blank';
@@ -24,10 +23,9 @@ export const FooterLink: FC<IFooterLinkProps> = ({
     });
   });
 
-  const classList = classNames(linkBoxClass);
 
   return (
-    <div className={classList} data-testid="kda-footer-link-item">
+    <div className={linkBoxClass} data-testid="kda-footer-link-item">
       <span className={linkClass}>{clones}</span>
     </div>
   );


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->

Instead of using variants, the footer just applies the darkThemeClass to a wrapping div on the footer to keep it in the dark theme. This can be applied via the `darkMode` prop on `Footer.Root`
