### PR TITLE
Update Select component

### DIFF
--- a/packages/libs/react-ui/src/components/Input/Input.css.ts
+++ b/packages/libs/react-ui/src/components/Input/Input.css.ts
@@ -17,7 +17,6 @@ export const containerClass = style([
     color: '$foreground',
     overflow: 'hidden',
     lineHeight: '$lg',
-    flexDirection: 'column',
     bg: {
       lightMode: '$white',
       darkMode: '$gray100',

--- a/packages/libs/react-ui/src/components/Input/Input.css.ts
+++ b/packages/libs/react-ui/src/components/Input/Input.css.ts
@@ -12,16 +12,19 @@ export const inputStatusColor = createVar();
 export const containerClass = style([
   sprinkles({
     alignItems: 'stretch',
+    borderRadius: '$sm',
     display: 'flex',
+    color: '$foreground',
     overflow: 'hidden',
+    lineHeight: '$lg',
+    flexDirection: 'column',
     bg: {
       lightMode: '$white',
       darkMode: '$gray100',
     },
-    color: '$foreground',
-    borderRadius: '$sm',
   }),
   {
+    position: 'relative',
     borderBottom: `1px solid ${fallbackVar(
       inputStatusColor,
       vars.colors.$gray30,
@@ -51,22 +54,23 @@ export const containerClass = style([
 export const inputContainerClass = style([
   sprinkles({
     alignItems: 'center',
-    lineHeight: '$lg',
     display: 'flex',
-    paddingX: '$4',
-    paddingY: '$2',
-    gap: '$2',
     flexGrow: 1,
+    gap: '$2',
+    lineHeight: '$lg',
+    paddingX: '$4',
   }),
 ]);
 
 export const inputClass = style([
   sprinkles({
+    alignItems: 'center',
     background: 'none',
     border: 'none',
     color: '$foreground',
     outline: 'none',
     flexGrow: 1,
+    paddingY: '$2',
   }),
   {
     '::placeholder': {

--- a/packages/libs/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/libs/react-ui/src/components/Input/Input.stories.tsx
@@ -4,11 +4,37 @@ import { IInputProps, Input } from '@components/Input';
 import { Stack } from '@components/Stack';
 import type { Meta, StoryObj } from '@storybook/react';
 import { vars } from '@theme/vars.css';
-import React from 'react';
+import React, { HTMLInputTypeAttribute } from 'react';
+
+const HTMLInputTypes: HTMLInputTypeAttribute[] = [
+  'button',
+  'checkbox',
+  'color',
+  'date',
+  'datetime-local',
+  'email',
+  'file',
+  'hidden',
+  'image',
+  'month',
+  'number',
+  'password',
+  'radio',
+  'range',
+  'reset',
+  'search',
+  'submit',
+  'tel',
+  'text',
+  'time',
+  'url',
+  'week',
+];
 
 const meta: Meta<
   {
     leftIcon: keyof typeof SystemIcon;
+    type?: React.HTMLInputTypeAttribute;
   } & IInputProps
 > = {
   title: 'Components/Input',
@@ -21,6 +47,10 @@ const meta: Meta<
     },
   },
   argTypes: {
+    type: {
+      control: { type: 'select' },
+      options: HTMLInputTypes,
+    },
     disabled: {
       description: 'Disables the input and applies visual styling.',
       control: {
@@ -35,7 +65,7 @@ const meta: Meta<
       description:
         'Icon rendered inside the input to the left of the input text.',
       options: [
-        undefined,
+        '-',
         ...(Object.keys(SystemIcon) as (keyof typeof SystemIcon)[]),
       ],
       control: {
@@ -46,7 +76,7 @@ const meta: Meta<
       description:
         'Icon rendered inside the input to the right of the input text.',
       options: [
-        undefined,
+        '-',
         ...(Object.keys(SystemIcon) as (keyof typeof SystemIcon)[]),
       ],
       control: {
@@ -58,6 +88,7 @@ const meta: Meta<
       control: {
         type: 'text',
       },
+      description: 'Text to display before the input',
     },
     leadingTextWidth: {
       description:
@@ -66,7 +97,7 @@ const meta: Meta<
         type: 'select',
       },
       options: [
-        undefined,
+        '- Omit this property to auto-size the leading text',
         ...Object.keys(vars.sizes).map((key) => key as keyof typeof vars.sizes),
       ],
     },
@@ -89,6 +120,7 @@ type Story = StoryObj<
     leadingText: string;
     leftIcon: keyof typeof SystemIcon;
     rightIcon: keyof typeof SystemIcon;
+    type: React.HTMLInputTypeAttribute;
   } & Omit<IInputProps, 'leftIcon' | 'rightIcon'>
 >;
 
@@ -96,8 +128,9 @@ export const Dynamic: Story = {
   name: 'Input',
   args: {
     leftIcon: undefined,
+    type: 'text',
     rightIcon: undefined,
-    leadingText: 'Leading',
+    leadingText: '',
     leadingTextWidth: undefined,
     outlined: false,
   },
@@ -109,6 +142,7 @@ export const Dynamic: Story = {
     leadingTextWidth,
     onChange,
     disabled,
+    type,
   }) => (
     <Input
       id="inlineInputStory"
@@ -120,6 +154,7 @@ export const Dynamic: Story = {
       leadingTextWidth={leadingTextWidth}
       outlined={outlined}
       disabled={disabled}
+      type={type}
     />
   ),
 };
@@ -128,19 +163,22 @@ export const InlineWithButton: Story = {
   name: 'Inline with button',
   args: {
     leftIcon: undefined,
+    type: 'text',
   },
-  render: ({ leftIcon, onChange }) => (
-    <Stack gap="$xs" alignItems="stretch">
+  render: ({ leftIcon, onChange, type }) => (
+    <Stack spacing="$xs" alignItems="stretch">
       <Input
         id="inlineInputStory"
         leftIcon={SystemIcon[leftIcon]}
         onChange={onChange}
         placeholder="This is a placeholder"
         outlined
+        type={type}
       />
       <Button title="Submit" onClick={() => {}}>
         Submit
       </Button>
+      <input type="" placeholder="This is a placeholder" />
     </Stack>
   ),
 };

--- a/packages/libs/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/libs/react-ui/src/components/Input/Input.stories.tsx
@@ -88,7 +88,6 @@ const meta: Meta<
       control: {
         type: 'text',
       },
-      description: 'Text to display before the input',
     },
     leadingTextWidth: {
       description:

--- a/packages/libs/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/libs/react-ui/src/components/Input/Input.stories.tsx
@@ -178,7 +178,6 @@ export const InlineWithButton: Story = {
       <Button title="Submit" onClick={() => {}}>
         Submit
       </Button>
-      <input type="" placeholder="This is a placeholder" />
     </Stack>
   ),
 };

--- a/packages/libs/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/libs/react-ui/src/components/Input/Input.stories.tsx
@@ -166,7 +166,7 @@ export const InlineWithButton: Story = {
     type: 'text',
   },
   render: ({ leftIcon, onChange, type }) => (
-    <Stack spacing="$xs" alignItems="stretch">
+    <Stack gap="$xs" alignItems="stretch">
       <Input
         id="inlineInputStory"
         leftIcon={SystemIcon[leftIcon]}

--- a/packages/libs/react-ui/src/components/Input/Input.tsx
+++ b/packages/libs/react-ui/src/components/Input/Input.tsx
@@ -23,7 +23,7 @@ export interface IInputProps
   leftIcon?: (typeof SystemIcon)[keyof typeof SystemIcon];
   rightIcon?: (typeof SystemIcon)[keyof typeof SystemIcon];
   disabled?: boolean;
-  type?: string;
+  type?: React.HTMLInputTypeAttribute;
   ref?: React.ForwardedRef<HTMLInputElement>;
   id: string;
   outlined?: boolean;

--- a/packages/libs/react-ui/src/components/Select/Option.tsx
+++ b/packages/libs/react-ui/src/components/Select/Option.tsx
@@ -1,5 +1,3 @@
-import { optionClass } from './Select.css';
-
 import React, { FC } from 'react';
 
 export interface IOptionProps
@@ -9,7 +7,5 @@ export interface IOptionProps
 }
 
 export const Option: FC<IOptionProps> = ({ children, ...rest }) => (
-  <option className={optionClass} {...rest}>
-    {children}
-  </option>
+  <option {...rest}>{children}</option>
 );

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -11,7 +11,6 @@ export const containerClass = style([
     overflow: 'hidden',
     lineHeight: '$lg',
     borderRadius: '$sm',
-    flexDirection: 'column',
     borderColor: {
       lightMode: '$white',
       darkMode: '$gray60',

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -10,7 +10,7 @@ export const containerClass = style([
     display: 'flex',
     overflow: 'hidden',
     lineHeight: '$lg',
-    borderRadius: '$sm',
+    borderRadius: '$xs',
     borderColor: {
       lightMode: '$white',
       darkMode: '$gray60',
@@ -46,7 +46,7 @@ export const selectVariants = styleVariants({
       backgroundColor: 'transparent',
     }),
     {
-      border: `1px solid ${vars.colors.$gray30}`,
+      border: `1px solid ${vars.colors.$gray40}`,
     },
   ],
 });

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -1,20 +1,28 @@
 import { vars } from '../../styles';
 
 import { sprinkles } from '@theme/sprinkles.css';
-import { style, styleVariants } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 
 export const containerClass = style([
   sprinkles({
     alignItems: 'stretch',
-    color: '$foreground',
-    display: 'flex',
-    overflow: 'hidden',
-    lineHeight: '$lg',
+    backgroundColor: {
+      lightMode: '$white',
+      darkMode: '$background',
+    },
     borderColor: {
       lightMode: '$white',
       darkMode: '$gray60',
     },
+    borderRadius: '$sm',
+    color: '$foreground',
+    display: 'flex',
+    lineHeight: '$lg',
+    overflow: 'hidden',
   }),
+  {
+    borderBottom: `1px solid ${vars.colors.$gray30}`,
+  },
 ]);
 
 export const containerClassDisabled = style([
@@ -27,30 +35,6 @@ export const containerClassDisabled = style([
     },
   }),
 ]);
-
-export const selectVariants = styleVariants({
-  form: [
-    sprinkles({
-      backgroundColor: {
-        lightMode: '$white',
-        darkMode: '$background',
-      },
-      borderRadius: '$sm',
-    }),
-    {
-      borderBottom: `1px solid ${vars.colors.$gray30}`,
-    },
-  ],
-  transparent: [
-    sprinkles({
-      backgroundColor: 'transparent',
-      borderRadius: '$xs',
-    }),
-    {
-      border: `1px solid ${vars.colors.$gray40}`,
-    },
-  ],
-});
 
 export const selectContainerClass = style([
   sprinkles({
@@ -66,8 +50,8 @@ export const selectContainerClass = style([
 
 export const iconClass = style([
   sprinkles({
-    display: 'flex',
     alignItems: 'center',
+    display: 'flex',
   }),
 ]);
 
@@ -76,10 +60,10 @@ export const selectClass = style([
     background: 'none',
     border: 'none',
     color: '$foreground',
+    flexGrow: 1,
     outline: 'none',
     paddingRight: '$2',
     paddingY: '$2',
-    flexGrow: 1,
   }),
   {
     backgroundColor: 'inherit',

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -56,7 +56,8 @@ export const selectContainerClass = style([
     lineHeight: '$lg',
     flexGrow: 1,
     display: 'flex',
-    paddingX: '$2',
+    paddingRight: '$2',
+    paddingLeft: '$4',
     gap: '$2',
   }),
 ]);

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -13,7 +13,7 @@ export const containerClass = style([
     flexDirection: 'column',
     backgroundColor: {
       lightMode: '$white',
-      darkMode: '$gray100',
+      darkMode: '$background',
     },
     color: '$foreground',
     borderColor: {
@@ -43,9 +43,10 @@ export const selectVariants = styleVariants({
       borderBottom: `1px solid ${vars.colors.$gray30}`,
     },
   ],
-  solid: [
+  flat: [
     {
       border: `1px solid ${vars.colors.$gray30}`,
+      background: 'transparent !important',
     },
   ],
 });

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -29,11 +29,9 @@ export const containerClassDisabled = style([
   sprinkles({
     backgroundColor: {
       lightMode: '$gray30',
-      // darkMode: '$gray100',
     },
     color: {
       lightMode: '$gray100',
-      // darkMode: '$gray40',
     },
   }),
 ]);

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -44,10 +44,10 @@ export const selectVariants = styleVariants({
   transparent: [
     sprinkles({
       backgroundColor: 'transparent',
+      borderRadius: '$xs',
     }),
     {
       border: `1px solid ${vars.colors.$gray40}`,
-      borderRadius: '$xs',
     },
   ],
 });

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -5,7 +5,6 @@ import { style } from '@vanilla-extract/css';
 
 export const containerClass = style([
   sprinkles({
-    padding: '$2',
     borderRadius: '$sm',
   }),
   {
@@ -55,17 +54,18 @@ export const iconClass = style([
   sprinkles({
     marginRight: '$2',
     marginLeft: '$2',
-    display: 'block',
+    display: 'flex',
+    alignItems: 'center',
   }),
 ]);
 
 export const selectClass = style([
   sprinkles({
+    padding: '$2',
     border: 'none',
     fontSize: '$base',
   }),
   {
-    padding: '0',
     backgroundColor: 'inherit',
     color: 'inherit',
     flex: '1',

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -10,7 +10,7 @@ export const containerClass = style([
     display: 'flex',
     overflow: 'hidden',
     lineHeight: '$lg',
-    borderRadius: '$xs',
+    borderRadius: '$sm',
     borderColor: {
       lightMode: '$white',
       darkMode: '$gray60',
@@ -47,6 +47,7 @@ export const selectVariants = styleVariants({
     }),
     {
       border: `1px solid ${vars.colors.$gray40}`,
+      borderRadius: '$xs',
     },
   ],
 });

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -21,9 +21,21 @@ export const containerClass = style([
     },
   }),
   {
-    // border: `1px solid`,
     position: 'relative',
   },
+]);
+
+export const containerClassDisabled = style([
+  sprinkles({
+    backgroundColor: {
+      lightMode: '$gray30',
+      // darkMode: '$gray100',
+    },
+    color: {
+      lightMode: '$gray100',
+      // darkMode: '$gray40',
+    },
+  }),
 ]);
 
 export const selectVariants = styleVariants({
@@ -32,9 +44,9 @@ export const selectVariants = styleVariants({
       borderBottom: `1px solid ${vars.colors.$gray30}`,
     },
   ],
-  form: [
+  solid: [
     {
-      borderBottom: `1px solid ${vars.colors.$gray30}`,
+      border: `1px solid ${vars.colors.$gray30}`,
     },
   ],
 });

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -35,7 +35,7 @@ export const containerClassDisabled = style([
 ]);
 
 export const selectVariants = styleVariants({
-  default: [
+  form: [
     {
       borderBottom: `1px solid ${vars.colors.$gray30}`,
     },

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -10,7 +10,6 @@ export const containerClass = style([
     display: 'flex',
     overflow: 'hidden',
     lineHeight: '$lg',
-    borderRadius: '$sm',
     borderColor: {
       lightMode: '$white',
       darkMode: '$gray60',
@@ -36,6 +35,7 @@ export const selectVariants = styleVariants({
         lightMode: '$white',
         darkMode: '$background',
       },
+      borderRadius: '$sm',
     }),
     {
       borderBottom: `1px solid ${vars.colors.$gray30}`,

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -1,48 +1,43 @@
 import { vars } from '../../styles';
 
 import { sprinkles } from '@theme/sprinkles.css';
-import { style } from '@vanilla-extract/css';
+import { style, styleVariants } from '@vanilla-extract/css';
 
 export const containerClass = style([
   sprinkles({
     borderRadius: '$sm',
+    paddingRight: '$4',
+    backgroundColor: {
+      lightMode: '$white',
+      darkMode: '$gray100',
+    },
+    color: {
+      lightMode: '$gray60',
+      darkMode: '$gray40',
+    },
+    borderColor: {
+      lightMode: '$white',
+      darkMode: '$gray60',
+    },
   }),
   {
+    // border: `1px solid`,
     position: 'relative',
   },
 ]);
 
-export const containerClassForm = style([
-  sprinkles({
-    backgroundColor: '$white',
-  }),
-  {
-    boxShadow: `0 1px 1px 0 ${vars.colors.$gray30}`,
-  },
-]);
-
-export const containerClassFormDisabled = style([
-  sprinkles({
-    backgroundColor: '$gray20',
-  }),
-  {
-    boxShadow: 'none',
-  },
-]);
-
-export const containerClassDefault = style([
-  sprinkles({
-    backgroundColor: '$black',
-    color: '$gray40',
-  }),
-  {
-    border: `1px solid ${vars.colors.$gray60}`,
-    ':disabled': {
-      pointerEvents: 'none',
-      backgroundColor: vars.colors.$gray20,
+export const selectVariants = styleVariants({
+  default: [
+    {
+      borderBottom: `1px solid ${vars.colors.$gray30}`,
     },
-  },
-]);
+  ],
+  form: [
+    {
+      borderBottom: `1px solid ${vars.colors.$gray30}`,
+    },
+  ],
+});
 
 export const selectContainerClass = style([
   sprinkles({

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -12,10 +12,6 @@ export const containerClass = style([
     lineHeight: '$lg',
     borderRadius: '$sm',
     flexDirection: 'column',
-    backgroundColor: {
-      lightMode: '$white',
-      darkMode: '$background',
-    },
     borderColor: {
       lightMode: '$white',
       darkMode: '$gray60',
@@ -36,14 +32,22 @@ export const containerClassDisabled = style([
 
 export const selectVariants = styleVariants({
   form: [
+    sprinkles({
+      backgroundColor: {
+        lightMode: '$white',
+        darkMode: '$background',
+      },
+    }),
     {
       borderBottom: `1px solid ${vars.colors.$gray30}`,
     },
   ],
-  flat: [
+  transparent: [
+    sprinkles({
+      backgroundColor: 'transparent',
+    }),
     {
       border: `1px solid ${vars.colors.$gray30}`,
-      background: 'transparent !important',
     },
   ],
 });

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -6,6 +6,7 @@ import { style, styleVariants } from '@vanilla-extract/css';
 export const containerClass = style([
   sprinkles({
     alignItems: 'stretch',
+    color: '$foreground',
     display: 'flex',
     overflow: 'hidden',
     lineHeight: '$lg',
@@ -15,15 +16,11 @@ export const containerClass = style([
       lightMode: '$white',
       darkMode: '$background',
     },
-    color: '$foreground',
     borderColor: {
       lightMode: '$white',
       darkMode: '$gray60',
     },
   }),
-  {
-    position: 'relative',
-  },
 ]);
 
 export const containerClassDisabled = style([
@@ -54,12 +51,12 @@ export const selectVariants = styleVariants({
 export const selectContainerClass = style([
   sprinkles({
     alignItems: 'center',
-    lineHeight: '$lg',
-    flexGrow: 1,
     display: 'flex',
-    paddingRight: '$2',
-    paddingLeft: '$4',
+    flexGrow: 1,
     gap: '$2',
+    lineHeight: '$lg',
+    paddingLeft: '$4',
+    paddingRight: '$2',
   }),
 ]);
 

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -66,10 +66,3 @@ export const selectClass = style([
     flex: '1',
   },
 ]);
-
-export const optionClass = style([
-  sprinkles({
-    backgroundColor: '$neutral1',
-    color: '$neutral5',
-  }),
-]);

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -17,8 +17,12 @@ export const containerClass = style([
     borderRadius: '$sm',
     color: '$foreground',
     display: 'flex',
+    flexGrow: 1,
+    gap: '$2',
     lineHeight: '$lg',
     overflow: 'hidden',
+    paddingLeft: '$4',
+    paddingRight: '$2',
   }),
   {
     borderBottom: `1px solid ${vars.colors.$gray30}`,
@@ -33,18 +37,6 @@ export const containerClassDisabled = style([
     color: {
       lightMode: '$foreground',
     },
-  }),
-]);
-
-export const selectContainerClass = style([
-  sprinkles({
-    alignItems: 'center',
-    display: 'flex',
-    flexGrow: 1,
-    gap: '$2',
-    lineHeight: '$lg',
-    paddingLeft: '$4',
-    paddingRight: '$2',
   }),
 ]);
 

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -5,19 +5,44 @@ import { style } from '@vanilla-extract/css';
 
 export const containerClass = style([
   sprinkles({
-    backgroundColor: '$neutral1',
-    color: '$neutral5',
     padding: '$2',
     borderRadius: '$sm',
   }),
   {
-    boxShadow: `0 1px 1px 0 ${vars.colors.$gray30}`,
     position: 'relative',
   },
 ]);
-export const containerClassDisabled = style([
-  sprinkles({ pointerEvents: 'none' }),
-  { opacity: 0.5 },
+
+export const containerClassForm = style([
+  sprinkles({
+    backgroundColor: '$white',
+  }),
+  {
+    boxShadow: `0 1px 1px 0 ${vars.colors.$gray30}`,
+  },
+]);
+
+export const containerClassFormDisabled = style([
+  sprinkles({
+    backgroundColor: '$gray20',
+  }),
+  {
+    boxShadow: 'none',
+  },
+]);
+
+export const containerClassDefault = style([
+  sprinkles({
+    backgroundColor: '$black',
+    color: '$gray40',
+  }),
+  {
+    border: `1px solid ${vars.colors.$gray60}`,
+    ':disabled': {
+      pointerEvents: 'none',
+      backgroundColor: vars.colors.$gray20,
+    },
+  },
 ]);
 
 export const selectContainerClass = style([

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -5,16 +5,17 @@ import { style, styleVariants } from '@vanilla-extract/css';
 
 export const containerClass = style([
   sprinkles({
+    alignItems: 'stretch',
+    display: 'flex',
+    overflow: 'hidden',
+    lineHeight: '$lg',
     borderRadius: '$sm',
-    paddingRight: '$4',
+    flexDirection: 'column',
     backgroundColor: {
       lightMode: '$white',
       darkMode: '$gray100',
     },
-    color: {
-      lightMode: '$gray60',
-      darkMode: '$gray40',
-    },
+    color: '$foreground',
     borderColor: {
       lightMode: '$white',
       darkMode: '$gray60',
@@ -28,10 +29,10 @@ export const containerClass = style([
 export const containerClassDisabled = style([
   sprinkles({
     backgroundColor: {
-      lightMode: '$gray30',
+      lightMode: '$gray20',
     },
     color: {
-      lightMode: '$gray100',
+      lightMode: '$foreground',
     },
   }),
 ]);
@@ -51,14 +52,17 @@ export const selectVariants = styleVariants({
 
 export const selectContainerClass = style([
   sprinkles({
+    alignItems: 'center',
+    lineHeight: '$lg',
+    flexGrow: 1,
     display: 'flex',
+    paddingX: '$2',
+    gap: '$2',
   }),
 ]);
 
 export const iconClass = style([
   sprinkles({
-    marginRight: '$2',
-    marginLeft: '$2',
     display: 'flex',
     alignItems: 'center',
   }),
@@ -66,13 +70,16 @@ export const iconClass = style([
 
 export const selectClass = style([
   sprinkles({
-    padding: '$2',
+    background: 'none',
     border: 'none',
-    fontSize: '$base',
+    color: '$foreground',
+    outline: 'none',
+    paddingRight: '$2',
+    paddingY: '$2',
+    flexGrow: 1,
   }),
   {
     backgroundColor: 'inherit',
     color: 'inherit',
-    flex: '1',
   },
 ]);

--- a/packages/libs/react-ui/src/components/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Select/Select.css.ts
@@ -1,3 +1,5 @@
+import { vars } from '../../styles';
+
 import { sprinkles } from '@theme/sprinkles.css';
 import { style } from '@vanilla-extract/css';
 
@@ -9,8 +11,8 @@ export const containerClass = style([
     borderRadius: '$sm',
   }),
   {
+    boxShadow: `0 1px 1px 0 ${vars.colors.$gray30}`,
     position: 'relative',
-    border: 'solid 1px',
   },
 ]);
 export const containerClassDisabled = style([

--- a/packages/libs/react-ui/src/components/Select/Select.stories.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.stories.tsx
@@ -13,15 +13,32 @@ const meta: Meta<
   title: 'Components/Select',
   argTypes: {
     disabled: {
+      description: 'toggle disabled state of component',
       control: {
         type: 'boolean',
+        defaultValue: false,
       },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    variant: {
+      description: 'switch between style variants',
+      control: {
+        type: 'select',
+      },
+      table: {
+        type: { summary: 'select' },
+        defaultValue: { summary: 'default' },
+      },
+      options: ['default', 'form'],
     },
     icon: {
       options: [
-        undefined,
-        ...(Object.keys(SystemIcon) as (keyof typeof SystemIcon)[]),
-      ],
+        ...['-'],
+        ...Object.keys(SystemIcon),
+      ] as (keyof typeof SystemIcon)[],
       control: {
         type: 'select',
       },
@@ -33,6 +50,7 @@ export default meta;
 type Story = StoryObj<
   {
     icon: keyof typeof SystemIcon;
+    variant: 'default' | 'form';
   } & Omit<ISelectProps, 'icon'>
 >;
 
@@ -41,7 +59,7 @@ export const Dynamic: Story = {
   args: {
     icon: undefined,
   },
-  render: ({ icon, disabled }) => {
+  render: ({ icon, disabled, variant = 'default' }) => {
     const [value, setValue] = useState<string>('1');
     return (
       <Select
@@ -53,6 +71,7 @@ export const Dynamic: Story = {
         }}
         disabled={Boolean(disabled)}
         value={value}
+        variant={variant}
       >
         <Option value={'1'}>option 1</Option>
         <Option value={'2'}>option 2</Option>

--- a/packages/libs/react-ui/src/components/Select/Select.stories.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.stories.tsx
@@ -1,6 +1,5 @@
 import { Option } from './Option';
 import { ISelectProps, Select } from './Select';
-import { selectVariants } from './Select.css';
 
 import { SystemIcon } from '@components/Icon';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -24,18 +23,6 @@ const meta: Meta<
         defaultValue: { summary: 'false' },
       },
     },
-    variant: {
-      description:
-        'switch between style variants. The default is `form` which is the standard select that matches our other form inputs. `flat` is a variant with a full border and transparent background.',
-      control: {
-        type: 'select',
-      },
-      table: {
-        type: { summary: 'select' },
-        defaultValue: { summary: 'form' },
-      },
-      options: Object.keys(selectVariants) as (keyof typeof selectVariants)[],
-    },
     icon: {
       options: [
         ...['-'],
@@ -52,7 +39,6 @@ export default meta;
 type Story = StoryObj<
   {
     icon: keyof typeof SystemIcon;
-    variant: keyof typeof selectVariants;
   } & Omit<ISelectProps, 'icon'>
 >;
 
@@ -61,7 +47,7 @@ export const Dynamic: Story = {
   args: {
     icon: undefined,
   },
-  render: ({ icon, disabled, variant = 'form' }) => {
+  render: ({ icon, disabled }) => {
     const [value, setValue] = useState<string>('1');
     return (
       <Select
@@ -73,7 +59,6 @@ export const Dynamic: Story = {
         }}
         disabled={Boolean(disabled)}
         value={value}
-        variant={variant}
       >
         <Option value={'1'}>option 1</Option>
         <Option value={'2'}>option 2</Option>

--- a/packages/libs/react-ui/src/components/Select/Select.stories.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.stories.tsx
@@ -1,5 +1,5 @@
 import { Option } from './Option';
-import { ISelectProps, Select, variants } from './Select';
+import { ISelectProps, Select, SelectVariants, variants } from './Select';
 
 import { SystemIcon } from '@components/Icon';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -24,13 +24,14 @@ const meta: Meta<
       },
     },
     variant: {
-      description: 'switch between style variants',
+      description:
+        'switch between style variants. The default is `form` which is the standard select that matches our other form inputs. `flat` is a variant with a full border and transparent background.',
       control: {
         type: 'select',
       },
       table: {
         type: { summary: 'select' },
-        defaultValue: { summary: 'default' },
+        defaultValue: { summary: variants[0] },
       },
       options: variants,
     },
@@ -50,7 +51,7 @@ export default meta;
 type Story = StoryObj<
   {
     icon: keyof typeof SystemIcon;
-    variant: 'default' | 'form';
+    variant: SelectVariants;
   } & Omit<ISelectProps, 'icon'>
 >;
 
@@ -59,7 +60,7 @@ export const Dynamic: Story = {
   args: {
     icon: undefined,
   },
-  render: ({ icon, disabled, variant = 'default' }) => {
+  render: ({ icon, disabled, variant = variants[0] }) => {
     const [value, setValue] = useState<string>('1');
     return (
       <Select

--- a/packages/libs/react-ui/src/components/Select/Select.stories.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.stories.tsx
@@ -1,5 +1,6 @@
 import { Option } from './Option';
-import { ISelectProps, Select, SelectVariants } from './Select';
+import { ISelectProps, Select } from './Select';
+import { selectVariants } from './Select.css';
 
 import { SystemIcon } from '@components/Icon';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -33,7 +34,7 @@ const meta: Meta<
         type: { summary: 'select' },
         defaultValue: { summary: 'form' },
       },
-      options: ['form', 'transparent'] as SelectVariants[],
+      options: ['form', 'transparent'],
     },
     icon: {
       options: [
@@ -51,7 +52,7 @@ export default meta;
 type Story = StoryObj<
   {
     icon: keyof typeof SystemIcon;
-    variant: SelectVariants;
+    variant: keyof typeof selectVariants;
   } & Omit<ISelectProps, 'icon'>
 >;
 

--- a/packages/libs/react-ui/src/components/Select/Select.stories.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.stories.tsx
@@ -1,5 +1,5 @@
 import { Option } from './Option';
-import { ISelectProps, Select } from './Select';
+import { ISelectProps, Select, variants } from './Select';
 
 import { SystemIcon } from '@components/Icon';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -32,7 +32,7 @@ const meta: Meta<
         type: { summary: 'select' },
         defaultValue: { summary: 'default' },
       },
-      options: ['default', 'form'],
+      options: variants,
     },
     icon: {
       options: [

--- a/packages/libs/react-ui/src/components/Select/Select.stories.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta<
         type: { summary: 'select' },
         defaultValue: { summary: 'form' },
       },
-      options: ['form', 'transparent'],
+      options: Object.keys(selectVariants) as (keyof typeof selectVariants)[],
     },
     icon: {
       options: [

--- a/packages/libs/react-ui/src/components/Select/Select.stories.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.stories.tsx
@@ -1,5 +1,5 @@
 import { Option } from './Option';
-import { ISelectProps, Select, SelectVariants, variants } from './Select';
+import { ISelectProps, Select, SelectVariants } from './Select';
 
 import { SystemIcon } from '@components/Icon';
 import type { Meta, StoryObj } from '@storybook/react';
@@ -31,9 +31,9 @@ const meta: Meta<
       },
       table: {
         type: { summary: 'select' },
-        defaultValue: { summary: variants[0] },
+        defaultValue: { summary: 'form' },
       },
-      options: variants,
+      options: ['form', 'transparent'] as SelectVariants[],
     },
     icon: {
       options: [
@@ -60,7 +60,7 @@ export const Dynamic: Story = {
   args: {
     icon: undefined,
   },
-  render: ({ icon, disabled, variant = variants[0] }) => {
+  render: ({ icon, disabled, variant = 'form' }) => {
     const [value, setValue] = useState<string>('1');
     return (
       <Select

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -11,8 +11,6 @@ import { SystemIcon } from '@components/Icon';
 import classNames from 'classnames';
 import React, { FC, forwardRef } from 'react';
 
-export type SelectVariants = 'form' | 'transparent';
-
 export interface ISelectProps
   extends Omit<
     React.HTMLAttributes<HTMLSelectElement>,
@@ -25,7 +23,7 @@ export interface ISelectProps
   onChange: React.ChangeEventHandler<HTMLSelectElement>;
   ref?: React.ForwardedRef<HTMLSelectElement>;
   ariaLabel: string;
-  variant?: SelectVariants;
+  variant?: keyof typeof selectVariants;
 }
 
 export const Select: FC<ISelectProps> = forwardRef<

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -48,7 +48,7 @@ export const Select: FC<ISelectProps> = forwardRef<
       className={classNames(
         containerClass,
         selectVariants[variant],
-        disabled && containerClassDisabled,
+        { containerClassDisabled: disabled }
       )}
       data-testid="kda-select"
     >

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -11,7 +11,7 @@ import { SystemIcon } from '@components/Icon';
 import classNames from 'classnames';
 import React, { FC, forwardRef } from 'react';
 
-export const variants: ['default', 'solid'] = ['default', 'solid'];
+export const variants: ['default', 'flat'] = ['default', 'flat'];
 
 export interface ISelectProps
   extends Omit<
@@ -45,7 +45,7 @@ export const Select: FC<ISelectProps> = forwardRef<
 ) {
   return (
     <div
-      className={classNames(containerClass, selectVariants[variant], {
+      className={classNames(selectVariants[variant], containerClass, {
         [containerClassDisabled]: disabled,
       })}
       data-testid="kda-select"

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -50,23 +50,21 @@ export const Select: FC<ISelectProps> = forwardRef<
       })}
       data-testid="kda-select"
     >
-      <label>
-        <div className={selectContainerClass}>
-          {Icon && (
-            <span className={iconClass}>
-              <Icon size="md" />
-            </span>
-          )}
-          <select
-            aria-label={ariaLabel}
-            ref={ref}
-            className={selectClass}
-            disabled={Boolean(disabled)}
-            {...rest}
-          >
-            {children}
-          </select>
-        </div>
+      <label className={selectContainerClass}>
+        {Icon && (
+          <span className={iconClass}>
+            <Icon size="md" />
+          </span>
+        )}
+        <select
+          aria-label={ariaLabel}
+          ref={ref}
+          className={selectClass}
+          disabled={Boolean(disabled)}
+          {...rest}
+        >
+          {children}
+        </select>
       </label>
     </div>
   );

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -1,5 +1,6 @@
 import {
   containerClass,
+  containerClassDisabled,
   iconClass,
   selectClass,
   selectContainerClass,
@@ -9,6 +10,8 @@ import {
 import { SystemIcon } from '@components/Icon';
 import classNames from 'classnames';
 import React, { FC, forwardRef } from 'react';
+
+export const variants: ['default', 'solid'] = ['default', 'solid'];
 
 export interface ISelectProps
   extends Omit<
@@ -22,7 +25,7 @@ export interface ISelectProps
   onChange: React.ChangeEventHandler<HTMLSelectElement>;
   ref?: React.ForwardedRef<HTMLSelectElement>;
   ariaLabel: string;
-  variant?: 'default' | 'form';
+  variant?: (typeof variants)[number];
 }
 
 export const Select: FC<ISelectProps> = forwardRef<
@@ -42,7 +45,11 @@ export const Select: FC<ISelectProps> = forwardRef<
 ) {
   return (
     <div
-      className={classNames(containerClass, selectVariants[variant])}
+      className={classNames(
+        containerClass,
+        selectVariants[variant],
+        disabled && containerClassDisabled,
+      )}
       data-testid="kda-select"
     >
       <label>

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -1,11 +1,9 @@
 import {
   containerClass,
-  containerClassDefault,
-  containerClassForm,
-  containerClassFormDisabled,
   iconClass,
   selectClass,
   selectContainerClass,
+  selectVariants,
 } from './Select.css';
 
 import { SystemIcon } from '@components/Icon';
@@ -44,11 +42,7 @@ export const Select: FC<ISelectProps> = forwardRef<
 ) {
   return (
     <div
-      className={classNames(
-        containerClass,
-        variant === 'form' ? containerClassForm : containerClassDefault,
-        disabled && variant === 'form' && containerClassFormDisabled,
-      )}
+      className={classNames(containerClass, selectVariants[variant])}
       data-testid="kda-select"
     >
       <label>

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -11,7 +11,8 @@ import { SystemIcon } from '@components/Icon';
 import classNames from 'classnames';
 import React, { FC, forwardRef } from 'react';
 
-export const variants: ['default', 'flat'] = ['default', 'flat'];
+export type SelectVariants = 'form' | 'flat';
+export const variants: SelectVariants[] = ['form', 'flat'];
 
 export interface ISelectProps
   extends Omit<
@@ -38,7 +39,7 @@ export const Select: FC<ISelectProps> = forwardRef<
     disabled = false,
     children,
     ariaLabel,
-    variant = 'default',
+    variant = variants[0],
     ...rest
   },
   ref,

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -50,7 +50,7 @@ export const Select: FC<ISelectProps> = forwardRef<
       })}
       data-testid="kda-select"
     >
-      <label className={selectContainerClass}>
+      <div className={selectContainerClass}>
         {Icon && (
           <span className={iconClass}>
             <Icon size="md" />
@@ -65,7 +65,7 @@ export const Select: FC<ISelectProps> = forwardRef<
         >
           {children}
         </select>
-      </label>
+      </div>
     </div>
   );
 });

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -25,7 +25,7 @@ export interface ISelectProps
   onChange: React.ChangeEventHandler<HTMLSelectElement>;
   ref?: React.ForwardedRef<HTMLSelectElement>;
   ariaLabel: string;
-  variant?: (typeof variants)[number];
+    variant?: keyof typeof selectVariants;
 }
 
 export const Select: FC<ISelectProps> = forwardRef<

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -4,7 +4,6 @@ import {
   iconClass,
   selectClass,
   selectContainerClass,
-  selectVariants,
 } from './Select.css';
 
 import { SystemIcon } from '@components/Icon';
@@ -23,7 +22,6 @@ export interface ISelectProps
   onChange: React.ChangeEventHandler<HTMLSelectElement>;
   ref?: React.ForwardedRef<HTMLSelectElement>;
   ariaLabel: string;
-  variant?: keyof typeof selectVariants;
 }
 
 export const Select: FC<ISelectProps> = forwardRef<
@@ -36,14 +34,13 @@ export const Select: FC<ISelectProps> = forwardRef<
     disabled = false,
     children,
     ariaLabel,
-    variant = 'form',
     ...rest
   },
   ref,
 ) {
   return (
     <div
-      className={classNames(containerClass, selectVariants[variant], {
+      className={classNames(containerClass, {
         [containerClassDisabled]: disabled,
       })}
       data-testid="kda-select"

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -11,8 +11,7 @@ import { SystemIcon } from '@components/Icon';
 import classNames from 'classnames';
 import React, { FC, forwardRef } from 'react';
 
-export type SelectVariants = 'form' | 'flat';
-export const variants: SelectVariants[] = ['form', 'flat'];
+export type SelectVariants = 'form' | 'transparent';
 
 export interface ISelectProps
   extends Omit<
@@ -26,7 +25,7 @@ export interface ISelectProps
   onChange: React.ChangeEventHandler<HTMLSelectElement>;
   ref?: React.ForwardedRef<HTMLSelectElement>;
   ariaLabel: string;
-  variant?: keyof typeof selectVariants;
+  variant?: SelectVariants;
 }
 
 export const Select: FC<ISelectProps> = forwardRef<
@@ -39,7 +38,7 @@ export const Select: FC<ISelectProps> = forwardRef<
     disabled = false,
     children,
     ariaLabel,
-    variant = variants[0],
+    variant = 'form',
     ...rest
   },
   ref,

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -3,7 +3,6 @@ import {
   containerClassDisabled,
   iconClass,
   selectClass,
-  selectContainerClass,
 } from './Select.css';
 
 import { SystemIcon } from '@components/Icon';
@@ -45,22 +44,20 @@ export const Select: FC<ISelectProps> = forwardRef<
       })}
       data-testid="kda-select"
     >
-      <div className={selectContainerClass}>
-        {Icon && (
-          <span className={iconClass}>
-            <Icon size="md" />
-          </span>
-        )}
-        <select
-          aria-label={ariaLabel}
-          ref={ref}
-          className={selectClass}
-          disabled={Boolean(disabled)}
-          {...rest}
-        >
-          {children}
-        </select>
-      </div>
+      {Icon && (
+        <span className={iconClass}>
+          <Icon size="md" />
+        </span>
+      )}
+      <select
+        aria-label={ariaLabel}
+        ref={ref}
+        className={selectClass}
+        disabled={Boolean(disabled)}
+        {...rest}
+      >
+        {children}
+      </select>
     </div>
   );
 });

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -25,7 +25,7 @@ export interface ISelectProps
   onChange: React.ChangeEventHandler<HTMLSelectElement>;
   ref?: React.ForwardedRef<HTMLSelectElement>;
   ariaLabel: string;
-    variant?: keyof typeof selectVariants;
+  variant?: keyof typeof selectVariants;
 }
 
 export const Select: FC<ISelectProps> = forwardRef<
@@ -45,11 +45,9 @@ export const Select: FC<ISelectProps> = forwardRef<
 ) {
   return (
     <div
-      className={classNames(
-        containerClass,
-        selectVariants[variant],
-        { containerClassDisabled: disabled }
-      )}
+      className={classNames(containerClass, selectVariants[variant], {
+        [containerClassDisabled]: disabled,
+      })}
       data-testid="kda-select"
     >
       <label>

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -14,13 +14,13 @@ export interface ISelectProps
     React.HTMLAttributes<HTMLSelectElement>,
     'aria-label' | 'as' | 'className'
   > {
+  ariaLabel: string;
   children: React.ReactNode;
-  icon?: (typeof SystemIcon)[keyof typeof SystemIcon];
   disabled?: boolean;
-  value: string[] | string | number;
+  icon?: (typeof SystemIcon)[keyof typeof SystemIcon];
   onChange: React.ChangeEventHandler<HTMLSelectElement>;
   ref?: React.ForwardedRef<HTMLSelectElement>;
-  ariaLabel: string;
+  value: string[] | string | number;
 }
 
 export const Select: FC<ISelectProps> = forwardRef<
@@ -28,11 +28,11 @@ export const Select: FC<ISelectProps> = forwardRef<
   ISelectProps
 >(function Select(
   {
+    ariaLabel,
+    children,
+    disabled = false,
     // eslint-disable-next-line @typescript-eslint/naming-convention
     icon: Icon,
-    disabled = false,
-    children,
-    ariaLabel,
     ...rest
   },
   ref,
@@ -51,9 +51,9 @@ export const Select: FC<ISelectProps> = forwardRef<
       )}
       <select
         aria-label={ariaLabel}
-        ref={ref}
         className={selectClass}
         disabled={Boolean(disabled)}
+        ref={ref}
         {...rest}
       >
         {children}

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -1,6 +1,8 @@
 import {
   containerClass,
-  containerClassDisabled,
+  containerClassDefault,
+  containerClassForm,
+  containerClassFormDisabled,
   iconClass,
   selectClass,
   selectContainerClass,
@@ -22,6 +24,7 @@ export interface ISelectProps
   onChange: React.ChangeEventHandler<HTMLSelectElement>;
   ref?: React.ForwardedRef<HTMLSelectElement>;
   ariaLabel: string;
+  variant?: 'default' | 'form';
 }
 
 export const Select: FC<ISelectProps> = forwardRef<
@@ -34,6 +37,7 @@ export const Select: FC<ISelectProps> = forwardRef<
     disabled = false,
     children,
     ariaLabel,
+    variant = 'default',
     ...rest
   },
   ref,
@@ -42,7 +46,8 @@ export const Select: FC<ISelectProps> = forwardRef<
     <div
       className={classNames(
         containerClass,
-        disabled ? containerClassDisabled : '',
+        variant === 'form' ? containerClassForm : containerClassDefault,
+        disabled && variant === 'form' && containerClassFormDisabled,
       )}
       data-testid="kda-select"
     >

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -51,22 +51,24 @@ export const Select: FC<ISelectProps> = forwardRef<
       )}
       data-testid="kda-select"
     >
-      <div className={selectContainerClass}>
-        {Icon && (
-          <span className={iconClass}>
-            <Icon size="md" />
-          </span>
-        )}
-        <select
-          aria-label={ariaLabel}
-          ref={ref}
-          className={selectClass}
-          disabled={Boolean(disabled)}
-          {...rest}
-        >
-          {children}
-        </select>
-      </div>
+      <label>
+        <div className={selectContainerClass}>
+          {Icon && (
+            <span className={iconClass}>
+              <Icon size="md" />
+            </span>
+          )}
+          <select
+            aria-label={ariaLabel}
+            ref={ref}
+            className={selectClass}
+            disabled={Boolean(disabled)}
+            {...rest}
+          >
+            {children}
+          </select>
+        </div>
+      </label>
     </div>
   );
 });

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -43,7 +43,7 @@ export const Select: FC<ISelectProps> = forwardRef<
 ) {
   return (
     <div
-      className={classNames(selectVariants[variant], containerClass, {
+      className={classNames(containerClass, selectVariants[variant], {
         [containerClassDisabled]: disabled,
       })}
       data-testid="kda-select"

--- a/packages/libs/react-ui/src/components/Tooltip/Tooltip.css.ts
+++ b/packages/libs/react-ui/src/components/Tooltip/Tooltip.css.ts
@@ -19,6 +19,7 @@ export const container = style([
     pointerEvents: 'none',
   }),
   {
+    zIndex: 10,
     top: '50%',
     marginRight: '-50%',
     border: `${vars.borderWidths.$md} solid ${vars.colors.$neutral2}`,

--- a/packages/libs/react-ui/tsconfig.json
+++ b/packages/libs/react-ui/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "./node_modules/@kadena-dev/heft-rig/profiles/default/tsconfig-base.json",
-  "ts-node": {
-    "require": ["tsconfig-paths/register"]
-  },
   "compilerOptions": {
     "baseUrl": ".",
     "types": ["node", "heft-jest", "@testing-library/jest-dom"],


### PR DESCRIPTION
### Select Component updates

[Asana Link](https://app.asana.com/0/1204958723576385/1205164815746147/f)

**What changed?**
- Updated Select styling to match design and support dark and light theme
- Tweaked the size of the native HTML select element that we render to ensure you can click anywhere on the actual Select component to see its options (previously required to click in the center of our visual component)
- Added disabled styling (missing exact design, [also missing in e.g. Input component](https://app.asana.com/0/1205288273408141/1205332525545630/f)?)
- Add variant prop to allow switching between default form select and one with a solid border and transparent background
- Set Tooltip z-index as a temporary fix to ensure it's above form elements (created [task](https://app.asana.com/0/1205288273408141/1205307366740459/f) to fix this for all components)
- Removed style from option elements as these can't be styled (?? not sure what the idea was there, am I missing something?)
- Added typing to the Input component type to match valid HTML Input Types rather than any string and updated Storybook implementation to allow switching between input types

**Implementation preview in Storybook, showing Input and Select:**

https://github.com/kadena-community/kadena.js/assets/79908211/75a157ed-c58f-4001-8095-0162d07a50d5

