### PR TITLE
fix(@kadena/react-ui): Update Grid prop names and overflow bug

### DIFF
--- a/packages/apps/docs/src/components/Layout/Blog/Blog.tsx
+++ b/packages/apps/docs/src/components/Layout/Blog/Blog.tsx
@@ -45,7 +45,7 @@ export const Blog: FC<IPageProps> = ({
             {children}
 
             <div className={bottomWrapperClass}>
-              <Grid.Root spacing={'xl'} columns={12}>
+              <Grid.Root spacing="$xl" columns={12}>
                 <Grid.Item columnSpan={4}>
                   <Stack
                     alignItems="flex-start"

--- a/packages/libs/react-ui/src/components/Grid/Grid.css.ts
+++ b/packages/libs/react-ui/src/components/Grid/Grid.css.ts
@@ -15,14 +15,14 @@ export const gridItemClass = style([
 ]);
 
 export const gapVariants = styleVariants({
-  '2xs': [sprinkles({ gridGap: '$2xs' })],
-  xs: [sprinkles({ gridGap: '$xs' })],
-  sm: [sprinkles({ gridGap: '$sm' })],
-  md: [sprinkles({ gridGap: '$md' })],
-  lg: [sprinkles({ gridGap: '$lg' })],
-  xl: [sprinkles({ gridGap: '$xl' })],
-  '2xl': [sprinkles({ gridGap: '$2xl' })],
-  '3xl': [sprinkles({ gridGap: '$3xl' })],
+  $2xs: [sprinkles({ gridGap: '$2xs' })],
+  $xs: [sprinkles({ gridGap: '$xs' })],
+  $sm: [sprinkles({ gridGap: '$sm' })],
+  $md: [sprinkles({ gridGap: '$md' })],
+  $lg: [sprinkles({ gridGap: '$lg' })],
+  $xl: [sprinkles({ gridGap: '$xl' })],
+  $2xl: [sprinkles({ gridGap: '$2xl' })],
+  $3xl: [sprinkles({ gridGap: '$3xl' })],
 });
 
 export const rowSpanVariants = styleVariants({
@@ -61,7 +61,7 @@ const containerColumnVariantsArray = Object.keys(breakpoints).map((key) => {
       {
         '@media': {
           [breakpoints[key]]: {
-            gridTemplateColumns: `repeat(${count}, 1fr)`,
+            gridTemplateColumns: `repeat(${count}, minmax(0, 1fr))`,
           },
         },
       },
@@ -72,7 +72,7 @@ const containerColumnVariantsArray = Object.keys(breakpoints).map((key) => {
 export const explicitColumnVariant = styleVariants(columnCount, (count) => {
   return [
     {
-      gridTemplateColumns: `repeat(${count}, 1fr)`,
+      gridTemplateColumns: `repeat(${count}, minmax(0, 1fr))`,
     },
   ];
 });

--- a/packages/libs/react-ui/src/components/Grid/Grid.stories.tsx
+++ b/packages/libs/react-ui/src/components/Grid/Grid.stories.tsx
@@ -57,7 +57,7 @@ type Story = StoryObj<
 export const GridRoot: Story = {
   name: 'Grid',
   args: {
-    spacing: 'xl',
+    spacing: '$xl',
     columns: {
       sm: 2,
       md: 4,
@@ -104,7 +104,7 @@ export const GridRoot: Story = {
 
 export const GridItem: Story = {
   args: {
-    spacing: 'xl',
+    spacing: '$xl',
     columns: 12,
     columnSpan: {
       sm: 2,

--- a/packages/libs/react-ui/src/components/Grid/GridRoot.tsx
+++ b/packages/libs/react-ui/src/components/Grid/GridRoot.tsx
@@ -36,7 +36,7 @@ const assembleColumnVariants = (
 const GridRoot: FC<IGridRootProps> = ({
   children,
   columns,
-  spacing = 'md',
+  spacing = '$md',
 }) => {
   const classList = classNames(
     gapVariants[spacing],


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->

- Updated the grid spacing options to have a `$` prefix like other components
- Updated the styles so that even if the contents are larger than column, they overflow. This means that the grid will always fit within it's parent container regardless of the child's size. We may want to change this in the future, but I think this behavior is better at the moment
