### PR TITLE
Fix button style react-ui

### DIFF
--- a/packages/apps/docs/src/components/BottomPageSection/components/EditPage.tsx
+++ b/packages/apps/docs/src/components/BottomPageSection/components/EditPage.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@kadena/react-components';
+import { Button } from '@kadena/react-ui';
 
 import React, { FC } from 'react';
 

--- a/packages/apps/docs/src/components/NotFound/NotFound.tsx
+++ b/packages/apps/docs/src/components/NotFound/NotFound.tsx
@@ -1,5 +1,4 @@
-import { Button } from '@kadena/react-components';
-import { Heading, Stack, Text } from '@kadena/react-ui';
+import { Button, Heading, Stack, Text } from '@kadena/react-ui';
 
 import Link from 'next/link';
 import React, { FC } from 'react';

--- a/packages/libs/react-ui/src/components/Button/Button.css.ts
+++ b/packages/libs/react-ui/src/components/Button/Button.css.ts
@@ -39,30 +39,30 @@ export const container = style([
       '&[href]': {
         display: 'inline-flex',
       },
-      '&:hover': {
-        backgroundColor: bgHoverColor,
-        color: colorPalette.$white,
-      },
-      '&:active': {
-        backgroundColor: bgActiveColor,
-      },
-      '&:focus-visible': {
-        outlineOffset: '2px',
-        outlineWidth: vars.borderWidths.$md,
-        outlineStyle: 'solid',
-        outlineColor: focusOutlineColor,
-      },
-      '&:disabled': {
-        opacity: 0.7,
-        backgroundColor: colorPalette.$gray60,
-        color: colorPalette.$gray10,
-        cursor: 'not-allowed',
-        pointerEvents: 'none',
-      },
       [`${darkThemeClass} &:hover`]: {
         color: colorPalette.$gray100,
         backgroundColor: colorPalette.$blue30,
       },
+    },
+    ':hover': {
+      backgroundColor: bgHoverColor,
+      color: colorPalette.$white,
+    },
+    ':active': {
+      backgroundColor: bgActiveColor,
+    },
+    ':focus-visible': {
+      outlineOffset: '2px',
+      outlineWidth: vars.borderWidths.$md,
+      outlineStyle: 'solid',
+      outlineColor: focusOutlineColor,
+    },
+    ':disabled': {
+      opacity: 0.7,
+      backgroundColor: colorPalette.$gray60,
+      color: colorPalette.$gray10,
+      cursor: 'not-allowed',
+      pointerEvents: 'none',
     },
     transition: 'background-color 0.4s ease',
   },

--- a/packages/libs/react-ui/src/components/Button/Button.css.ts
+++ b/packages/libs/react-ui/src/components/Button/Button.css.ts
@@ -13,44 +13,47 @@ const bgHoverColor = createVar(),
 
 export const container = style([
   sprinkles({
-    display: 'flex',
-    placeItems: 'center',
-    gap: '$2',
+    border: 'none',
     borderRadius: '$sm',
     cursor: 'pointer',
+    display: 'flex',
+    fontSize: '$base',
+    fontWeight: '$semiBold',
+    gap: '$2',
+    lineHeight: '$normal',
     paddingX: '$4',
     paddingY: '$3',
-    border: 'none',
-    fontSize: '$base',
+    placeItems: 'center',
     textDecoration: 'none',
-    lineHeight: '$normal',
   }),
   {
     selectors: {
       '&[href]': {
         display: 'inline-flex',
       },
+      '&:hover': {
+        backgroundColor: bgHoverColor,
+        color: 'white',
+      },
+      '&:active': {
+        backgroundColor: bgActiveColor,
+      },
+      '&:focus-visible': {
+        outlineOffset: '2px',
+        outlineWidth: '$md',
+        outlineStyle: 'solid',
+        outlineColor: focusOutlineColor,
+      },
+      '&:disabled': {
+        opacity: 0.7,
+        backgroundColor: '$neutral3',
+        color: '$neutral1',
+        cursor: 'not-allowed',
+        pointerEvents: 'none',
+      },
     },
+    color: 'white',
     transition: 'background-color 0.4s ease',
-    ':hover': {
-      backgroundColor: bgHoverColor,
-    },
-    ':active': {
-      backgroundColor: bgActiveColor,
-    },
-    ':focus-visible': {
-      outlineOffset: '2px',
-      outlineWidth: vars.borderWidths.$md,
-      outlineStyle: 'solid',
-      outlineColor: focusOutlineColor,
-    },
-    ':disabled': {
-      opacity: 0.7,
-      backgroundColor: vars.colors.$neutral3,
-      color: vars.colors.$neutral1,
-      cursor: 'not-allowed',
-      pointerEvents: 'none',
-    },
   },
 ]);
 

--- a/packages/libs/react-ui/src/components/Button/Button.css.ts
+++ b/packages/libs/react-ui/src/components/Button/Button.css.ts
@@ -1,5 +1,6 @@
+import { colorPalette } from '@theme/colors';
 import { sprinkles } from '@theme/sprinkles.css';
-import { ColorType, vars } from '@theme/vars.css';
+import { ColorType, darkThemeClass, vars } from '@theme/vars.css';
 import {
   createVar,
   keyframes,
@@ -25,6 +26,13 @@ export const container = style([
     paddingY: '$3',
     placeItems: 'center',
     textDecoration: 'none',
+    color: {
+      lightMode: '$white',
+      darkMode: '$gray80',
+    },
+    backgroundColor: {
+      darkMode: '$blue50',
+    },
   }),
   {
     selectors: {
@@ -33,26 +41,29 @@ export const container = style([
       },
       '&:hover': {
         backgroundColor: bgHoverColor,
-        color: 'white',
+        color: colorPalette.$white,
       },
       '&:active': {
         backgroundColor: bgActiveColor,
       },
       '&:focus-visible': {
         outlineOffset: '2px',
-        outlineWidth: '$md',
+        outlineWidth: vars.borderWidths.$md,
         outlineStyle: 'solid',
         outlineColor: focusOutlineColor,
       },
       '&:disabled': {
         opacity: 0.7,
-        backgroundColor: '$neutral3',
-        color: '$neutral1',
+        backgroundColor: colorPalette.$gray60,
+        color: colorPalette.$gray10,
         cursor: 'not-allowed',
         pointerEvents: 'none',
       },
+      [`${darkThemeClass} &:hover`]: {
+        color: colorPalette.$gray100,
+        backgroundColor: colorPalette.$blue30,
+      },
     },
-    color: 'white',
     transition: 'background-color 0.4s ease',
   },
 ]);


### PR DESCRIPTION
We noted that in Docs, after switching from [react-components to react-ui](https://github.com/kadena-community/kadena.js/pull/717), the hover style of a button that's rendered as anchor wasn't correct. This fixes that by correctly setting the button color and font weight.

Current/faulty hover:
![image](https://github.com/kadena-community/kadena.js/assets/79908211/49b685f5-994a-40a3-a9ab-b1c13fdf03bd)

New/fixed hover:
![image](https://github.com/kadena-community/kadena.js/assets/79908211/975d5481-1421-4a39-8aba-3030fd6db6e7)
