### PR TITLE
Remove `format:pkg` and fix markdown package

### DIFF
--- a/common/changes/@kadena-dev/eslint-config/fix-format-pkg_2023-08-02-06-25.json
+++ b/common/changes/@kadena-dev/eslint-config/fix-format-pkg_2023-08-02-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/eslint-config",
+      "comment": "Remove format:pkg everywhere",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena-dev/eslint-config"
+}

--- a/common/changes/@kadena-dev/eslint-plugin/fix-format-pkg_2023-08-02-06-25.json
+++ b/common/changes/@kadena-dev/eslint-plugin/fix-format-pkg_2023-08-02-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/eslint-plugin",
+      "comment": "Remove format:pkg everywhere",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena-dev/eslint-plugin"
+}

--- a/common/changes/@kadena-dev/heft-rig/fix-format-pkg_2023-08-02-06-25.json
+++ b/common/changes/@kadena-dev/heft-rig/fix-format-pkg_2023-08-02-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/heft-rig",
+      "comment": "Remove format:pkg everywhere",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena-dev/heft-rig"
+}

--- a/common/changes/@kadena-dev/rush-fix-versions/fix-format-pkg_2023-08-02-06-25.json
+++ b/common/changes/@kadena-dev/rush-fix-versions/fix-format-pkg_2023-08-02-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena-dev/rush-fix-versions",
+      "comment": "Remove format:pkg everywhere",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena-dev/rush-fix-versions"
+}

--- a/common/changes/@kadena/chainweb-node-client/fix-format-pkg_2023-08-02-06-25.json
+++ b/common/changes/@kadena/chainweb-node-client/fix-format-pkg_2023-08-02-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-node-client",
+      "comment": "Remove format:pkg everywhere",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainweb-node-client"
+}

--- a/common/changes/@kadena/chainweb-stream-client/fix-format-pkg_2023-08-02-06-25.json
+++ b/common/changes/@kadena/chainweb-stream-client/fix-format-pkg_2023-08-02-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/chainweb-stream-client",
+      "comment": "Remove format:pkg everywhere",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/chainweb-stream-client"
+}

--- a/common/changes/@kadena/client/fix-format-pkg_2023-08-02-06-25.json
+++ b/common/changes/@kadena/client/fix-format-pkg_2023-08-02-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "Remove format:pkg everywhere",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/common/changes/@kadena/cryptography-utils/fix-format-pkg_2023-08-02-06-25.json
+++ b/common/changes/@kadena/cryptography-utils/fix-format-pkg_2023-08-02-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/cryptography-utils",
+      "comment": "Remove format:pkg everywhere",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/cryptography-utils"
+}

--- a/common/changes/@kadena/pactjs/fix-format-pkg_2023-08-02-06-25.json
+++ b/common/changes/@kadena/pactjs/fix-format-pkg_2023-08-02-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs",
+      "comment": "Remove format:pkg everywhere",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs"
+}

--- a/common/changes/@kadena/types/fix-format-pkg_2023-08-02-06-25.json
+++ b/common/changes/@kadena/types/fix-format-pkg_2023-08-02-06-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/types",
+      "comment": "Remove format:pkg everywhere",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/types"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1299,11 +1299,11 @@ importers:
       remark-gfm: ~3.0.1
       remark-order-reference-links: ^0.0.3
       remark-parse: ^10.0.2
-      remark-prettier: ^2.0.0
       remark-reference-links: ^6.0.1
       strip-json-comments: ^5.0.0
       typescript: 5.1.6
       unified: ^10.1.2
+      unified-prettier: ^1.0.1
       unist-util-visit: ^4.1.2
       vfile: 5.3.7
     dependencies:
@@ -1315,9 +1315,9 @@ importers:
       remark-gfm: 3.0.1
       remark-order-reference-links: 0.0.3
       remark-parse: 10.0.2
-      remark-prettier: 2.0.0_prettier@3.0.0
       remark-reference-links: 6.0.1
       strip-json-comments: 5.0.1
+      unified-prettier: 1.0.2_prettier@3.0.0
       unist-util-visit: 4.1.2
     devDependencies:
       '@kadena-dev/eslint-config': link:../eslint-config
@@ -23420,21 +23420,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /remark-prettier/2.0.0_prettier@3.0.0:
-    resolution: {integrity: sha512-66v8KoqnBivhcfjtahHmHU7qkQuVPq/JIsqTW8suqI8mVuHCpxjapoY2XIBLjC5J7suYICVtNRBXRwrRX7a1hA==}
-    engines: {node: '>=14.0.0'}
-    deprecated: Use unified-consistency and unified-prettier instead
-    peerDependencies:
-      prettier: ^2
-    dependencies:
-      '@types/mdast': 3.0.12
-      '@types/prettier': 2.7.3
-      mdast-util-to-markdown: 1.5.0
-      prettier: 3.0.0
-      prettier-linter-helpers: 1.0.0
-      vfile-location: 4.1.0
-    dev: false
-
   /remark-reference-links/6.0.1:
     resolution: {integrity: sha512-34wY2C6HXSuKVTRtyJJwefkUD8zBOZOSHFZ4aSTnU2F656gr9WeuQ2dL6IJDK3NPd2F6xKF2t4XXcQY9MygAXg==}
     dependencies:
@@ -25818,6 +25803,15 @@ packages:
       - supports-color
     dev: false
 
+  /unified-prettier/1.0.2_prettier@3.0.0:
+    resolution: {integrity: sha512-Hal9mbA+X9cRiVc3SPKo7L2cL1/PIdYxA2XX93iQVDs1uAVLjFaS/Qg4miFgBXypMrgXWclBU5c6+H9I0atjCw==}
+    peerDependencies:
+      prettier: ^3.0.0
+    dependencies:
+      prettier: 3.0.0
+      unified: 10.1.2
+    dev: false
+
   /unified/10.1.2:
     resolution: {integrity: sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==}
     dependencies:
@@ -26151,13 +26145,6 @@ packages:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
     dev: true
-
-  /vfile-location/4.1.0:
-    resolution: {integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==}
-    dependencies:
-      '@types/unist': 2.0.7
-      vfile: 5.3.7
-    dev: false
 
   /vfile-message/3.1.4:
     resolution: {integrity: sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "293eb7b95bc5413cb8bd8f985349e03585a40acf",
+  "pnpmShrinkwrapHash": "318ad3e9fad8bdd27a5ee2d31c85690ecc5dcee9",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/packages/apps/graph-client/package.json
+++ b/packages/apps/graph-client/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rushx postinstall && next build",
     "dev": "concurrently --kill-others \"npm:next:dev\" \"npm:start:graph\" \"sleep 3; rushx generate:sdk -w\"",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/apps/graph/package.json
+++ b/packages/apps/graph/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "scripts": {
     "build": "",
-    "format": "npm run format:pkg && npm run format:src",
+    "format": "npm run format:src",
     "format:ci": "prettier config src --check",
     "format:src": "prettier config src --write",
     "lint": "eslint package.json src --ext .js,.ts --fix",

--- a/packages/apps/immutable-records/package.json
+++ b/packages/apps/immutable-records/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "node build.mjs",
     "dev": "next dev",
-    "format": "npm run format:pkg && npm run format:src && npm run format:md",
+    "format": "npm run format:src && npm run format:md",
     "format:ci": "prettier src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier src --write",

--- a/packages/apps/tools/README.md
+++ b/packages/apps/tools/README.md
@@ -7,10 +7,10 @@ securely and efficiently using smart contracts on the Kadena blockchain.
 
 ## Table of Contents
 
-- [Table of Contents](#table-of-contents)
-- [Installation](#installation)
-- [Usage](#usage)
-- [License](#license)
+- [Table of Contents][1]
+- [Installation][2]
+- [Usage][3]
+- [License][4]
 
 ## Installation
 

--- a/packages/apps/tools/package.json
+++ b/packages/apps/tools/package.json
@@ -6,7 +6,7 @@
     "build": "npm run generate:icons && npm run generate:contracts && next build",
     "dev": "npm run generate:icons && next dev",
     "eject": "react-scripts eject",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier locales src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier locales src --write",

--- a/packages/libs/bootstrap-lib/package.json
+++ b/packages/libs/bootstrap-lib/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "build": "heft build --clean",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/libs/chainweb-node-client/package.json
+++ b/packages/libs/chainweb-node-client/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "build": "heft build --clean",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config openapi src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config openapi src --write",

--- a/packages/libs/chainweb-stream-client/README.md
+++ b/packages/libs/chainweb-stream-client/README.md
@@ -13,8 +13,8 @@ Chainweb-stream client for browsers and node.js
 
 [Chainweb-stream][1] client for browsers and node.js
 
-Stream account or module/event transactions from chainweb-stream, including their
-confirmation depth.
+Stream account or module/event transactions from chainweb-stream, including
+their confirmation depth.
 
 Introduces and normalizes the following features across environments:
 
@@ -68,7 +68,7 @@ Find more detailed examples under `src/examples`.
 | network           |   Yes    | Chainweb network                                                | \`mainnet01             | testnet04 | ...\` |
 | type              |   Yes    | Transaction type to stream (event/account)                      | \`event                 | account\` |       |
 | id                |   Yes    | Account ID or module/event name                                 | `k:abcdef01234..`       |           |       |
-| host              |   Yes    | Chainweb-stream backend URL                                        | `http://localhost:4000` |           |       |
+| host              |   Yes    | Chainweb-stream backend URL                                     | `http://localhost:4000` |           |       |
 | limit             |    No    | Initial data load limit                                         | 100                     |           |       |
 | connectTimeout    |    No    | Connection timeout in ms                                        | 10_000                  |           |       |
 | heartbeatTimeout  |    No    | Stale connection timeout in ms                                  | 30_000                  |           |       |

--- a/packages/libs/chainweb-stream-client/package.json
+++ b/packages/libs/chainweb-stream-client/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "build": "heft build --clean",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/libs/chainwebjs/package.json
+++ b/packages/libs/chainwebjs/package.json
@@ -49,7 +49,7 @@
   ],
   "scripts": {
     "build": "heft build --clean",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/libs/client-examples/package.json
+++ b/packages/libs/client-examples/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "prebuild": "npm run pactjs:generate:contract:file && npm run pactjs:generate:contract:crowdfund",
     "build": "npm run prebuild && tsc --noEmit",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/libs/client/package.json
+++ b/packages/libs/client/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "heft build --clean",
     "dev:postinstall": "rushx pactjs:retrieve:contract; rushx pactjs:generate:contract",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/libs/cryptography-utils/package.json
+++ b/packages/libs/cryptography-utils/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "build": "heft build --clean",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/libs/kadena.js/package.json
+++ b/packages/libs/kadena.js/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "build": "heft build --clean",
     "build:prod": "webpack --mode=production",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/libs/pactjs-generator/package.json
+++ b/packages/libs/pactjs-generator/package.json
@@ -23,7 +23,7 @@
     "build:grammar:watch": "chokidar src/lexer.js src/grammar.ne src/tests/test.contract.pact -c \"rushx build:grammar\"",
     "test:grammar:watch": "heft test -w -t grammar --disable-code-coverage",
     "util:lexer-grammar:watch": "concurrently --kill-others npm:build:*:watch # npm:test:grammar:watch",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/libs/pactjs/package.json
+++ b/packages/libs/pactjs/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "build": "heft build --clean",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/libs/react-components/package.json
+++ b/packages/libs/react-components/package.json
@@ -16,7 +16,7 @@
     "build": "tsc -p ./tsconfig.esm.json & tsc -p ./tsconfig.cjs.json",
     "build:storybook": "storybook build",
     "build:test": "tsc & tsc -p ./tsconfig.esm.json",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/libs/react-ui/package.json
+++ b/packages/libs/react-ui/package.json
@@ -29,7 +29,7 @@
     "build": "rimraf theme && tsc && tsc-alias && tsc -p ./tsconfig.cjs.json && tsc-alias -p ./tsconfig.cjs.json && copyfiles -f \"./types/styles/*\" theme",
     "build:storybook": "storybook build",
     "build:test": "tsc --noEmit & tsc -p ./tsconfig.cjs.json --noEmit",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier src --write",

--- a/packages/libs/types/package.json
+++ b/packages/libs/types/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "build": "heft build --clean",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/tools/cookbook/package.json
+++ b/packages/tools/cookbook/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "",
     "dev:postinstall": "mkdir -p ./contracts; rushx pactjs:retrieve:contract; rushx pactjs:generate:contract",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/tools/eslint-config/package.json
+++ b/packages/tools/eslint-config/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "build": "",
-    "format": "npm run format:pkg && npm run format:src",
+    "format": "npm run format:src",
     "format:ci": "prettier mixins profile --check",
     "format:src": "prettier mixins profile --write",
     "lint": "eslint ./mixins ./profile --ext .js,.ts --fix",

--- a/packages/tools/eslint-plugin/package.json
+++ b/packages/tools/eslint-plugin/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "build": "heft build --clean",
-    "format": "npm run format:pkg && npm run format:src",
+    "format": "npm run format:src",
     "format:ci": "prettier src --check",
     "format:src": "prettier src --write",
     "test": "heft test"

--- a/packages/tools/heft-rig/package.json
+++ b/packages/tools/heft-rig/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "build": "",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier profiles --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier profiles --write",

--- a/packages/tools/integration-tests/package.json
+++ b/packages/tools/integration-tests/package.json
@@ -23,7 +23,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "heft build --clean",
-    "format": "npm run format:pkg && npm run format:src",
+    "format": "npm run format:src",
     "format:ci": "prettier config src --check",
     "format:src": "prettier config src --write",
     "lint": "eslint package.json src --ext .js,.ts --fix",

--- a/packages/tools/kda-cli/package.json
+++ b/packages/tools/kda-cli/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "heft build",
     "dev": "heft build -w",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/tools/pactjs-cli/package.json
+++ b/packages/tools/pactjs-cli/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "heft build --clean",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",

--- a/packages/tools/remark-plugins/package.json
+++ b/packages/tools/remark-plugins/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier src --check",
     "format:md": "remark README.md -o --use ./lib/index.js",
     "format:src": "prettier src --write",

--- a/packages/tools/remark-plugins/package.json
+++ b/packages/tools/remark-plugins/package.json
@@ -27,8 +27,8 @@
     "remark-gfm": "~3.0.1",
     "remark-order-reference-links": "^0.0.3",
     "remark-parse": "^10.0.2",
-    "remark-prettier": "^2.0.0",
     "remark-reference-links": "^6.0.1",
+    "unified-prettier": "^1.0.1",
     "strip-json-comments": "^5.0.0",
     "unist-util-visit": "^4.1.2"
   },

--- a/packages/tools/remark-plugins/src/index.ts
+++ b/packages/tools/remark-plugins/src/index.ts
@@ -6,9 +6,9 @@ import remarkFrontMatter from 'remark-frontmatter';
 import remarkGFM from 'remark-gfm';
 import remarkOrderLinks from 'remark-order-reference-links';
 import remarkParse from 'remark-parse';
-import remarkPrettier from 'remark-prettier';
 import remarkReferenceLinks from 'remark-reference-links';
 import type { Preset } from 'unified';
+import unifiedPrettier from 'unified-prettier';
 
 const remarkPresetKadena: Preset = {
   settings: {},
@@ -17,7 +17,7 @@ const remarkPresetKadena: Preset = {
     // @ts-ignore
     remarkParse,
     [handleCommentMarkers, commentMarkers],
-    remarkPrettier,
+    unifiedPrettier,
     remarkGFM,
     fencedCodeBlocks,
     remarkReferenceLinks,

--- a/packages/tools/rush-fix-versions/package.json
+++ b/packages/tools/rush-fix-versions/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "heft build",
-    "format": "npm run format:md && npm run format:pkg && npm run format:src",
+    "format": "npm run format:md && npm run format:src",
     "format:ci": "prettier config src --check",
     "format:md": "remark README.md -o --use @kadena-dev/markdown",
     "format:src": "prettier config src --write",


### PR DESCRIPTION
* Remove `format:pkg` script everywhere (6ac10b8d)
* Replace remark-prettier with unified-prettier (after the prettier v3 bump) (0916be96)
* Apply some formatting (f9d66cd6)
* Update changelog (4bde5e94)