### PR TITLE
fix(@kadena/react-ui): Fix Tooltip flicker

### DIFF
--- a/packages/libs/react-ui/src/components/Tooltip/Tooltip.css.ts
+++ b/packages/libs/react-ui/src/components/Tooltip/Tooltip.css.ts
@@ -16,6 +16,7 @@ export const container = style([
     width: 'max-content',
     position: 'fixed',
     display: 'none',
+    pointerEvents: 'none',
   }),
   {
     top: '50%',
@@ -30,6 +31,7 @@ export const baseArrow = style([
     width: '$4',
     height: '$4',
     backgroundColor: '$neutral1',
+    pointerEvents: 'none',
   }),
   {
     rotate: '45deg',


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->


Set pointer events of tooltip to false so it doesn't flicker when you hover a portion of the tooltip