### PR TITLE
[@kadena/tools] Implement initial openItem in Drawer Toolbar

### DIFF
--- a/packages/apps/tools/src/components/Common/DrawerToolbar/index.tsx
+++ b/packages/apps/tools/src/components/Common/DrawerToolbar/index.tsx
@@ -23,16 +23,19 @@ export interface IDrawerToolbarSection {
   children: ReactNode;
 }
 interface IProps {
+  initialOpenItem?: boolean;
   sections: IDrawerToolbarSection[];
 }
 
 export const DrawerToolbar: ForwardRefExoticComponent<
   Omit<IProps, 'ref'> & React.RefAttributes<HTMLElement>
 > = forwardRef<HTMLElement, IProps>(function DrawerToolbar(
-  { sections },
+  { sections, initialOpenItem = false },
   ref = null,
 ) {
-  const [visibleSection, setVisibleSection] = useState<number | null>(null);
+  const [visibleSection, setVisibleSection] = useState<number | null>(
+    initialOpenItem ? 0 : null,
+  );
   const isOpen = visibleSection !== null;
 
   const handleOpenSection = useCallback(
@@ -61,7 +64,7 @@ export const DrawerToolbar: ForwardRefExoticComponent<
               <IconButton
                 icon={Icon}
                 title={title}
-                onClick={() => setVisibleSection(index)}
+                onClick={() => handleOpenSection(index)}
               />
             </div>
           ))}


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->
