### PR TITLE
feat(@kadena/react-ui): Content header

### DIFF
--- a/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.css.ts
+++ b/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.css.ts
@@ -1,0 +1,19 @@
+import { style } from '@vanilla-extract/css';
+import { sprinkles } from '@theme/sprinkles.css';
+import { vars } from '@theme/vars.css';
+
+export const containerClass = style([
+  sprinkles({
+    display: 'grid',
+    gap: '$md',
+  }),
+  {
+    gridRowGap: vars.sizes.$xs,
+    alignItems: 'center',
+    gridTemplateColumns: 'max-content 1fr',
+  },
+]);
+
+export const descriptionClass = style({
+  gridColumnStart: 2,
+});

--- a/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.css.ts
+++ b/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.css.ts
@@ -6,11 +6,11 @@ export const containerClass = style([
   sprinkles({
     display: 'grid',
     gap: '$md',
+    alignItems: 'center',
   }),
   {
     gridRowGap: vars.sizes.$xs,
-    alignItems: 'center',
-    gridTemplateColumns: 'max-content 1fr',
+    gridTemplateColumns: 'auto 1fr',
   },
 ]);
 

--- a/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.stories.tsx
+++ b/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.stories.tsx
@@ -1,0 +1,59 @@
+import { SystemIcon } from '@components/Icon';
+import { ContentHeader, IContentHeaderProps } from '@components/ContentHeader';
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+const meta: Meta<
+  {
+    selectIcon: keyof typeof SystemIcon;
+  } & IContentHeaderProps
+> = {
+  title: 'Components/ContentHeader',
+  argTypes: {
+    selectIcon: {
+      options: Object.keys(SystemIcon) as (keyof typeof SystemIcon)[],
+      control: {
+        type: 'select',
+      },
+    },
+    heading: {
+      control: {
+        type: 'text',
+      },
+    },
+    description: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<
+  {
+    selectIcon: keyof typeof SystemIcon;
+  } & IContentHeaderProps
+>;
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/7.0/react/api/csf
+ * to learn how to use render functions.
+ */
+
+export const Primary: Story = {
+  name: 'ContentHeader',
+  args: {
+    selectIcon: 'Account',
+    heading: 'Incoming Transactions',
+    description:
+      'This table is listing all the incoming transaction sorted by date descending descriptive text.',
+  },
+  render: ({ selectIcon, heading, description }) => {
+    const Icon = SystemIcon[selectIcon];
+    return (
+      <ContentHeader heading={heading} icon={Icon} description={description} />
+    );
+  },
+};

--- a/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.tsx
+++ b/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.tsx
@@ -18,9 +18,11 @@ export const ContentHeader: FC<IContentHeaderProps> = ({
     <div className={containerClass}>
       <Icon size="md" />
       <Heading as="h4">{heading}</Heading>
-      <Text as="p" className={descriptionClass}>
-        {description}
-      </Text>
+      {description ? (
+        <Text as="p" className={descriptionClass}>
+          {description}
+        </Text>
+      ) : null}
     </div>
   );
 };

--- a/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.tsx
+++ b/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.tsx
@@ -1,0 +1,26 @@
+import { SystemIcon } from '@components/Icon';
+import { Heading, Text } from '@components/Typography';
+import React, { FC } from 'react';
+import { containerClass, descriptionClass } from './ContentHeader.css';
+
+export interface IContentHeaderProps {
+  icon: (typeof SystemIcon)[keyof typeof SystemIcon];
+  heading: string;
+  description?: string;
+}
+
+export const ContentHeader: FC<IContentHeaderProps> = ({
+  icon: Icon,
+  heading,
+  description,
+}) => {
+  return (
+    <div className={containerClass}>
+      <Icon size="md" />
+      <Heading as="h4">{heading}</Heading>
+      <Text as="p" className={descriptionClass}>
+        {description}
+      </Text>
+    </div>
+  );
+};

--- a/packages/libs/react-ui/src/components/ContentHeader/index.ts
+++ b/packages/libs/react-ui/src/components/ContentHeader/index.ts
@@ -1,0 +1,2 @@
+export { ContentHeader } from './ContentHeader';
+export type { IContentHeaderProps } from './ContentHeader';

--- a/packages/libs/react-ui/src/components/Tooltip/Tooltip.css.ts
+++ b/packages/libs/react-ui/src/components/Tooltip/Tooltip.css.ts
@@ -16,6 +16,7 @@ export const container = style([
     width: 'max-content',
     position: 'fixed',
     display: 'none',
+    pointerEvents: 'none',
   }),
   {
     top: '50%',
@@ -30,6 +31,7 @@ export const baseArrow = style([
     width: '$4',
     height: '$4',
     backgroundColor: '$neutral1',
+    pointerEvents: 'none',
   }),
   {
     rotate: '45deg',

--- a/packages/libs/react-ui/src/components/Typography/Text/Text.tsx
+++ b/packages/libs/react-ui/src/components/Typography/Text/Text.tsx
@@ -7,7 +7,7 @@ import {
   transformVariant,
 } from './Text.css';
 
-import className from 'classnames';
+import cn from 'classnames';
 import React, { FC } from 'react';
 
 export interface ITextProps {
@@ -18,6 +18,7 @@ export interface ITextProps {
   color?: keyof typeof colorVariant;
   transform?: keyof typeof transformVariant;
   size?: keyof typeof sizeVariant;
+  className?: string;
   children: React.ReactNode;
 }
 
@@ -29,15 +30,17 @@ export const Text: FC<ITextProps> = ({
   size = 'lg',
   color = 'default',
   transform = 'none',
+  className = '',
   children,
 }) => {
-  const classList = className(
+  const classList = cn(
     elementVariant[variant],
     fontVariant[font],
     sizeVariant[size],
     colorVariant[color],
     transformVariant[transform],
     { [boldClass]: bold },
+    className,
   );
 
   switch (as) {

--- a/packages/libs/react-ui/src/components/index.ts
+++ b/packages/libs/react-ui/src/components/index.ts
@@ -1,8 +1,10 @@
+import { Content } from './../../../../apps/docs/src/components/Layout/components/ArticleStyles';
 export type { IAccordionProps, IAccordionSectionProps } from './Accordion';
 export type { IBoxProps } from './Box';
 export type { IBreadcrumbsProps, IBreadcrumbItemProps } from './Breadcrumbs';
 export type { IButtonProps } from './Button';
 export type { ICardProps } from './Card';
+export type { IContentHeaderProps } from './ContentHeader';
 export type { IGridContainerProps, IGridItemProps } from './Grid';
 export type { IIconButtonProps } from './IconButton';
 export type { IIconProps } from './Icon';
@@ -52,6 +54,7 @@ export { Box } from './Box';
 export { Breadcrumbs } from './Breadcrumbs';
 export { Button } from './Button';
 export { Card } from './Card';
+export { ContentHeader } from './ContentHeader';
 export { NavFooter } from './NavFooter';
 export { Grid } from './Grid';
 export { IconButton } from './IconButton';


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->

Added the content header component

<img width="512" alt="image" src="https://github.com/kadena-community/kadena.js/assets/9022549/3dfaec6c-9666-42fa-876a-1ec447accc78">


NOTE: did not add tests as there is no logic here that can't be tested using chromatic
