### PR TITLE
Refactor/rename sender to sender account

### DIFF
--- a/packages/apps/tools/src/services/cross-chain-transfer-finish/finish-xchain-transfer.ts
+++ b/packages/apps/tools/src/services/cross-chain-transfer-finish/finish-xchain-transfer.ts
@@ -29,7 +29,7 @@ export async function finishXChainTransfer(
       .setNetworkId(networkId)
       .setMeta({
         chainId: targetChainId,
-        sender: gasPayer,
+        senderAccount: gasPayer,
         // this needs to be below 850 if you want to use gas-station otherwise the gas-station does
         gasLimit: 850,
       })

--- a/packages/apps/tools/src/services/faucet/index.ts
+++ b/packages/apps/tools/src/services/faucet/index.ts
@@ -48,7 +48,7 @@ export const fundExistingAccount = async (
         new PactNumber(amount).toPactDecimal(),
       ),
     ])
-    .setMeta({ sender: SENDER_OPERATION_ACCOUNT, chainId })
+    .setMeta({ senderAccount: SENDER_OPERATION_ACCOUNT, chainId })
     .setNetworkId(NETWORK_ID)
     .createTransaction();
 

--- a/packages/apps/tools/src/services/modules/describe-module.ts
+++ b/packages/apps/tools/src/services/modules/describe-module.ts
@@ -18,7 +18,7 @@ export const describeModule = async (
   moduleName: string,
   chainId: ChainwebChainId,
   network: Network,
-  sender: string = kadenaConstants.DEFAULT_SENDER,
+  senderAccount: string = kadenaConstants.DEFAULT_SENDER,
   gasPrice: number = kadenaConstants.GAS_PRICE,
   gasLimit: number = kadenaConstants.GAS_LIMIT,
   ttl: number = kadenaConstants.API_TTL,
@@ -34,7 +34,7 @@ export const describeModule = async (
 
   const transaction = Pact.builder
     .execution(`(describe-module "${moduleName}")`)
-    .setMeta({ gasLimit, gasPrice, ttl, sender, chainId })
+    .setMeta({ gasLimit, gasPrice, ttl, senderAccount, chainId })
     .setNetworkId(networkId)
     .createTransaction();
 

--- a/packages/apps/tools/src/services/modules/list-module.ts
+++ b/packages/apps/tools/src/services/modules/list-module.ts
@@ -19,7 +19,7 @@ export interface IModulesResult {
 export const listModules = async (
   chainId: ChainwebChainId,
   network: Network,
-  sender: string = kadenaConstants.DEFAULT_SENDER,
+  senderAccount: string = kadenaConstants.DEFAULT_SENDER,
   gasPrice: number = kadenaConstants.GAS_PRICE,
   gasLimit: number = kadenaConstants.GAS_LIMIT,
   ttl: number = kadenaConstants.API_TTL,
@@ -35,7 +35,7 @@ export const listModules = async (
 
   const transaction = Pact.builder
     .execution('(list-modules)')
-    .setMeta({ gasLimit, gasPrice, ttl, sender, chainId })
+    .setMeta({ gasLimit, gasPrice, ttl, senderAccount, chainId })
     .setNetworkId(networkId)
     .createTransaction();
 

--- a/packages/libs/client-examples/src/example-contract/crosschain-transfer.ts
+++ b/packages/libs/client-examples/src/example-contract/crosschain-transfer.ts
@@ -61,7 +61,7 @@ function startInTheFirstChain(
       ),
     ])
     .addKeyset('receiver-guard', 'keys-all', to.publicKey)
-    .setMeta({ chainId: from.chainId, sender: from.account })
+    .setMeta({ chainId: from.chainId, senderAccount: from.account })
     .setNetworkId(NETWORK_ID)
     .createTransaction();
 }
@@ -80,7 +80,7 @@ function finishInTheTargetChain(
     // ])
     .setMeta({
       chainId: targetChainId,
-      sender: gasPayer,
+      senderAccount: gasPayer,
       // this need to be less than or equal to 850 if you want to use gas-station, otherwise the gas-station does not pay the gas
       gasLimit: 850,
     });
@@ -97,7 +97,9 @@ async function doCrossChainTransfer(
     Promise.resolve(startInTheFirstChain(from, to, amount))
       .then((command) => signWithChainweaver(command))
       .then((command) =>
-        isSignedTransaction(command) ? command : Promise.reject('CMD_NOT_SIGNED'),
+        isSignedTransaction(command)
+          ? command
+          : Promise.reject('CMD_NOT_SIGNED'),
       )
       // inspect is only for development you can remove them
       .then(inspect('EXEC_SIGNED'))

--- a/packages/libs/client-examples/src/example-contract/crowdfund.ts
+++ b/packages/libs/client-examples/src/example-contract/crowdfund.ts
@@ -35,7 +35,7 @@ export async function createProject(
     .addKeyset('owner-guard', 'keys-all', sender.publicKey)
     .addSigner(sender.publicKey)
     .setNetworkId('testnet04')
-    .setMeta({ chainId: '0', sender: sender.account })
+    .setMeta({ chainId: '0', senderAccount: sender.account })
     .createTransaction();
 
   const signedTransaction = await signWithChainweaver(unsignedTransaction);

--- a/packages/libs/client-examples/src/example-contract/functional/transfer-fp.ts
+++ b/packages/libs/client-examples/src/example-contract/functional/transfer-fp.ts
@@ -42,7 +42,7 @@ const getTransferCommand = ({
         decimal: amount,
       }),
     ]),
-    setMeta({ sender, chainId }),
+    setMeta({ senderAccount: sender, chainId }),
     setNetworkId(networkId),
   );
 

--- a/packages/libs/client-examples/src/example-contract/safe-transfe.ts
+++ b/packages/libs/client-examples/src/example-contract/safe-transfe.ts
@@ -36,7 +36,7 @@ async function doSafeTransfer(
       withCapability('coin.TRANSFER', to.account, from.account, aLowAmount),
     ])
     .setNetworkId(NETWORK_ID)
-    .setMeta({ chainId: '1', sender: from.account })
+    .setMeta({ chainId: '1', senderAccount: from.account })
     .createTransaction();
 
   const signedCommand = await signWithChainweaver(unsignedTr);

--- a/packages/libs/client-examples/src/example-contract/simple-transfer.ts
+++ b/packages/libs/client-examples/src/example-contract/simple-transfer.ts
@@ -25,7 +25,7 @@ async function transfer(
       withCapability('coin.GAS'),
       withCapability('coin.TRANSFER', sender, receiver, amount),
     ])
-    .setMeta({ chainId: '0', sender })
+    .setMeta({ chainId: '0', senderAccount: sender })
     .setNetworkId(NETWORK_ID)
     .createTransaction();
 

--- a/packages/libs/client-examples/src/example-contract/transfer-create.ts
+++ b/packages/libs/client-examples/src/example-contract/transfer-create.ts
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
       chainId: '1',
       gasLimit: 1000,
       gasPrice: 1.0e-6,
-      sender: senderAccount,
+      senderAccount,
       ttl: 10 * 60, // 10 minutes
     })
     .setNetworkId(NETWORK_ID)

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -58,9 +58,9 @@ export interface IBuilder<TCommand> {
     addSigner: IAddSigner<TCommand>;
     createTransaction: () => IUnsignedCommand;
     getCommand: () => Partial<IPactCommand>;
-    setMeta: (meta: {
-        chainId: IPactCommand['meta']['chainId'];
-    } & Partial<IPactCommand['meta']>) => IBuilder<TCommand>;
+    setMeta: (meta: Partial<Omit<IPactCommand['meta'], 'sender'>> & {
+        senderAccount?: string;
+    }) => IBuilder<TCommand>;
     setNetworkId: (id: string) => IBuilder<TCommand>;
     // Warning: (ae-forgotten-export) The symbol "ISetNonce" needs to be exported by the entry point index.d.ts
     setNonce: ISetNonce<TCommand>;

--- a/packages/libs/client/src/composePactCommand/test/composePactCommand.test.ts
+++ b/packages/libs/client/src/composePactCommand/test/composePactCommand.test.ts
@@ -101,7 +101,7 @@ describe('composePactCommand', () => {
       ]),
       setMeta({
         chainId: '1',
-        sender: 'gas-station',
+        senderAccount: 'gas-station',
         gasPrice: 381,
         gasLimit: 400,
         creationTime: 123,
@@ -272,7 +272,10 @@ describe('composePactCommand', () => {
 
   it('adds does not set sender if its not presented', () => {
     const command: Partial<IPactCommand> = composePactCommand(
-      composePactCommand(execution('(test)'), setMeta({ sender: 'test' })),
+      composePactCommand(
+        execution('(test)'),
+        setMeta({ senderAccount: 'test' }),
+      ),
       composePactCommand(execution('(test 2)'), setMeta({ chainId: '1' })),
       setMeta({
         gasLimit: 1,

--- a/packages/libs/client/src/composePactCommand/utils/setMeta.ts
+++ b/packages/libs/client/src/composePactCommand/utils/setMeta.ts
@@ -8,12 +8,17 @@ import { patchCommand } from './patchCommand';
  */
 export const setMeta =
   (
-    options: Partial<IPactCommand['meta']>,
+    options: Partial<Omit<IPactCommand['meta'], 'sender'>> & {
+      senderAccount?: string;
+    },
   ): ((command: Partial<IPactCommand>) => Partial<IPactCommand>) =>
-  (command) =>
-    patchCommand(command, {
+  (command) => {
+    const { senderAccount, ...rest } = options;
+    return patchCommand(command, {
       meta: {
         ...command.meta,
-        ...options,
+        ...rest,
+        ...(senderAccount !== undefined ? { sender: senderAccount } : {}),
       } as IPactCommand['meta'],
     });
+  };

--- a/packages/libs/client/src/createTransactionBuilder/createTransactionBuilder.ts
+++ b/packages/libs/client/src/createTransactionBuilder/createTransactionBuilder.ts
@@ -116,9 +116,9 @@ export interface IBuilder<TCommand> {
    * ```
    */
   setMeta: (
-    meta: { chainId: IPactCommand['meta']['chainId'] } & Partial<
-      IPactCommand['meta']
-    >,
+    meta: Partial<Omit<IPactCommand['meta'], 'sender'>> & {
+      senderAccount?: string;
+    },
   ) => IBuilder<TCommand>;
   /**
    * Set nonce

--- a/packages/libs/client/src/signing/chainweaver/tests/signWithChainweaver.test.ts
+++ b/packages/libs/client/src/signing/chainweaver/tests/signWithChainweaver.test.ts
@@ -66,7 +66,7 @@ describe('signWithChainweaver', () => {
       .execution(coin.transfer('k:from', 'k:to', { decimal: '1.0' }))
       .addSigner('', (withCap) => [withCap('coin.GAS')])
       .setMeta({
-        sender: '',
+        senderAccount: '',
         chainId: '0',
       })
       .createTransaction();
@@ -104,7 +104,7 @@ describe('signWithChainweaver', () => {
         withCap('coin.TRANSFER', 'k:from', 'k:to', { decimal: '1.234' }),
       ])
       .setMeta({
-        sender: '',
+        senderAccount: '',
         chainId: '0',
       })
       .createTransaction();


### PR DESCRIPTION
accepting sender in the meta was so confusing because it's not clear its an account or a public key. 
So I renamed to to senderAccount.