### PR TITLE
chore(client): update changelog

### DIFF
--- a/common/changes/@kadena/client/chore-ag-update-changelog-for-1.0.0_2023-08-22-14-00.json
+++ b/common/changes/@kadena/client/chore-ag-update-changelog-for-1.0.0_2023-08-22-14-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/client",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/client"
+}

--- a/packages/libs/client/CHANGELOG.json
+++ b/packages/libs/client/CHANGELOG.json
@@ -8,70 +8,18 @@
       "comments": {
         "none": [
           {
-            "comment": "prepare for final release of 1.0.0"
+            "comment": "Make the API more flexible by splitting it into three steps: build, sign and submit transaction"
+          },
+          { "comment": "Accepts multiple code in one transactions" },
+          {
+            "comment": "Refactoring types and suggest all related capabilities of the functions"
           },
           {
-            "comment": "Edit `@kadena/client` docs (fix links + improve readability)"
+            "comment": "exposing sighWithChainWeaver and SignWithWalletConnect"
           },
+          { "comment": "deprecating `poll` and `send`" },
           {
-            "comment": "Move sort-package-json to eslint plugin"
-          },
-          {
-            "comment": "Fix devDep for client"
-          },
-          {
-            "comment": "add jsdoc to client methods"
-          },
-          {
-            "comment": "Upgrade to new API"
-          },
-          {
-            "comment": "export commandBuilder for configure it with initial data"
-          },
-          {
-            "comment": "formatting and linting"
-          },
-          {
-            "comment": "submit returns single requestKey for one single input + export literal and readKeyset utils"
-          },
-          {
-            "comment": "fixed readKeyset"
-          },
-          {
-            "comment": "Rename createPactCommand to composePactCommand."
-          },
-          {
-            "comment": "Remove the wrapper payload.execution and payload.continuation."
-          },
-          {
-            "comment": "fix typo in `createClient().dirtyReady` to `createClient().dirtyRead`"
-          },
-          {
-            "comment": "Improve API for ISignFunction where the input matches the output. A single transaction returns a single signed transaction and respectively for an array"
-          },
-          {
-            "comment": "Fix links in client readme"
-          },
-          {
-            "comment": "Apply formatting"
-          },
-          {
-            "comment": "Remove format:pkg everywhere"
-          },
-          {
-            "comment": "update pact parser to parse symbols as string"
-          },
-          {
-            "comment": "remove ms from the time string"
-          },
-          {
-            "comment": "refactored composePactCommand to a more functional way and fixed issues with setMeta"
-          },
-          {
-            "comment": "refactore the client's utilities in order to return or accept requestObject { requestKey, chainId, networkId }"
-          },
-          {
-            "comment": "renamed getClient to createClient"
+            "comment": "introducing `submit` `pollStatus` `dirtyRead` `preflight` `signatureVerification` `runPact`"
           }
         ],
         "dependency": [

--- a/packages/libs/client/CHANGELOG.md
+++ b/packages/libs/client/CHANGELOG.md
@@ -7,28 +7,14 @@ Fri, 04 Aug 2023 16:10:02 GMT
 
 ### Updates
 
-- prepare for final release of 1.0.0
-- Edit `@kadena/client` docs (fix links + improve readability)
-- Move sort-package-json to eslint plugin
-- Fix devDep for client
-- add jsdoc to client methods
-- Upgrade to new API
-- export commandBuilder for configure it with initial data
-- formatting and linting
-- submit returns single requestKey for one single input + export literal and readKeyset utils
-- fixed readKeyset
-- Rename createPactCommand to composePactCommand.
-- Remove the wrapper payload.execution and payload.continuation.
-- fix typo in `createClient().dirtyReady` to `createClient().dirtyRead`
-- Improve API for ISignFunction where the input matches the output. A single transaction returns a single signed transaction and respectively for an array
-- Fix links in client readme
-- Apply formatting
-- Remove format:pkg everywhere
-- update pact parser to parse symbols as string
-- remove ms from the time string
-- refactored composePactCommand to a more functional way and fixed issues with setMeta
-- refactore the client's utilities in order to return or accept requestObject { requestKey, chainId, networkId }
-- renamed getClient to createClient
+- Make the API more flexible by splitting it into three steps - build
+  transactions | signing and | submitting
+- Accepts multiple code in one transactions
+- Refactoring types and suggest all related capabilities of the functions
+- exposing sighWithChainWeaver and SignWithWalletConnect
+- deprecating `poll` and `send`
+- introducing `submit` `pollStatus` `dirtyRead` `preflight`
+  `signatureVerification` `runPact`
 
 ## 0.6.1
 Mon, 10 Jul 2023 14:25:54 GMT


### PR DESCRIPTION
When we worked on version 1.0.0 we added changelog information using `rush change`.
This has lead to a too granular list of changes. To make it more relevant for
the consumer of the library, we decided to update the changelog with only a limited
set of entries
