### PR TITLE
Add workflow to verify changelog has been added to PRs

### DIFF
--- a/.github/workflows/ci-changelog.yml
+++ b/.github/workflows/ci-changelog.yml
@@ -1,0 +1,32 @@
+name: CI (contains changelog update?)
+
+on:
+  pull_request_target:
+    branches:
+      - main
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Fetch base branch
+        run: git fetch origin main:main
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.NodeVersion }}
+          cache: 'pnpm'
+
+      - name: Contains changelog update?
+        run: pnpx @changesets/cli status


### PR DESCRIPTION
Changesets recommends to [ignore](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md#not-every-change-requires-a-changeset) pull requests that should not bump any versions, but we are only human so might forget without knowing whether this was on purpose or forgotten.

This PR adds a tiny workflow to ensure we add a changeset file, even if the bump is "none".