### PR TITLE
feat(pactjs-cli): let users combine --file and --contract

### DIFF
--- a/common/changes/@kadena/pactjs-cli/feat-use-file-contract-together_2023-08-23-08-13.json
+++ b/common/changes/@kadena/pactjs-cli/feat-use-file-contract-together_2023-08-23-08-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kadena/pactjs-cli",
+      "comment": "let users use --file and --contract together",
+      "type": "none"
+    }
+  ],
+  "packageName": "@kadena/pactjs-cli"
+}

--- a/packages/tools/pactjs-cli/src/contract-generate/index.ts
+++ b/packages/tools/pactjs-cli/src/contract-generate/index.ts
@@ -39,9 +39,6 @@ const Options = z
     if (file === undefined && contract === undefined) {
       return false;
     }
-    if (file !== undefined && contract !== undefined) {
-      return false;
-    }
     return true;
   }, 'Error: either file or contract must be specified')
   .refine(({ contract, api: host }) => {


### PR DESCRIPTION
the pactParser supports combining files and contracts name while generating types so I removed the restriction in the cli tool
  