### PR TITLE
NavHeader feat: actively listen to activeLink changes

### DIFF
--- a/packages/apps/tools/src/components/Common/Layout/partials/Header/Header.tsx
+++ b/packages/apps/tools/src/components/Common/Layout/partials/Header/Header.tsx
@@ -58,7 +58,6 @@ const Header: FC<IHeaderProps> = () => {
       >
         {navItems.map((item, index) => (
           <NavHeader.Link
-            active={pathname === item.href}
             key={index}
             href={item.href}
             onClick={handleMenuItemClick}

--- a/packages/libs/react-ui/src/components/NavHeader/NavHeaderNavigation.tsx
+++ b/packages/libs/react-ui/src/components/NavHeader/NavHeaderNavigation.tsx
@@ -13,6 +13,7 @@ import React, {
   FC,
   FunctionComponentElement,
   HTMLAttributeAnchorTarget,
+  useEffect,
 } from 'react';
 
 export interface INavItem {
@@ -35,6 +36,10 @@ export const NavHeaderNavigation: FC<INavHeaderNavigationProps> = ({
 }) => {
   const { glowX, animationDuration, glowRef, navRef, activeNav, setActiveNav } =
     useGlow(activeLink);
+
+  useEffect(() => {
+    if (activeLink) setActiveNav(activeLink);
+  }, [activeLink]);
 
   return (
     <nav className={navWrapperClass} ref={navRef}>


### PR DESCRIPTION
**History:** initially `activeLink` was added as a prop on the `NavHeader.Navigation` to set the initially active navigation item.

**Update:** this PR will extend that functionality to actively listen to changes to the prop and update the navigation accordingly.

_This ensures that, for example, when passing the `activeLink` prop (controlled version of the NavHeader) and using the browser navigation buttons to go back or forward in history, the state will update and highlight the correct navigation item._

https://github.com/kadena-community/kadena.js/assets/79908211/976bebe8-ac02-4cbc-9544-3ac4a549c4e7
