### PR TITLE
fix(@kadena/react-ui): Update Select props to align with Input props and tested with external lib

### DIFF
--- a/packages/apps/tools/src/components/Common/Layout/partials/Header/Header.tsx
+++ b/packages/apps/tools/src/components/Common/Layout/partials/Header/Header.tsx
@@ -68,6 +68,7 @@ const Header: FC<IHeaderProps> = () => {
       </NavHeader.Navigation>
       <NavHeader.Content>
         <Select
+          id="network-select"
           ariaLabel={t('Select Network')}
           value={selectedNetwork as string}
           onChange={(e) => setSelectedNetwork(e.target.value as Network)}

--- a/packages/libs/react-ui/src/components/Select/Select.stories.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.stories.tsx
@@ -51,7 +51,7 @@ export const Dynamic: Story = {
     const [value, setValue] = useState<string>('1');
     return (
       <Select
-        id="selectStory"
+        id="select-story"
         ariaLabel={'select'}
         icon={SystemIcon[icon]}
         onChange={(e) => {

--- a/packages/libs/react-ui/src/components/Select/Select.stories.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.stories.tsx
@@ -51,6 +51,7 @@ export const Dynamic: Story = {
     const [value, setValue] = useState<string>('1');
     return (
       <Select
+        id="selectStory"
         ariaLabel={'select'}
         icon={SystemIcon[icon]}
         onChange={(e) => {

--- a/packages/libs/react-ui/src/components/Select/Select.test.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.test.tsx
@@ -6,7 +6,12 @@ import React from 'react';
 describe('Select', () => {
   it('renders without errors', () => {
     const { getByTestId } = render(
-      <Select value="1" onChange={() => {}} ariaLabel="select">
+      <Select
+        id="selectWithoutErrors"
+        value="1"
+        onChange={() => {}}
+        ariaLabel="select"
+      >
         <Option value="1">Option 1</Option>
         <Option value="2">Option 2</Option>
       </Select>,
@@ -18,7 +23,12 @@ describe('Select', () => {
 
   it('renders the provided children options', () => {
     const { getByTestId } = render(
-      <Select value="1" onChange={() => {}} ariaLabel="select">
+      <Select
+        id="rendersChildrenOptions"
+        value="1"
+        onChange={() => {}}
+        ariaLabel="select"
+      >
         <Option value="1">Option 1</Option>
         <Option value="2">Option 2</Option>
       </Select>,
@@ -37,7 +47,12 @@ describe('Select', () => {
   it('invokes the onChange event handler when an option is selected', () => {
     const handleChange = jest.fn();
     const { getByTestId } = render(
-      <Select value="1" onChange={handleChange} ariaLabel="select">
+      <Select
+        id="onChangeSelect"
+        value="1"
+        onChange={handleChange}
+        ariaLabel="select"
+      >
         <Option value="1">Option 1</Option>
         <Option value="2">Option 2</Option>
       </Select>,
@@ -54,7 +69,13 @@ describe('Select', () => {
 
   it('disables the select element when disabled prop is true', () => {
     const { getByTestId } = render(
-      <Select value="1" onChange={() => {}} disabled ariaLabel="select">
+      <Select
+        id="disables"
+        value="1"
+        onChange={() => {}}
+        disabled
+        ariaLabel="select"
+      >
         <Option value="1">Option 1</Option>
         <Option value="2">Option 2</Option>
       </Select>,
@@ -71,7 +92,13 @@ describe('Select', () => {
   it('renders an icon when the "icon" prop is provided', () => {
     const IconMock = jest.fn(() => <span className="icon">User</span>);
     const { getByTestId, getByText } = render(
-      <Select value="1" onChange={() => {}} icon={IconMock} ariaLabel="select">
+      <Select
+        id="rendersIcon"
+        value="1"
+        onChange={() => {}}
+        icon={IconMock}
+        ariaLabel="select"
+      >
         <Option value="1">Option 1</Option>
         <Option value="2">Option 2</Option>
       </Select>,

--- a/packages/libs/react-ui/src/components/Select/Select.test.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.test.tsx
@@ -7,7 +7,7 @@ describe('Select', () => {
   it('renders without errors', () => {
     const { getByTestId } = render(
       <Select
-        id="selectWithoutErrors"
+        id="select-without-errors"
         value="1"
         onChange={() => {}}
         ariaLabel="select"
@@ -24,7 +24,7 @@ describe('Select', () => {
   it('renders the provided children options', () => {
     const { getByTestId } = render(
       <Select
-        id="rendersChildrenOptions"
+        id="renders-child-options"
         value="1"
         onChange={() => {}}
         ariaLabel="select"
@@ -48,7 +48,7 @@ describe('Select', () => {
     const handleChange = jest.fn();
     const { getByTestId } = render(
       <Select
-        id="onChangeSelect"
+        id="on-change-select"
         value="1"
         onChange={handleChange}
         ariaLabel="select"
@@ -70,7 +70,7 @@ describe('Select', () => {
   it('disables the select element when disabled prop is true', () => {
     const { getByTestId } = render(
       <Select
-        id="disables"
+        id="disabled-select"
         value="1"
         onChange={() => {}}
         disabled
@@ -93,7 +93,7 @@ describe('Select', () => {
     const IconMock = jest.fn(() => <span className="icon">User</span>);
     const { getByTestId, getByText } = render(
       <Select
-        id="rendersIcon"
+        id="renders-icon"
         value="1"
         onChange={() => {}}
         icon={IconMock}

--- a/packages/libs/react-ui/src/components/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Select/Select.tsx
@@ -12,31 +12,27 @@ import React, { FC, forwardRef } from 'react';
 export interface ISelectProps
   extends Omit<
     React.HTMLAttributes<HTMLSelectElement>,
-    'aria-label' | 'as' | 'className'
+    'aria-label' | 'as' | 'className' | 'children' | 'id'
   > {
   ariaLabel: string;
   children: React.ReactNode;
   disabled?: boolean;
   icon?: (typeof SystemIcon)[keyof typeof SystemIcon];
-  onChange: React.ChangeEventHandler<HTMLSelectElement>;
   ref?: React.ForwardedRef<HTMLSelectElement>;
-  value: string[] | string | number;
+  onChange?: React.ChangeEventHandler<HTMLSelectElement>;
+  id: string;
+  value?: string;
 }
 
 export const Select: FC<ISelectProps> = forwardRef<
   HTMLSelectElement,
   ISelectProps
 >(function Select(
-  {
-    ariaLabel,
-    children,
-    disabled = false,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    icon: Icon,
-    ...rest
-  },
+  { ariaLabel, children, disabled = false, icon, ...rest },
   ref,
 ) {
+  const Icon = icon;
+
   return (
     <div
       className={classNames(containerClass, {


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->

When the Select component was being used in the dev wallet, it wasn't working with react-hook-form. This PR adjusts props a little to require an `id` like the input and be compatible with react-hook-form. Tested this in the dev-wallet
