### PR TITLE
[client] Make addSignatures public

### DIFF
--- a/common/changes/@kadena/client/feat-addSignatures_2023-08-16-14-23.json
+++ b/common/changes/@kadena/client/feat-addSignatures_2023-08-16-14-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "Make addSignatures public",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -19,6 +19,12 @@ import { LocalRequestBody } from '@kadena/chainweb-node-client';
 import { LocalResponse } from '@kadena/chainweb-node-client';
 import { SessionTypes } from '@walletconnect/types';
 
+// @public
+export const addSignatures: (transaction: IUnsignedCommand, ...signatures: {
+    sig: string;
+    pubKey?: string;
+}[]) => IUnsignedCommand | ICommand;
+
 export { ChainId }
 
 // @public

--- a/packages/libs/client/src/signing/chainweaver/signWithChainweaver.ts
+++ b/packages/libs/client/src/signing/chainweaver/signWithChainweaver.ts
@@ -6,7 +6,7 @@ import {
   IQuicksignSigner,
 } from '../../signing-api/v1/quicksign';
 import { ISignFunction } from '../ISignFunction';
-import { addSignatures } from '../utils/addSignature';
+import { addSignatures } from '../utils/addSignatures';
 import { parseTransactionCommand } from '../utils/parseTransactionCommand';
 
 import fetch from 'cross-fetch';

--- a/packages/libs/client/src/signing/index.ts
+++ b/packages/libs/client/src/signing/index.ts
@@ -2,6 +2,7 @@ export { TWalletConnectChainId } from './walletconnect/walletConnectTypes';
 export { ISingleSignFunction, ISignFunction } from './ISignFunction';
 
 export * from './chainweaver/signWithChainweaver';
+export * from './utils/isSignedTransaction';
+export * from './utils/addSignatures';
 export * from './walletconnect/signWithWalletConnect';
 export * from './walletconnect/quicksignWithWalletConnect';
-export * from './utils/isSignedTransaction';

--- a/packages/libs/client/src/signing/utils/addSignatures.ts
+++ b/packages/libs/client/src/signing/utils/addSignatures.ts
@@ -11,7 +11,7 @@ const debug: Debugger = _debug('@kadena/client:signing:addSignature');
 /**
  * adds signatures to an {@link IUnsignedCommand | unsigned command}
  *
- * @internal
+ * @public
  */
 export const addSignatures: (
   transaction: IUnsignedCommand,

--- a/packages/libs/client/src/signing/utils/tests/addSignature.test.ts
+++ b/packages/libs/client/src/signing/utils/tests/addSignature.test.ts
@@ -1,5 +1,5 @@
 import { IPactCommand } from '../../../interfaces/IPactCommand';
-import { addSignatures } from '../addSignature';
+import { addSignatures } from '../addSignatures';
 
 describe('addSignature', () => {
   it('returns a new transaction object by adding the input signatures to the sigs array', () => {

--- a/packages/libs/client/src/signing/walletconnect/quicksignWithWalletConnect.ts
+++ b/packages/libs/client/src/signing/walletconnect/quicksignWithWalletConnect.ts
@@ -2,7 +2,7 @@ import { ICommand, IUnsignedCommand } from '@kadena/types';
 
 import { IQuicksignResponse } from '../../signing-api/v1/quicksign';
 import { ISignFunction } from '../ISignFunction';
-import { addSignatures } from '../utils/addSignature';
+import { addSignatures } from '../utils/addSignatures';
 import { parseTransactionCommand } from '../utils/parseTransactionCommand';
 
 import { TWalletConnectChainId } from './walletConnectTypes';


### PR DESCRIPTION
Made addSignatures public (again) to make signing in other ways than supported with @kadena/client easier.

Closes: #781 