### PR TITLE
fix(docs): header with inline codes

### DIFF
--- a/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
+++ b/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
@@ -2,13 +2,13 @@ import { styled, StyledComponent, SystemIcons } from '@kadena/react-components';
 import { Heading } from '@kadena/react-ui';
 
 import { createSlug } from '@/utils';
-import React, { FC, ReactNode } from 'react';
+import React, { FC, ReactElement } from 'react';
 
 type TagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 interface IProp {
   as: TagType;
   variant?: TagType;
-  children: string | string[] | ReactNode[];
+  children: ReactElement[];
   index?: number;
   parentTitle?: string;
 }
@@ -78,9 +78,17 @@ export const TaggedHeading: FC<IProp> = ({
 
   if (Array.isArray(children)) {
     slugInputStr = children
-      .filter((child) => typeof child === 'string')
-      .map((child) => (child as string)?.replace(/\s+(?=\S*$)/g, ''))
-      .filter((child) => child !== '')
+      .map((child) => {
+        if (typeof child === 'string') {
+          return (child as string).trim();
+        } else if (
+          typeof child === 'object' &&
+          typeof child.props?.children === 'string'
+        ) {
+          return child.props.children.trim();
+        }
+        return '';
+      })
       .join(' ');
   } else {
     slugInputStr = children;

--- a/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
+++ b/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
@@ -2,13 +2,13 @@ import { styled, StyledComponent, SystemIcons } from '@kadena/react-components';
 import { Heading } from '@kadena/react-ui';
 
 import { createSlug } from '@/utils';
-import React, { FC, ReactElement } from 'react';
+import React, { FC, ReactNode } from 'react';
 
 type TagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 interface IProp {
   as: TagType;
   variant?: TagType;
-  children: string | ReactElement[];
+  children: ReactNode;
   index?: number;
   parentTitle?: string;
 }
@@ -77,20 +77,17 @@ export const TaggedHeading: FC<IProp> = ({
   let slugInputStr = '';
 
   if (Array.isArray(children)) {
-    slugInputStr = children
+    slugInputStr = [children]
+      .flat()
       .map((child) => {
-        if (typeof child === 'string') {
-          return (child as string).trim();
-        } else if (
-          typeof child === 'object' &&
-          typeof child.props?.children === 'string'
-        ) {
+        if (typeof child === 'string') return child.trim();
+        if (typeof child.props.children === 'string')
           return child.props.children.trim();
-        }
         return '';
       })
+      .filter((child) => child !== '') // remove empty strings to avoid join adding extra spaces
       .join(' ');
-  } else {
+  } else if (typeof children === 'string') {
     slugInputStr = children;
   }
 

--- a/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
+++ b/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
@@ -2,13 +2,13 @@ import { styled, StyledComponent, SystemIcons } from '@kadena/react-components';
 import { Heading } from '@kadena/react-ui';
 
 import { createSlug } from '@/utils';
-import React, { FC } from 'react';
+import React, { FC, ReactNode } from 'react';
 
 type TagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 interface IProp {
   as: TagType;
   variant?: TagType;
-  children: string;
+  children: string | string[] | ReactNode[];
   index?: number;
   parentTitle?: string;
 }
@@ -74,7 +74,19 @@ export const TaggedHeading: FC<IProp> = ({
   index,
   parentTitle,
 }) => {
-  const slug = createSlug(children, index, parentTitle);
+  let slugInputStr = '';
+
+  if (Array.isArray(children)) {
+    slugInputStr = children
+      .filter((child) => typeof child === 'string')
+      .map((child) => (child as string)?.replace(/\s+(?=\S*$)/g, ''))
+      .filter((child) => child !== '')
+      .join(' ');
+  } else {
+    slugInputStr = children;
+  }
+
+  const slug = createSlug(slugInputStr, index, parentTitle);
 
   return (
     <StyledHeader as={as} variant={variant ?? as}>

--- a/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
+++ b/packages/apps/docs/src/components/Markdown/Heading/Heading.tsx
@@ -8,7 +8,7 @@ type TagType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 interface IProp {
   as: TagType;
   variant?: TagType;
-  children: ReactElement[];
+  children: string | ReactElement[];
   index?: number;
   parentTitle?: string;
 }

--- a/packages/apps/docs/src/scripts/importReadme.mjs
+++ b/packages/apps/docs/src/scripts/importReadme.mjs
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import 'dotenv/config';
 import { remark } from 'remark';
 import { toMarkdown } from 'mdast-util-to-markdown';
+import { toString } from 'mdast-util-to-string';
 
 const DOCSROOT = './src/pages/docs/';
 
@@ -53,11 +54,7 @@ const getTitle = (pageAST) => {
     throw new Error('first node is not a Heading');
   }
 
-  return node.children
-    .filter((child) => child.type === 'text')
-    .map((child) => child.value)
-    .join(' ')
-    .trim();
+  return node.children.map((child) => toString(child).trim()).join(' ');
 };
 
 const createTreeRoot = (page) => ({

--- a/packages/apps/docs/src/scripts/importReadme.mjs
+++ b/packages/apps/docs/src/scripts/importReadme.mjs
@@ -46,14 +46,18 @@ export const createSlug = (str) => {
 };
 
 const getTitle = (pageAST) => {
-  // TODO: flatten all children recursively to prevent issue with
+  // flatten all children recursively to prevent issue with
   // E.g. ## some title with `code`
   const node = pageAST.children[0];
   if (node.type !== 'heading' || node.depth !== 2) {
     throw new Error('first node is not a Heading');
   }
 
-  return node.children[0].value;
+  return node.children
+    .filter((child) => child.type === 'text')
+    .map((child) => child.value)
+    .join(' ')
+    .trim();
 };
 
 const createTreeRoot = (page) => ({

--- a/packages/apps/docs/src/scripts/importReadme.mjs
+++ b/packages/apps/docs/src/scripts/importReadme.mjs
@@ -54,7 +54,7 @@ const getTitle = (pageAST) => {
     throw new Error('first node is not a Heading');
   }
 
-  return node.children.map((child) => toString(child).trim()).join(' ');
+  return node.children.flatMap((child) => toString(child).trim()).join(' ');
 };
 
 const createTreeRoot = (page) => ({


### PR DESCRIPTION
This PR fixes an issue with headers with inline code
Example - " ## Header with `features` "