### PR TITLE
fix(@kadena/react-ui): Fixed leadingTextWidth in TextField Component + Added Story descriptions

### DIFF
--- a/packages/apps/tools/src/pages/transactions/cross-chain-transfer-finisher/index.tsx
+++ b/packages/apps/tools/src/pages/transactions/cross-chain-transfer-finisher/index.tsx
@@ -442,12 +442,12 @@ const CrossChainTransferFinisher: FC = () => {
                     disabled={true}
                     label={t('Gas Price')}
                     info={t('approx. USD 000.1 ¢')}
+                    leadingTextWidth="$16"
                     inputProps={{
                       ...register('gasPrice', { shouldUnregister: true }),
                       id: 'gas-price-input',
                       placeholder: t('Enter Gas Price'),
                       leadingText: t('KDA'),
-                      leadingTextWidth: '$16',
                     }}
                   />
                 </Grid.Item>

--- a/packages/libs/react-ui/src/components/Input/Input.css.ts
+++ b/packages/libs/react-ui/src/components/Input/Input.css.ts
@@ -97,7 +97,6 @@ export const leadingTextWrapperClass = style([
     backgroundColor: '$neutral2',
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
   }),
 ]);
 

--- a/packages/libs/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/libs/react-ui/src/components/Input/Input.stories.tsx
@@ -22,10 +22,13 @@ const meta: Meta<
   },
   argTypes: {
     disabled: {
-      description:
-        "Disables the input and applies visual styling. Defaults to 'false'.",
+      description: 'Disables the input and applies visual styling.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
       },
     },
     leftIcon: {
@@ -68,10 +71,13 @@ const meta: Meta<
       ],
     },
     outlined: {
-      description:
-        "Option to render the input with an outline. Defaults to 'false'.",
+      description: 'Option to render the input with an outline.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
       },
     },
   },

--- a/packages/libs/react-ui/src/components/Input/Input.stories.tsx
+++ b/packages/libs/react-ui/src/components/Input/Input.stories.tsx
@@ -12,13 +12,25 @@ const meta: Meta<
   } & IInputProps
 > = {
   title: 'Components/Input',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The Input component is a wrapper around the native input element that provides the ability to add additional information.',
+      },
+    },
+  },
   argTypes: {
     disabled: {
+      description:
+        "Disables the input and applies visual styling. Defaults to 'false'.",
       control: {
         type: 'boolean',
       },
     },
     leftIcon: {
+      description:
+        'Icon rendered inside the input to the left of the input text.',
       options: [
         undefined,
         ...(Object.keys(SystemIcon) as (keyof typeof SystemIcon)[]),
@@ -28,6 +40,8 @@ const meta: Meta<
       },
     },
     rightIcon: {
+      description:
+        'Icon rendered inside the input to the right of the input text.',
       options: [
         undefined,
         ...(Object.keys(SystemIcon) as (keyof typeof SystemIcon)[]),
@@ -37,11 +51,14 @@ const meta: Meta<
       },
     },
     leadingText: {
+      description: 'Leading text that is rendered to the left of the input.',
       control: {
         type: 'text',
       },
     },
     leadingTextWidth: {
+      description:
+        'Width of the leading text. Defaults to the size of the text itself.',
       control: {
         type: 'select',
       },
@@ -51,6 +68,8 @@ const meta: Meta<
       ],
     },
     outlined: {
+      description:
+        "Option to render the input with an outline. Defaults to 'false'.",
       control: {
         type: 'boolean',
       },

--- a/packages/libs/react-ui/src/components/Input/Input.tsx
+++ b/packages/libs/react-ui/src/components/Input/Input.tsx
@@ -45,7 +45,6 @@ export const Input: FC<IInputProps> = forwardRef<HTMLInputElement, IInputProps>(
     const RightIcon = rightIcon;
     const LeftIcon = leftIcon;
 
-    console.log({ leadingTextWidth });
     return (
       <div
         className={classNames(containerClass, { [outlinedClass]: outlined })}

--- a/packages/libs/react-ui/src/components/Input/Input.tsx
+++ b/packages/libs/react-ui/src/components/Input/Input.tsx
@@ -45,21 +45,20 @@ export const Input: FC<IInputProps> = forwardRef<HTMLInputElement, IInputProps>(
     const RightIcon = rightIcon;
     const LeftIcon = leftIcon;
 
+    console.log({ leadingTextWidth });
     return (
       <div
         className={classNames(containerClass, { [outlinedClass]: outlined })}
         data-testid="kda-input"
       >
         {Boolean(leadingText) && (
-          <div className={leadingTextWrapperClass}>
-            <span
-              className={classNames(
-                leadingTextClass,
-                leadingTextWidth && leadingTextWidthVariant[leadingTextWidth],
-              )}
-            >
-              {leadingText}
-            </span>
+          <div
+            className={classNames(
+              leadingTextWrapperClass,
+              leadingTextWidth && leadingTextWidthVariant[leadingTextWidth],
+            )}
+          >
+            <span className={leadingTextClass}>{leadingText}</span>
           </div>
         )}
         <div className={inputContainerClass}>

--- a/packages/libs/react-ui/src/components/InputWrapper/InputWrapper.stories.tsx
+++ b/packages/libs/react-ui/src/components/InputWrapper/InputWrapper.stories.tsx
@@ -1,28 +1,39 @@
 import { statusVariant } from './InputWrapper.css';
 
 import { SystemIcon } from '@components/Icon';
-import { IInputProps, Input } from '@components/Input';
+import { Input } from '@components/Input';
 import { IInputWrapperProps, InputWrapper } from '@components/InputWrapper';
 import type { Meta, StoryObj } from '@storybook/react';
 import { vars } from '@theme/vars.css';
 import React from 'react';
 
-const meta: Meta<
-  {
-    helperText: string;
-    leadingText: string;
-    leftIcon: keyof typeof SystemIcon;
-    rightIcon: keyof typeof SystemIcon;
-  } & IInputWrapperProps
-> = {
+type StoryProps = {
+  helperText: string;
+  leadingText: string;
+  leftIcon: keyof typeof SystemIcon;
+  rightIcon: keyof typeof SystemIcon;
+} & IInputWrapperProps;
+
+const meta: Meta<StoryProps> = {
   title: 'Components/InputWrapper',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The InputWrapper component is intended to be used to wrap one or more form input components to provide them with a shared and optional label, tag, info, helper text and status colors.',
+      },
+    },
+  },
   argTypes: {
     label: {
+      description: 'Label for the input.',
       control: {
         type: 'text',
       },
     },
     leadingTextWidth: {
+      description:
+        'Width of the leading text of all inputs inside. Each of the inputs will default to the length of their leading text when this is not set.',
       control: {
         type: 'select',
       },
@@ -32,21 +43,27 @@ const meta: Meta<
       ],
     },
     tag: {
+      description: 'Tag that is rendered next to the label',
       control: {
         type: 'text',
       },
     },
     info: {
+      description: 'Text that is rendered on the top right with an info icon',
       control: {
         type: 'text',
       },
     },
     helperText: {
+      description:
+        'Text that is rendered below the input to give the user additional information. Often will be used for validation messages.',
       control: {
         type: 'text',
       },
     },
     status: {
+      description:
+        'This determines the color of the helper text and input border. It can be used to indicate an error.',
       options: [
         undefined,
         ...(Object.keys(statusVariant) as (keyof typeof statusVariant)[]),
@@ -56,6 +73,8 @@ const meta: Meta<
       },
     },
     disabled: {
+      description:
+        "Disables the input and applies visual styling. Defaults to 'false'.",
       control: {
         type: 'boolean',
       },
@@ -63,14 +82,7 @@ const meta: Meta<
   },
 };
 
-export default meta;
-type Story = StoryObj<
-  {
-    helperText: string;
-    leadingText: string;
-  } & IInputWrapperProps &
-    Omit<IInputProps, 'leftIcon' | 'rightIcon'>
->;
+type Story = StoryObj<StoryProps>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
@@ -125,3 +137,5 @@ export const Group: Story = {
     );
   },
 };
+
+export default meta;

--- a/packages/libs/react-ui/src/components/InputWrapper/InputWrapper.stories.tsx
+++ b/packages/libs/react-ui/src/components/InputWrapper/InputWrapper.stories.tsx
@@ -73,10 +73,13 @@ const meta: Meta<StoryProps> = {
       },
     },
     disabled: {
-      description:
-        "Disables the input and applies visual styling. Defaults to 'false'.",
+      description: 'Disables the input and applies visual styling.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
       },
     },
   },

--- a/packages/libs/react-ui/src/components/InputWrapper/InputWrapper.tsx
+++ b/packages/libs/react-ui/src/components/InputWrapper/InputWrapper.tsx
@@ -22,7 +22,7 @@ export const InputWrapper: FC<IInputWrapperProps> = ({
   disabled,
   children,
   label,
-  leadingTextWidth = '$32',
+  leadingTextWidth = undefined,
   htmlFor,
   tag,
   info,

--- a/packages/libs/react-ui/src/components/TextField/TextField.stories.tsx
+++ b/packages/libs/react-ui/src/components/TextField/TextField.stories.tsx
@@ -77,10 +77,13 @@ const meta: Meta<StoryProps> = {
       },
     },
     disabled: {
-      description:
-        "Disables the input and applies visual styling. Defaults to 'false'.",
+      description: 'Disables the input and applies visual styling.',
       control: {
         type: 'boolean',
+      },
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
       },
     },
     leftIcon: {

--- a/packages/libs/react-ui/src/components/TextField/TextField.stories.tsx
+++ b/packages/libs/react-ui/src/components/TextField/TextField.stories.tsx
@@ -1,66 +1,99 @@
 import { SystemIcon } from '@components/Icon';
-import { IInputProps } from '@components/Input';
 import { statusVariant } from '@components/InputWrapper/InputWrapper.css';
 import { ITextFieldProps, TextField } from '@components/TextField';
 import type { Meta, StoryObj } from '@storybook/react';
+import { vars } from '@theme/vars.css';
 import React from 'react';
 
-const meta: Meta<
-  {
-    helperText: string;
-    leadingText: string;
-    leftIcon: keyof typeof SystemIcon;
-    rightIcon: keyof typeof SystemIcon;
-  } & ITextFieldProps
-> = {
+type StoryProps = {
+  helperText: string;
+  leadingText: string;
+  leftIcon: keyof typeof SystemIcon;
+  rightIcon: keyof typeof SystemIcon;
+} & ITextFieldProps;
+
+const meta: Meta<StoryProps> = {
   title: 'Components/TextField',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'TextField is the composition of Input and InputWrapper to provide an input with a label, helper text, and other peripheral information.',
+      },
+    },
+  },
   argTypes: {
     label: {
+      description: 'Label for the input',
       control: {
         type: 'text',
       },
     },
     tag: {
+      description: 'Tag that is rendered next to the label',
       control: {
         type: 'text',
       },
     },
     info: {
+      description: 'Text that is rendered on the top right with an info icon',
       control: {
         type: 'text',
       },
     },
     helperText: {
+      description:
+        'Text that is rendered below the input to give the user additional information. Often will be used for validation messages.',
       control: {
         type: 'text',
       },
     },
     leadingText: {
+      description: "Leading text that is rendered inside the input's border.",
       control: {
         type: 'text',
       },
+    },
+    leadingTextWidth: {
+      description:
+        'Width of the leading text. Defaults to the size of the text itself.',
+      control: {
+        type: 'select',
+      },
+      options: [
+        undefined,
+        ...Object.keys(vars.sizes).map((key) => key as keyof typeof vars.sizes),
+      ],
     },
     status: {
       options: [
         undefined,
         ...(Object.keys(statusVariant) as (keyof typeof statusVariant)[]),
       ],
+      description:
+        'This determines the color of the helper text and input border. It can be used to indicate an error.',
       control: {
         type: 'select',
       },
     },
     disabled: {
+      description:
+        "Disables the input and applies visual styling. Defaults to 'false'.",
       control: {
         type: 'boolean',
       },
     },
     leftIcon: {
+      description:
+        'Icon rendered inside the input to the left of the input text.',
       options: Object.keys(SystemIcon) as (keyof typeof SystemIcon)[],
       control: {
         type: 'select',
       },
     },
     rightIcon: {
+      description:
+        'Icon rendered inside the input to the right of the input text.',
       options: Object.keys(SystemIcon) as (keyof typeof SystemIcon)[],
       control: {
         type: 'select',
@@ -69,16 +102,7 @@ const meta: Meta<
   },
 };
 
-export default meta;
-type Story = StoryObj<
-  {
-    helperText: string;
-    leadingText: string;
-    leftIcon: keyof typeof SystemIcon;
-    rightIcon: keyof typeof SystemIcon;
-  } & ITextFieldProps &
-    Omit<IInputProps, 'leftIcon' | 'rightIcon'>
->;
+type Story = StoryObj<StoryProps>;
 
 /*
  *👇 Render functions are a framework specific feature to allow you control on how the component renders.
@@ -98,18 +122,19 @@ export const Group: Story = {
     leftIcon: 'Account',
     rightIcon: undefined,
     leadingText: 'Leading',
+    leadingTextWidth: undefined,
   },
   render: ({
     leadingText,
     leftIcon,
     rightIcon,
-    onChange,
     disabled,
     status,
     tag,
     helperText,
     info,
     label,
+    leadingTextWidth,
   }) => {
     return (
       <TextField
@@ -119,15 +144,17 @@ export const Group: Story = {
         status={status}
         disabled={disabled}
         helperText={helperText}
+        leadingTextWidth={leadingTextWidth}
         inputProps={{
           id: 'inputStory',
           leadingText,
           leftIcon: SystemIcon[leftIcon],
           rightIcon: SystemIcon[rightIcon],
-          onChange,
           placeholder: 'This is a placeholder',
         }}
       />
     );
   },
 };
+
+export default meta;

--- a/packages/libs/react-ui/src/components/TextField/TextField.tsx
+++ b/packages/libs/react-ui/src/components/TextField/TextField.tsx
@@ -4,7 +4,7 @@ import React, { FC } from 'react';
 
 export interface ITextFieldProps
   extends Omit<IInputWrapperProps, 'children' | 'htmlFor'> {
-  inputProps: Omit<IInputProps, 'disabled' | 'children'>;
+  inputProps: Omit<IInputProps, 'disabled' | 'children' | 'leadingTextWidth'>;
 }
 
 export const TextField: FC<ITextFieldProps> = ({


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `rush test` and `rush change`
- In short: help us help you to get this through!
-->

The `leadingTextWidth` prop didn't apply the provided width to the actual input when providing it via inputProps - it needed to be applied to the wrapper instead.
- Moved the classname that applies with width to the container around the text rather than the text itself
- Removed the `leadingTextWidth` prop from the inputProps in `TextField` to prevent confusion
- Removed the default `leadingTextWidth` value from `InputWrapper` so that the behavior is more predictable
- Added `leadingTextWidth` to the `TextField` story
- Added descriptions to the following stories: `InputWrapper`, `TextField`, `Input`
