### PR TITLE
Refactor NavHeader

### DIFF
--- a/packages/libs/react-ui/src/components/NavHeader/NavHeader.stories.tsx
+++ b/packages/libs/react-ui/src/components/NavHeader/NavHeader.stories.tsx
@@ -98,6 +98,7 @@ export const Dynamic: IStory = {
     renderSampleContent = false,
   }) => {
     const navItems = useCustomNavigation ? customNavigation : sampleNavItems;
+
     return (
       <NavHeader.Root brand={brand}>
         <NavHeader.Navigation>

--- a/packages/libs/react-ui/src/components/NavHeader/NavHeader.stories.tsx
+++ b/packages/libs/react-ui/src/components/NavHeader/NavHeader.stories.tsx
@@ -27,6 +27,7 @@ const sampleNavItems: INavItems = [
 
 type StoryProps = {
   linksCount: number;
+  navHeaderActiveLink: number;
   renderSampleContent: boolean;
   useCustomNavigation: boolean;
   customNavigation: INavItems;
@@ -66,6 +67,14 @@ const meta: Meta<StoryProps> = {
       description: 'Adjust sample navigation items count',
       if: { arg: 'useCustomNavigation', neq: true },
     },
+    navHeaderActiveLink: {
+      control: { disable: true },
+      description:
+        'Which link should be active at start? Set as NavHeader.Navigation prop to change from default',
+      table: {
+        defaultValue: { summary: 0 },
+      },
+    },
     customNavigation: {
       defaultValue: [],
       description: 'Custom navigation items',
@@ -88,6 +97,7 @@ export const Dynamic: IStory = {
   args: {
     brand: logoVariants[0],
     linksCount: 3,
+    navHeaderActiveLink: 0,
     customNavigation: sampleNavItems,
   },
   render: ({
@@ -95,13 +105,14 @@ export const Dynamic: IStory = {
     useCustomNavigation,
     customNavigation,
     linksCount,
+    navHeaderActiveLink,
     renderSampleContent = false,
   }) => {
     const navItems = useCustomNavigation ? customNavigation : sampleNavItems;
 
     return (
       <NavHeader.Root brand={brand}>
-        <NavHeader.Navigation>
+        <NavHeader.Navigation activeLink={navHeaderActiveLink}>
           {navItems.slice(0, linksCount).map((item, index) => (
             <NavHeader.Link key={index} href={item.href}>
               {item.label}

--- a/packages/libs/react-ui/src/components/NavHeader/NavHeaderLink.tsx
+++ b/packages/libs/react-ui/src/components/NavHeader/NavHeaderLink.tsx
@@ -1,28 +1,25 @@
 import { activeLinkClass, linkClass } from './NavHeader.css';
+import { INavItem } from './NavHeaderNavigation';
 
 import classNames from 'classnames';
-import React, { FC, HTMLAttributeAnchorTarget } from 'react';
+import React, { FC } from 'react';
 
-export interface INavHeaderLinkProps {
-  children: string;
-  href: string;
-  active?: boolean;
-  target?: HTMLAttributeAnchorTarget | undefined;
-}
-
-export const NavHeaderLink: FC<INavHeaderLinkProps> = ({
+export const NavHeaderLink: FC<INavItem & { children?: string }> = ({
+  active,
   children,
   href,
-  active,
   target,
+  onClick,
 }) => {
   return (
     <a
       className={classNames(linkClass, {
         [activeLinkClass]: active,
+        'nav-item': true,
       })}
       href={href}
       target={target}
+      onClick={onClick}
     >
       {children}
     </a>

--- a/packages/libs/react-ui/src/components/NavHeader/NavHeaderNavigation.tsx
+++ b/packages/libs/react-ui/src/components/NavHeader/NavHeaderNavigation.tsx
@@ -1,8 +1,15 @@
 import { NavGlow } from './assets/glow';
-import { glowClass, navListClass, navWrapperClass } from './NavHeader.css';
+import {
+  activeLinkClass,
+  glowClass,
+  linkClass,
+  navListClass,
+  navWrapperClass,
+} from './NavHeader.css';
 import { INavHeaderLinkProps } from './NavHeaderLink';
 import useGlow from './useGlow';
 
+import classNames from 'classnames';
 import React, { FC, FunctionComponentElement } from 'react';
 
 export type INavItemTarget = '_self' | '_blank';
@@ -15,13 +22,15 @@ export type INavItems = INavItem[];
 
 export interface INavHeaderNavigationProps {
   children: FunctionComponentElement<INavHeaderLinkProps>[];
+  activeLink?: number;
 }
 
 export const NavHeaderNavigation: FC<INavHeaderNavigationProps> = ({
   children,
+  activeLink,
 }) => {
   const { glowX, animationDuration, glowRef, navRef, activeNav, setActiveNav } =
-    useGlow();
+    useGlow(activeLink);
 
   return (
     <nav className={navWrapperClass} ref={navRef}>
@@ -46,6 +55,9 @@ export const NavHeaderNavigation: FC<INavHeaderNavigationProps> = ({
               >,
               {
                 active: activeNav === index + 1,
+                className: classNames(linkClass, {
+                  [activeLinkClass]: activeNav === index + 1,
+                }),
               },
             )}
           </li>

--- a/packages/libs/react-ui/src/components/NavHeader/NavHeaderNavigation.tsx
+++ b/packages/libs/react-ui/src/components/NavHeader/NavHeaderNavigation.tsx
@@ -6,22 +6,25 @@ import {
   navListClass,
   navWrapperClass,
 } from './NavHeader.css';
-import { INavHeaderLinkProps } from './NavHeaderLink';
 import useGlow from './useGlow';
 
 import classNames from 'classnames';
-import React, { FC, FunctionComponentElement } from 'react';
+import React, {
+  FC,
+  FunctionComponentElement,
+  HTMLAttributeAnchorTarget,
+} from 'react';
 
-export type INavItemTarget = '_self' | '_blank';
 export interface INavItem {
+  active?: boolean;
   href: string;
-  target?: INavItemTarget;
-  title: string;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  target?: HTMLAttributeAnchorTarget;
 }
 export type INavItems = INavItem[];
 
 export interface INavHeaderNavigationProps {
-  children: FunctionComponentElement<INavHeaderLinkProps>[];
+  children: FunctionComponentElement<INavItem>[];
   activeLink?: number;
 }
 
@@ -49,14 +52,14 @@ export const NavHeaderNavigation: FC<INavHeaderNavigationProps> = ({
           <li key={`navItem-${index}`} onClick={() => setActiveNav(index + 1)}>
             {React.cloneElement(
               child as React.ReactElement<
-                HTMLElement | INavHeaderLinkProps,
-                | string
-                | React.JSXElementConstructor<JSX.Element & INavHeaderLinkProps>
+                HTMLElement | INavItem,
+                string | React.JSXElementConstructor<JSX.Element & INavItem>
               >,
               {
                 active: activeNav === index + 1,
                 className: classNames(linkClass, {
                   [activeLinkClass]: activeNav === index + 1,
+                  'nav-item': true,
                 }),
               },
             )}

--- a/packages/libs/react-ui/src/components/NavHeader/useGlow.ts
+++ b/packages/libs/react-ui/src/components/NavHeader/useGlow.ts
@@ -9,12 +9,12 @@ interface IUseGlowReturn {
   setActiveNav: React.Dispatch<React.SetStateAction<number>>;
 }
 
-const useGlow = (): IUseGlowReturn => {
+const useGlow = (active = 0): IUseGlowReturn => {
   const glowRef = useRef<HTMLDivElement>(null);
   const navRef = useRef<HTMLDivElement>(null);
 
-  const [glowX, setGlowX] = useState(0);
-  const [activeNav, setActiveNav] = useState(0);
+  const [glowX, setGlowX] = useState(active);
+  const [activeNav, setActiveNav] = useState(active);
 
   const prevGlowX = useRef<number>(glowX);
   const glowAnimationSpeed = useRef<number>(0);

--- a/packages/libs/react-ui/src/components/NavHeader/useGlow.ts
+++ b/packages/libs/react-ui/src/components/NavHeader/useGlow.ts
@@ -21,7 +21,7 @@ const useGlow = (active = 0): IUseGlowReturn => {
 
   useEffect(() => {
     const activeNavElement = navRef.current?.querySelector(
-      `li:nth-child(${activeNav}) a`,
+      `li:nth-child(${activeNav}) .nav-item`,
     );
     const activeNavBounds = activeNavElement?.getBoundingClientRect();
     const glowBounds = glowRef.current?.getBoundingClientRect();

--- a/packages/libs/react-ui/src/components/index.ts
+++ b/packages/libs/react-ui/src/components/index.ts
@@ -62,6 +62,7 @@ export { Button } from './Button';
 export { Card } from './Card';
 export { ContentHeader } from './ContentHeader';
 export { NavFooter } from './NavFooter';
+export { NavHeader } from './NavHeader';
 export { Grid } from './Grid';
 export { IconButton } from './IconButton';
 export { Input } from './Input/Input';

--- a/packages/libs/react-ui/src/index.ts
+++ b/packages/libs/react-ui/src/index.ts
@@ -75,6 +75,7 @@ export {
   Modal,
   ModalProvider,
   NavFooter,
+  NavHeader,
   Notification,
   Option,
   Pagination,


### PR DESCRIPTION
Through many changes to the implementation of NavHeader we ended up with a less than ideal version of it.

This PR will fix some of these issues and also some other things that were forgotten <sup>1</sup>

**<sup>1</sup> other things this PR fixes:**
- the useGlow hook now supports a prop to set the active link
- we forgot to export the NavHeader from the react-ui components index barrel file