### PR TITLE
Disable build caching in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
           node common/scripts/install-run-rush.js install ${{ env.AFFECTED_OR_ALL }}
 
       - name: Cache builds
-        if: github.ref_name != 'main'
+        if: ${{ false }}
+        # if: github.ref_name != 'main'
         uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
Didn't seem to work properly, see e.g. https://github.com/kadena-community/kadena.js/pull/751 + https://github.com/kadena-community/kadena.js/actions/runs/5794161673/job/15703214188?pr=751. 

After re-opening the same PR (https://github.com/kadena-community/kadena.js/pull/755) the re-build did work.