### PR TITLE
fix(@kadena/react-ui): ContentHeader icon color in dark mode

### DIFF
--- a/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.css.ts
+++ b/packages/libs/react-ui/src/components/ContentHeader/ContentHeader.css.ts
@@ -7,6 +7,7 @@ export const containerClass = style([
     display: 'grid',
     gap: '$md',
     alignItems: 'center',
+    color: '$neutral6',
   }),
   {
     gridRowGap: vars.sizes.$xs,


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->
