### PR TITLE
[docs] Bug: Sidemenu text is showing up on BlogChain

### DIFF
--- a/packages/apps/docs/src/pages/docs/blogchain/index.tsx
+++ b/packages/apps/docs/src/pages/docs/blogchain/index.tsx
@@ -62,9 +62,6 @@ const BlogChainHome: FC<IProps> = ({ frontmatter, posts }) => {
                 isDone={isDone}
               />
             </BlogList>
-            {
-              //<div>sidemenu</div>
-            }
           </Stack>
         </Article>
       </Content>

--- a/packages/apps/docs/src/pages/docs/blogchain/index.tsx
+++ b/packages/apps/docs/src/pages/docs/blogchain/index.tsx
@@ -62,7 +62,9 @@ const BlogChainHome: FC<IProps> = ({ frontmatter, posts }) => {
                 isDone={isDone}
               />
             </BlogList>
-            <div>sidemenu</div>
+            {
+              //<div>sidemenu</div>
+            }
           </Stack>
         </Article>
       </Content>


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->

Hides the sidemenu placeholder for the Blogchain section of the docs
