### PR TITLE
Fix(pactjs-cli) : add missing shebang to the executable file

### DIFF
--- a/.changeset/sharp-llamas-push.md
+++ b/.changeset/sharp-llamas-push.md
@@ -1,0 +1,5 @@
+---
+'@kadena/pactjs-cli': patch
+---
+
+add missing shebang to the executable file

--- a/packages/tools/pactjs-cli/bin/pactjs.js
+++ b/packages/tools/pactjs-cli/bin/pactjs.js
@@ -1,1 +1,3 @@
+#!/usr/bin/env node
+
 require('../lib/index.js');

--- a/packages/tools/pactjs-cli/src/index.ts
+++ b/packages/tools/pactjs-cli/src/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { contractGenerateCommand } from './contract-generate';
 import { retrieveContractCommand } from './retrieve-contract';
 import { templateGenerateCommand } from './template-generate';


### PR DESCRIPTION
Add missing shebang to the executable file. that will fix the followoing issue
```bash
bin/pactjs: line 1: syntax error near unexpected token `'../lib/index.js''
```