### PR TITLE
Add check for `bin` shebang and `[pre|post]install` scripts

### DIFF
--- a/.changeset/dry-files-wonder.md
+++ b/.changeset/dry-files-wonder.md
@@ -1,0 +1,5 @@
+---
+'@kadena-dev/lint-package': minor
+---
+
+Add check for bin shebang and [pre|post]install scripts

--- a/packages/tools/kda-cli/README.md
+++ b/packages/tools/kda-cli/README.md
@@ -44,9 +44,8 @@ To install the executable from this repo:
 ```sh
 pnpm install
 pnpm build --filter @kadena/kda-cli
-chmod +x ./lib/index.js
 # if you are using NVM, you should have this environment variable available
-ln -s $(pwd)/lib/index.js $NVM_BIN/kda
+ln -s $(pwd)/bin/kda.js $NVM_BIN/kda
 # if not, you can replace $NVM_BIN to any path you have added in your $PATH
 ```
 

--- a/packages/tools/kda-cli/bin/kda.js
+++ b/packages/tools/kda-cli/bin/kda.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import '../lib/index.js';

--- a/packages/tools/kda-cli/package.json
+++ b/packages/tools/kda-cli/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "kda": "lib/index.js"
+    "kda": "bin/kda.js"
   },
   "files": [
     "lib"


### PR DESCRIPTION
Since this is now part of our linter scripts, we should see something like this:

```
❯ pnpm lint -F @kadena/pactjs-cli

...

@kadena/pactjs-cli:lint: . lint:pkg$ lint-package
@kadena/pactjs-cli:lint: . lint:src$ eslint package.json src --ext .js,.ts --fix
@kadena/pactjs-cli:lint: . lint:pkg: /Users/lars/p/kadena/kadena.js/packages/tools/pactjs-cli/config/api-extractor.json
@kadena/pactjs-cli:lint: . lint:pkg:         warning   API Extractor is enabled, "types" in package.json should be "dist/pactjs-cli.d.ts"
@kadena/pactjs-cli:lint: . lint:pkg: /Users/lars/p/kadena/kadena.js/packages/tools/pactjs-cli/package.json
@kadena/pactjs-cli:lint: . lint:pkg:         error     Missing or incorrect shebang in executable bin/pactjs.js

...

ERROR  run failed: command  exited (1)
```

The CI should halt. This error will be fixed in another PR. Then we can rebase this and have some confidence `error` rules in `@kadena-dev/lint-package` work as expected :)

Looks good:

<img width="1143" alt="Screenshot 2023-09-04 at 10 22 37 PM" src="https://github.com/kadena-community/kadena.js/assets/456426/4e759dae-6bb1-4dfa-be7d-0fb8da27331e">
