### PR TITLE
Fixes multiple cookbook files that used an old syntax for @kadena/client

### DIFF
--- a/.changeset/fresh-cows-sin.md
+++ b/.changeset/fresh-cows-sin.md
@@ -1,0 +1,5 @@
+---
+'@kadena/cookbook': patch
+---
+
+Fixes several recipes that used the old `@kadena/client` syntax

--- a/packages/tools/cookbook/src/accounts/create-account.ts
+++ b/packages/tools/cookbook/src/accounts/create-account.ts
@@ -1,5 +1,5 @@
 import {
-  getClient,
+  createClient,
   isSignedTransaction,
   Pact,
   signWithChainweaver,
@@ -40,8 +40,8 @@ async function createAccount(
       keys: [accountKey(receiver)],
       pred: 'keys-all',
     })
-    .addSigner(gasProviderPublicKey, (withCap: any) => [withCap('coin.GAS')])
-    .setMeta({ chainId: '1', sender: gasProvider })
+    .addSigner(gasProviderPublicKey, (withCap) => [withCap('coin.GAS')])
+    .setMeta({ chainId: '1', senderAccount: gasProvider })
     .setNetworkId(NETWORK_ID)
     .createTransaction();
 
@@ -52,7 +52,7 @@ async function createAccount(
     return;
   }
 
-  const { submit, pollStatus } = getClient(API_HOST);
+  const { submit, pollStatus } = createClient(API_HOST);
 
   const requestKey = await submit(signedTransaction);
   console.log('request key', requestKey);

--- a/packages/tools/cookbook/src/accounts/details.ts
+++ b/packages/tools/cookbook/src/accounts/details.ts
@@ -1,4 +1,4 @@
-import { getClient, Pact } from '@kadena/client';
+import { createClient, Pact } from '@kadena/client';
 
 import { apiHost } from '../utils/api-host';
 
@@ -18,7 +18,7 @@ const [account] = process.argv.slice(2);
  * @return
  */
 async function details(account: string): Promise<void> {
-  const { local } = getClient(apiHost());
+  const { local } = createClient(apiHost());
 
   const transaction = Pact.builder
     .execution(Pact.modules.coin.details(account))

--- a/packages/tools/cookbook/src/accounts/get-balance.ts
+++ b/packages/tools/cookbook/src/accounts/get-balance.ts
@@ -1,4 +1,4 @@
-import { getClient, Pact } from '@kadena/client';
+import { createClient, Pact } from '@kadena/client';
 
 import { apiHost } from '../utils/api-host';
 
@@ -18,7 +18,7 @@ const [account] = process.argv.slice(2);
  * @return
  */
 async function getBalance(account: string): Promise<void> {
-  const { local } = getClient(apiHost());
+  const { local } = createClient(apiHost());
 
   const transaction = Pact.builder
     .execution(Pact.modules.coin['get-balance'](account))

--- a/packages/tools/cookbook/src/accounts/transfer-create-with-chainweaver.ts
+++ b/packages/tools/cookbook/src/accounts/transfer-create-with-chainweaver.ts
@@ -1,5 +1,5 @@
 import {
-  getClient,
+  createClient,
   isSignedTransaction,
   Pact,
   signWithChainweaver,
@@ -23,20 +23,20 @@ const [sender, receiver, transferAmount] = process.argv.slice(2);
 /**
  * Create a new KDA account and transfer funds to it
  *
- * @param sender - Account sending coins
+ * @param senderAccount - Account sending coins
  * @param receiver - Account being created and receiving coins
  * @param amount - Amount of coins transferred to the new account
  * @return
  */
 async function transferCreate(
-  sender: string,
+  senderAccount: string,
   receiver: string,
   amount: number,
 ): Promise<void> {
   const senderPublicKey = accountKey(sender);
   const pactDecimal: IPactDecimal = { decimal: `${amount}` };
 
-  const { submit, pollStatus } = getClient(API_HOST);
+  const { submit, pollStatus } = createClient(API_HOST);
 
   const transaction = Pact.builder
     .execution(
@@ -51,11 +51,11 @@ async function transferCreate(
       keys: [accountKey(receiver)],
       pred: 'keys-all',
     })
-    .addSigner(senderPublicKey, (withCap: any) => [
+    .addSigner(senderPublicKey, (withCap) => [
       withCap('coin.TRANSFER', sender, receiver, pactDecimal),
       withCap('coin.GAS'),
     ])
-    .setMeta({ chainId: '1', sender: sender })
+    .setMeta({ chainId: '1', senderAccount })
     .setNetworkId(NETWORK_ID)
     .createTransaction();
 


### PR DESCRIPTION
A few minor changes were added in one of the later versions of the client. This PR fixes the examples that we have in the cookbook for this new version.