### PR TITLE
fix(docs): ui alignment fixes

### DIFF
--- a/packages/apps/docs/src/components/Layout/Landing/Landing.tsx
+++ b/packages/apps/docs/src/components/Layout/Landing/Landing.tsx
@@ -1,5 +1,4 @@
 import {
-  Article,
   articleClass,
   contentClass,
   contentClassVariants,
@@ -34,7 +33,6 @@ export const Landing: FC<IPageProps> = ({
         >
           <article className={articleClass}>
             {children}
-
             <NotFound />
           </article>
         </div>

--- a/packages/apps/docs/src/pages/_app.tsx
+++ b/packages/apps/docs/src/pages/_app.tsx
@@ -54,10 +54,7 @@ export const MyApp = ({
 
   const handleBeforeUnload = (event: BeforeUnloadEvent): void => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { href } = (event as any).originalTarget?.activeElement || {};
-
-    if (!href) return;
-
+    const { href } = (event as any).originalTarget.activeElement;
     onExternalButtonClick(href);
   };
 

--- a/packages/apps/docs/src/pages/_app.tsx
+++ b/packages/apps/docs/src/pages/_app.tsx
@@ -54,7 +54,10 @@ export const MyApp = ({
 
   const handleBeforeUnload = (event: BeforeUnloadEvent): void => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const { href } = (event as any).originalTarget.activeElement;
+    const { href } = (event as any).originalTarget?.activeElement || {};
+
+    if (!href) return;
+
     onExternalButtonClick(href);
   };
 

--- a/packages/apps/docs/src/pages/docs/blogchain/index.tsx
+++ b/packages/apps/docs/src/pages/docs/blogchain/index.tsx
@@ -3,9 +3,7 @@ import { Stack } from '@kadena/react-ui';
 import { InfiniteScroll } from '@/components';
 import { BlogItem, BlogList } from '@/components/Blog';
 import {
-  Article,
   articleClass,
-  Content,
   contentClass,
   contentClassVariants,
   TitleHeader,

--- a/packages/apps/docs/src/pages/docs/kadena/index.tsx
+++ b/packages/apps/docs/src/pages/docs/kadena/index.tsx
@@ -39,7 +39,7 @@ const Home: FC = () => {
         </Text>
       </div>
 
-      <Stack wrap="wrap" spacing="$2xs" width="100%">
+      <Stack wrap="wrap" width="100%">
         <BrowseSection title="General" className={browseSectionWrapper}>
           <Link href="/docs/kadena/overview">Overview of Kadena</Link>
           <Link href="/docs/kadena/whitepapers">Whitepapers</Link>

--- a/packages/apps/docs/src/pages/index.tsx
+++ b/packages/apps/docs/src/pages/index.tsx
@@ -34,7 +34,7 @@ const Home: FC<IProps> = ({ popularPages }) => {
       >
         <article className={articleClass}>
           <Box marginBottom="$10">
-            <Stack wrap="wrap" spacing="$2xs">
+            <Stack wrap="wrap">
               <BrowseSection title="General" className={browseSectionWrapper}>
                 <Link href="/docs/kadena">Overview of Kadena</Link>
                 <Link href="/docs/kadena/kda/manage-kda">Manage your KDA</Link>

--- a/packages/apps/docs/src/styles/index.css.ts
+++ b/packages/apps/docs/src/styles/index.css.ts
@@ -1,18 +1,14 @@
-import { breakpoints, sprinkles } from '@kadena/react-ui/theme';
+import { breakpoints, vars } from '@kadena/react-ui/theme';
 
 import { style } from '@vanilla-extract/css';
 
 const browseSectionWrapper = style([
-  sprinkles({
-    gap: '$4',
-    paddingY: 0,
-    paddingX: '$4',
-  }),
   {
-    flexBasis: '48%',
+    flexBasis: '50%',
+    rowGap: vars.sizes.$4,
     '@media': {
       [breakpoints.md]: {
-        flexBasis: '30%',
+        flexBasis: '33%',
       },
     },
   },


### PR DESCRIPTION
This PR addresses couple of issues!

- UI alignment issues of the browse section spacing
- ~Before unload causing an issue when user manually reload the page, because of event is undefined at that time. So, added an extra check for it~ it's been take care of in general tracking PR