### PR TITLE
Use `jsonc` for json in Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,5 +11,5 @@ yarn.lock                    merge=binary
 #
 # For more information, see this issue: https://github.com/microsoft/rushstack/issues/1088
 #
-*.json                       linguist-language=JSON-with-Comments
+*.json                       linguist-language=jsonc
 *                            text=auto eol=lf

--- a/packages/libs/react-ui/config/rush-project.json
+++ b/packages/libs/react-ui/config/rush-project.json
@@ -1,0 +1,79 @@
+/**
+ * The "config/rush-project.json" file configures Rush-specific settings for an individual project
+ * in a Rush monorepo.  More documentation is available on the Rush website: https://rushjs.io
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush-project.schema.json",
+
+  /**
+   * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
+   * settings to be shared across multiple projects.
+   */
+  // "extends": "my-rig/profiles/default/config/rush-project.json",
+
+  /**
+   * The incremental analyzer can skip Rush commands for projects whose input files have not changed since
+   * the last build.  Normally, every Git-tracked file under the project folder is assumed to be an input.
+   * Use "incrementalBuildIgnoredGlobs" to ignore specific files, specified as globs relative to
+   * the project folder.  The glob syntax is based on the .gitignore file format.
+   */
+  "incrementalBuildIgnoredGlobs": [
+    // "etc/api-report/*.md"
+  ],
+
+  /**
+   * Disable caching for this project. The project will never be restored from cache. This may be useful
+   * if this project affects state outside of its folder.
+   *
+   * Default value: false
+   */
+  // "disableBuildCacheForProject": true,
+
+  /**
+   * Options for individual commands and phases.
+   */
+  "operationSettings": [
+    {
+      /**
+       * (Required) The name of the operation.
+       * This should be a key in the "package.json" file's "scripts" section.
+       */
+      "operationName": "build",
+
+      /**
+       * Specify the folders where this operation writes its output files.  If enabled, the Rush build cache
+       * will restore these folders from the cache.  The strings are folder names under the project root folder.
+       * These folders should not be tracked by Git.  They must not contain symlinks.
+       */
+      "outputFolderNames": ["dist", "types"]
+
+      /**
+       * Disable caching for this operation.  The operation will never be restored from cache.
+       * This may be useful if this operation affects state outside of its folder.
+       */
+      // "disableBuildCacheForOperation": true
+    }
+    // {
+    //   /**
+    //    * (Required) The name of the operation.
+    //    * This should be a key in the "package.json" file's "scripts" section.
+    //    */
+    //   "operationName": "build",
+    //
+    //   /**
+    //    * Specify the folders where this operation writes its output files.  If enabled, the Rush build cache
+    //    * will restore these folders from the cache.  The strings are folder names under the project root folder.
+    //    * These folders should not be tracked by Git.  They must not contain symlinks.
+    //    */
+    //   "outputFolderNames": [
+    //     "lib", "dist"
+    //   ],
+    //
+    //   /**
+    //    * Disable caching for this operation.  The operation will never be restored from cache.
+    //    * This may be useful if this operation affects state outside of its folder.
+    //    */
+    //   // "disableBuildCacheForOperation": true
+    // }
+  ]
+}


### PR DESCRIPTION
- chore(monorepo): use `jsonc` as parser for json in Github
