### PR TITLE
fix(notification): next js hydration error

### DIFF
--- a/packages/libs/react-ui/src/components/Notification/NotificationContainer.tsx
+++ b/packages/libs/react-ui/src/components/Notification/NotificationContainer.tsx
@@ -1,6 +1,6 @@
 import {
-  closeButtonClass,
   cardColorVariants,
+  closeButtonClass,
   containerClass,
   contentClass,
   descriptionClass,
@@ -44,7 +44,7 @@ export const NotificationContainer: FC<INotificationProps> = ({
 
       <div className={contentClass}>
         {title !== undefined && <h4>{title}</h4>}
-        <p className={descriptionClass}>{children}</p>
+        <div className={descriptionClass}>{children}</div>
       </div>
 
       {hasCloseButton && (


### PR DESCRIPTION
Using a `p` tag for description causing an issues in docs, like div tags wrapped within p tag. It introduced next js hydration error. 

```
<p>
  <div>
    notification description
  </div>
</p>
```