### PR TITLE
chore(@kadena/react-ui): Update nav links to use asChild convention

### DIFF
--- a/.changeset/honest-months-hang.md
+++ b/.changeset/honest-months-hang.md
@@ -1,0 +1,6 @@
+---
+'@kadena/react-ui': none
+---
+
+Updated the NavHeader and NavFooter Link components to accept an asChild prop so
+that they can be used with external links

--- a/packages/apps/tools/src/components/Common/Layout/partials/Header/Header.tsx
+++ b/packages/apps/tools/src/components/Common/Layout/partials/Header/Header.tsx
@@ -8,8 +8,9 @@ import routes from '@/constants/routes';
 import { useWalletConnectClient } from '@/context/connect-wallet-context';
 import type { IMenuItem } from '@/types/Layout';
 import { getNetworks } from '@/utils/wallet';
-import { useRouter } from 'next/router';
 import useTranslation from 'next-translate/useTranslation';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
 import type { FC, ReactNode } from 'react';
 import React from 'react';
 
@@ -59,12 +60,8 @@ const Header: FC<IHeaderProps> = () => {
         activeLink={navItems.findIndex((item) => item.href === pathname) + 1}
       >
         {navItems.map((item, index) => (
-          <NavHeader.Link
-            key={index}
-            href={item.href}
-            onClick={handleMenuItemClick}
-          >
-            {item.label}
+          <NavHeader.Link key={index} onClick={handleMenuItemClick} asChild>
+            <Link href={item.href}>{item.label}</Link>
           </NavHeader.Link>
         ))}
       </NavHeader.Navigation>
@@ -74,7 +71,7 @@ const Header: FC<IHeaderProps> = () => {
           ariaLabel={t('Select Network')}
           value={selectedNetwork as string}
           onChange={(e) => setSelectedNetwork(e.target.value as Network)}
-          icon={'Link'}
+          icon="Link"
         >
           {networks.map((network) => (
             <Option key={network} value={network}>

--- a/packages/libs/react-ui/src/components/NavFooter/NavFooter.css.ts
+++ b/packages/libs/react-ui/src/components/NavFooter/NavFooter.css.ts
@@ -51,14 +51,6 @@ export const footerPanel = style([
   }),
 ]);
 
-export const linkBoxClass = style([
-  sprinkles({
-    display: 'flex',
-    padding: 0,
-    whiteSpace: 'nowrap',
-  }),
-]);
-
 export const linkClass = style([
   sprinkles({
     display: 'flex',

--- a/packages/libs/react-ui/src/components/NavFooter/NavFooter.stories.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/NavFooter.stories.tsx
@@ -11,17 +11,39 @@ const meta: Meta<{
   darkMode: boolean;
 }> = {
   title: 'Navigation/NavFooter',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The NavFooter component provides styled bottom bar navigation that be configured with main nav links on the left side and buttons on the right side.<br><br><i>Note: In times when you need to use a different `Link` component (like next/link in Next.js), you can wrap it in the `NavHeader.Link` component and set the `asChild` prop to pass on styles and additional props.</i><br><br><i>In progress: maximum navigation items is currently limited (not technically enforced).<br>Pending design update to support more items.</i>',
+      },
+    },
+  },
   argTypes: {
     darkMode: {
+      description:
+        'By default the footer switches colors in dark/light mode. This prop allows you to override that behavior and always show dark mode.',
       control: {
         type: 'boolean',
       },
+      table: {
+        defaultValue: { summary: false },
+      },
     },
     linksCount: {
+      description: 'Controls to adjust the number of links in the example.',
       control: { type: 'range', min: 1, max: 6, step: 1 },
+      table: {
+        defaultValue: { summary: 4 },
+      },
     },
     iconsCount: {
+      description:
+        'Controls to adjust the number of icons and buttons in the example.',
       control: { type: 'range', min: 1, max: 6, step: 1 },
+      table: {
+        defaultValue: { summary: 3 },
+      },
     },
   },
 };

--- a/packages/libs/react-ui/src/components/NavFooter/NavFooterLink.tsx
+++ b/packages/libs/react-ui/src/components/NavFooter/NavFooterLink.tsx
@@ -1,30 +1,33 @@
-import { linkBoxClass, linkClass } from './NavFooter.css';
+import { linkClass } from './NavFooter.css';
 
-import classNames from 'classnames';
 import type { FC, HTMLAttributeAnchorTarget } from 'react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 export type Target = '_self' | '_blank';
 export interface INavFooterLinkProps {
-  children: string;
+  children: ReactNode;
   href?: string;
   target?: HTMLAttributeAnchorTarget | undefined;
+  asChild?: boolean;
 }
 
 export const NavFooterLink: FC<INavFooterLinkProps> = ({
   children,
-  href,
-  target,
+  asChild = false,
+  ...restProps
 }) => {
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      ...restProps,
+      ...children.props,
+      className: linkClass,
+      children: children.props.children,
+    });
+  }
+
   return (
-    <div className={linkBoxClass} data-testid="kda-footer-link-item">
-      {href !== undefined ? (
-        <a className={classNames(linkClass)} href={href} target={target}>
-          {children}
-        </a>
-      ) : (
-        <span>{children}</span>
-      )}
-    </div>
+    <a className={linkClass} {...restProps} data-testid="kda-footer-link-item">
+      {children}
+    </a>
   );
 };

--- a/packages/libs/react-ui/src/components/NavHeader/NavHeader.stories.tsx
+++ b/packages/libs/react-ui/src/components/NavHeader/NavHeader.stories.tsx
@@ -44,7 +44,7 @@ const meta: Meta<StoryProps> = {
     docs: {
       description: {
         component:
-          '<i>Note: maximum navigation items is currently limited (not technically enforced).<br>Pending design update to support more items.</i><br><br><strong>NavHeader.Link usage is optional</strong><br>You set your own children of NavHeader.Navigation (e.g. when using NextJS <Link> component).<br>You can set the initial active link with the <i>activeLink</i> prop on the Navigation component.',
+          'The NavHeader component provides styled top bar navigation that be configured with main nav links on the left side and any additional custom items on the right side.<br><br><i>Note: In times when you need to use a different `Link` component (like next/link in Next.js), you can wrap it in the `NavHeader.Link` component and set the `asChild` prop to pass on styles and additional props.</i><br><br><i>In progress: maximum navigation items is currently limited (not technically enforced).<br>Pending design update to support more items.</i>',
       },
     },
   },

--- a/packages/libs/react-ui/src/components/NavHeader/NavHeader.stories.tsx
+++ b/packages/libs/react-ui/src/components/NavHeader/NavHeader.stories.tsx
@@ -1,26 +1,27 @@
-import type { INavHeaderRootProps, INavItems } from './NavHeader';
+import type { INavHeaderRootProps } from './NavHeader';
 import { NavHeader } from './';
 
+import { type INavHeaderLinkProps } from './NavHeaderLink';
 import { logoVariants } from '@components/BrandLogo';
 import { Button } from '@components/Button';
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-const sampleNavItems: INavItems = [
+const sampleNavItems: INavHeaderLinkProps[] = [
   {
-    label: 'Faucet',
+    children: 'Faucet',
     href: '#faucet',
   },
   {
-    label: 'Transactions',
+    children: 'Transactions',
     href: '#transactions',
   },
   {
-    label: 'Balance',
+    children: 'Balance',
     href: '#balance',
   },
   {
-    label: 'Learn Pact',
+    children: 'Learn Pact',
     href: '#pact',
   },
 ];
@@ -30,7 +31,7 @@ type StoryProps = {
   navHeaderActiveLink: number;
   renderSampleContent: boolean;
   useCustomNavigation: boolean;
-  customNavigation: INavItems;
+  customNavigation: INavHeaderLinkProps[];
 } & INavHeaderRootProps;
 
 const meta: Meta<StoryProps> = {
@@ -117,9 +118,9 @@ export const Dynamic: IStory = {
             <NavHeader.Link
               key={index}
               href={item.href}
-              onClick={(event) => console.log(item.label, { event })}
+              onClick={(event) => console.log(item.children, { event })}
             >
-              {item.label}
+              {item.children}
             </NavHeader.Link>
           ))}
         </NavHeader.Navigation>

--- a/packages/libs/react-ui/src/components/NavHeader/NavHeaderLink.tsx
+++ b/packages/libs/react-ui/src/components/NavHeader/NavHeaderLink.tsx
@@ -1,27 +1,39 @@
 import { activeLinkClass, linkClass } from './NavHeader.css';
-import type { INavItem } from './NavHeaderNavigation';
 
 import classNames from 'classnames';
-import type { FC } from 'react';
 import React from 'react';
+import type { FC, HTMLAttributeAnchorTarget, ReactNode } from 'react';
 
-export const NavHeaderLink: FC<INavItem> = ({
+export interface INavHeaderLinkProps {
+  active?: boolean;
+  children: ReactNode;
+  href?: string;
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  target?: HTMLAttributeAnchorTarget;
+  asChild?: boolean;
+}
+
+export const NavHeaderLink: FC<INavHeaderLinkProps> = ({
   active,
   children,
-  href,
-  target,
-  onClick,
+  asChild = false,
+  ...restProps
 }) => {
+  const className = classNames(linkClass, {
+    [activeLinkClass]: active,
+  });
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      ...restProps,
+      ...children.props,
+      className: className,
+      children: children.props.children,
+    });
+  }
+
   return (
-    <a
-      className={classNames(linkClass, {
-        [activeLinkClass]: active,
-        'nav-item': true,
-      })}
-      href={href}
-      target={target}
-      onClick={onClick}
-    >
+    <a className={className} {...restProps}>
       {children}
     </a>
   );

--- a/packages/libs/react-ui/src/components/NavHeader/NavHeaderNavigation.tsx
+++ b/packages/libs/react-ui/src/components/NavHeader/NavHeaderNavigation.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { NavGlow } from './assets/glow';
 import {
   activeLinkClass,
   glowClass,
@@ -8,27 +7,16 @@ import {
   navListClass,
   navWrapperClass,
 } from './NavHeader.css';
+import { type INavHeaderLinkProps } from './NavHeaderLink';
+import { NavGlow } from './assets/glow';
 import useGlow from './useGlow';
 
 import classNames from 'classnames';
-import type {
-  FC,
-  FunctionComponentElement,
-  HTMLAttributeAnchorTarget,
-} from 'react';
+import type { FC, FunctionComponentElement } from 'react';
 import React, { useEffect } from 'react';
 
-export interface INavItem {
-  active?: boolean;
-  children?: string;
-  href: string;
-  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
-  target?: HTMLAttributeAnchorTarget;
-}
-export type INavItems = INavItem[];
-
 export interface INavHeaderNavigationProps {
-  children: FunctionComponentElement<INavItem>[];
+  children: FunctionComponentElement<INavHeaderLinkProps>[];
   activeLink?: number;
 }
 
@@ -60,8 +48,9 @@ export const NavHeaderNavigation: FC<INavHeaderNavigationProps> = ({
           <li key={`navItem-${index}`} onClick={() => setActiveNav(index + 1)}>
             {React.cloneElement(
               child as React.ReactElement<
-                HTMLElement | INavItem,
-                string | React.JSXElementConstructor<JSX.Element & INavItem>
+                HTMLElement | INavHeaderLinkProps,
+                | string
+                | React.JSXElementConstructor<JSX.Element & INavHeaderLinkProps>
               >,
               {
                 active: activeNav === index + 1,

--- a/packages/libs/react-ui/src/components/NavHeader/index.ts
+++ b/packages/libs/react-ui/src/components/NavHeader/index.ts
@@ -2,11 +2,8 @@ import type { INavHeaderRootProps } from './NavHeader';
 import { NavHeaderContainer } from './NavHeader';
 import type { INavHeaderContentProps } from './NavHeaderContent';
 import { NavHeaderContent } from './NavHeaderContent';
-import { NavHeaderLink } from './NavHeaderLink';
-import type {
-  INavHeaderNavigationProps,
-  INavItem,
-} from './NavHeaderNavigation';
+import { NavHeaderLink, type INavHeaderLinkProps } from './NavHeaderLink';
+import type { INavHeaderNavigationProps } from './NavHeaderNavigation';
 import { NavHeaderNavigation } from './NavHeaderNavigation';
 
 import type { FC } from 'react';
@@ -14,14 +11,14 @@ import type { FC } from 'react';
 export {
   INavHeaderRootProps,
   INavHeaderContentProps,
-  INavItem as INavHeaderLinkProps,
+  INavHeaderLinkProps,
   INavHeaderNavigationProps,
 };
 
 export interface INavHeaderProps {
   Root: FC<INavHeaderRootProps>;
   Navigation: FC<INavHeaderNavigationProps>;
-  Link: FC<INavItem>;
+  Link: FC<INavHeaderLinkProps>;
   Content: FC<INavHeaderContentProps>;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->

Updated the following to accept an as child prop so that they can be used with next/link
- NavHeader.Link
- NavFooter.Link
