### PR TITLE
chore(react-ui): fix build cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,7 @@ jobs:
           node common/scripts/install-run-rush.js install ${{ env.AFFECTED_OR_ALL }}
 
       - name: Cache builds
-        if: ${{ false }}
-        # if: github.ref_name != 'main'
+        if: github.ref_name != 'main'
         uses: actions/cache@v3
         with:
           path: |

--- a/common/changes/@kadena/client/ag-fix-react-ui-build-cache_2023-08-08-11-42.json
+++ b/common/changes/@kadena/client/ag-fix-react-ui-build-cache_2023-08-08-11-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/packages/libs/client/config/rush-project.json
+++ b/packages/libs/client/config/rush-project.json
@@ -45,7 +45,7 @@
        * will restore these folders from the cache.  The strings are folder names under the project root folder.
        * These folders should not be tracked by Git.  They must not contain symlinks.
        */
-      "outputFolderNames": ["dist", "types", "theme"]
+      "outputFolderNames": ["dist", "fp", "lib"]
 
       /**
        * Disable caching for this operation.  The operation will never be restored from cache.

--- a/packages/libs/react-ui/config/rush-project.json
+++ b/packages/libs/react-ui/config/rush-project.json
@@ -1,0 +1,79 @@
+/**
+ * The "config/rush-project.json" file configures Rush-specific settings for an individual project
+ * in a Rush monorepo.  More documentation is available on the Rush website: https://rushjs.io
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush-project.schema.json",
+
+  /**
+   * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
+   * settings to be shared across multiple projects.
+   */
+  // "extends": "my-rig/profiles/default/config/rush-project.json",
+
+  /**
+   * The incremental analyzer can skip Rush commands for projects whose input files have not changed since
+   * the last build.  Normally, every Git-tracked file under the project folder is assumed to be an input.
+   * Use "incrementalBuildIgnoredGlobs" to ignore specific files, specified as globs relative to
+   * the project folder.  The glob syntax is based on the .gitignore file format.
+   */
+  "incrementalBuildIgnoredGlobs": [
+    // "etc/api-report/*.md"
+  ],
+
+  /**
+   * Disable caching for this project. The project will never be restored from cache. This may be useful
+   * if this project affects state outside of its folder.
+   *
+   * Default value: false
+   */
+  // "disableBuildCacheForProject": true,
+
+  /**
+   * Options for individual commands and phases.
+   */
+  "operationSettings": [
+    {
+      /**
+       * (Required) The name of the operation.
+       * This should be a key in the "package.json" file's "scripts" section.
+       */
+      "operationName": "build",
+
+      /**
+       * Specify the folders where this operation writes its output files.  If enabled, the Rush build cache
+       * will restore these folders from the cache.  The strings are folder names under the project root folder.
+       * These folders should not be tracked by Git.  They must not contain symlinks.
+       */
+      "outputFolderNames": ["dist", "types"]
+
+      /**
+       * Disable caching for this operation.  The operation will never be restored from cache.
+       * This may be useful if this operation affects state outside of its folder.
+       */
+      // "disableBuildCacheForOperation": true
+    }
+    // {
+    //   /**
+    //    * (Required) The name of the operation.
+    //    * This should be a key in the "package.json" file's "scripts" section.
+    //    */
+    //   "operationName": "build",
+    //
+    //   /**
+    //    * Specify the folders where this operation writes its output files.  If enabled, the Rush build cache
+    //    * will restore these folders from the cache.  The strings are folder names under the project root folder.
+    //    * These folders should not be tracked by Git.  They must not contain symlinks.
+    //    */
+    //   "outputFolderNames": [
+    //     "lib", "dist"
+    //   ],
+    //
+    //   /**
+    //    * Disable caching for this operation.  The operation will never be restored from cache.
+    //    * This may be useful if this operation affects state outside of its folder.
+    //    */
+    //   // "disableBuildCacheForOperation": true
+    // }
+  ]
+}


### PR DESCRIPTION
Fixes the build cache for react-ui

The build cache record was missing the `types` directory as the defaults are different than what is configured as output for the `@kadena/react-ui` project. 

See for info: 
https://rushjs.io/pages/maintainer/build_cache/#configuring-project-output-folders
https://rushjs.io/pages/configs/rush-project_json/