### PR TITLE
chore(monorepo): update README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,12 +37,15 @@ tutorials" such as:
 
 ### Switch branches
 
-Depending on the changes, you may need to invoke the following commands when
-switching branches to keep everything in check:
+When switching branches external- (npm) and monorepo-dependencies might have
+changed. Run the following command to update both:
 
-```bash
-rush update
-rush build -t <package name>
+```sh
+rush install
+rush build
+# or to install and build for a specific package
+rush install -t <package>
+rush build -t <package>
 ```
 
 ## Tests
@@ -62,6 +65,51 @@ Make sure to update the changelog before it gets merged:
 ```bash
 rush change
 ```
+
+## Fixing monorepo issues
+
+### Package or type not found
+
+When compiling, either locally or in Github CI, an issue with `type not found`
+could occur. To make sure it's not an issue with your code check the following.
+
+- is the dependency present in the packages' `package.json`
+- did you run `rush install`
+- did you run `rush build -t <package-to-work-on>`, or `rush build` to build all
+  packages
+- try `rush rebuild`, this will build regardless of any caching mechanisms
+- remove all non-tracked files and folders, and rebuild. Make sure to backup
+  `.env` and other files that you want to preserve
+  ```sh
+  cd packages && git clean -dfx .
+  rush install && rush rebuild
+  # or only specifically for a package
+  rush install -t <package> && rush rebuild -t <package>
+  ```
+
+### PR has conflicts with main
+
+1. run `git fetch && git rebase origin/master`. This will update the status of
+   the remote branches and then rebase your current branch on `master`
+   1. you get conflicts in either `repo-state.yaml` or `pnpm-lock.json`.  
+      run `rush update` to update those two files according to the packages'
+      dependencies
+   2. fix your other conflicts manually
+
+### Github Actions CI build is red, locally it works
+
+This could be an issue where you're depending on local caches or locally built
+projects that aren't up-to-date with master
+
+1. go into the `packages` directory and clear all non-committed files
+   ```sh
+   cd packages && git clean -dfx .
+   ```
+2. install packages and build and test the project. Use `rush rebuild` to bypass
+   caches
+   ```sh
+   rush install && rush rebuild && rush test
+   ```
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,43 @@ This monorepo contains libraries and tooling for frontend development.
 New contributors are welcome! If you're interested, please see [our guide to
 contributing][4].
 
+## Getting started
+
+First, you need to have `rush` (the monorepo manager tool) installed. You can
+use your preferred package manager to do so.
+
+```sh
+npm install --global @microsoft/rush
+# or
+pnpm install --global @microsoft/rush
+# or
+yarn install --global @microsoft/rush
+```
+
+To run a specific package in the monorepo, install its relevant packages, and
+build itself and its dependencies. You can omit `-t <package-name>` if you want
+to `install` and `build` all packages.
+
+```sh
+rush install -t <package-name>
+rush build -t <package-name>
+```
+
+Navigate to the relevant package and read the `README.md` on how to "Getting
+Started" for that packages.
+
+You can read all commands for that package by opening the `package.json`. In
+order to get the right dependencies and references, use `rushx` to start the
+`package.json#scripts`-commands.
+
+```sh
+# for example
+cd packages/apps/docs && rushx dev
+```
+
+If you experience issues with the monorepo, please take a look at
+[contribution guide > Fixing monorepo issues](./CONTRIBUTING.md#fixing-monorepo-issues)
+
 ## Packages
 
 Overview of the main packages maintained in this repository:


### PR DESCRIPTION
After several questions from the community, it would be a good idea
to have the getting started in the README itself, instead of hidden
in the CONTRIBUTION guide.

After comments on issue resolution in the monorepo, it is reasonable
to have a basic guide on how to fix problems. Relevant steps have
been added to the CONTRIBUTION guide.
