### PR TITLE
chore(build): use turbo to execute all ci tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Build packages
-        run: pnpm build
+      - name: Optimized build, lint, test all packages
+        run: pnpm turbo build lint test
 
-      - name: Lint packages
-        run: pnpm lint:ci
-
-      - name: Test packages
-        run: pnpm test
+      - name: List mismatched dependencies
+        run: pnpm run lint:versions
 
       - name: Verify source code formatting
         if: github.ref_name != 'main'


### PR DESCRIPTION
Turbo knows what tasks depend on each other. Using this
we can optimize all tasks that we need in ci and execute
them as one task
