### PR TITLE
Fix the name collision between the arguments of capabilities in the generated type

### DIFF
--- a/.changeset/large-clouds-search.md
+++ b/.changeset/large-clouds-search.md
@@ -1,0 +1,6 @@
+---
+'@kadena/pactjs-generator': patch
+---
+
+Fix the name collision between the arguments of capabilities in the generated
+type

--- a/packages/libs/pactjs-generator/src/contract/generation/generator.ts
+++ b/packages/libs/pactjs-generator/src/contract/generation/generator.ts
@@ -76,7 +76,16 @@ function genFunCapsInterface(func: IFunction): string {
   const interfaceName = getFuncCapInterfaceName(func);
 
   const cap = func.allExtractedCaps.map((cap) => {
-    let parameters = [`name: "${cap.fullModuleName}.${cap.name}"`];
+    let capabilityName = 'capabilityName';
+    while (
+      cap.capability.parameters &&
+      cap.capability.parameters.find((p) => p.name === capabilityName)
+    ) {
+      // make sure we don't have a name collision
+      capabilityName = `_${capabilityName}`;
+    }
+
+    let parameters = [`${capabilityName}: "${cap.fullModuleName}.${cap.name}"`];
     if (cap.capability.parameters) {
       const args = getParameters(cap.capability.parameters);
       parameters = [...parameters, ...args];

--- a/packages/libs/pactjs-generator/src/contract/generation/tests/__snapshots__/generator.test.ts.snap
+++ b/packages/libs/pactjs-generator/src/contract/generation/tests/__snapshots__/generator.test.ts.snap
@@ -37,7 +37,7 @@ interface ICapability_test_func {
   * this is defcap doc
   */
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 
@@ -73,7 +73,7 @@ interface ICapability_test_func {
   * this is defcap doc
   */
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 
@@ -90,6 +90,46 @@ declare module '@kadena/client' {
         parameterone: object,
         parametertwo: boolean) => string & { capability : ICapability_test_func & ICapability_Coin_GAS} 
 
+    }
+  }
+}"
+`;
+
+exports[`generateDts adds some _ to capabilityName to make it unique and avoid name collision if the capability function has also an argument exactly with the same name 1`] = `
+"
+import type { PactReference } from '@kadena/client';
+import type { IPactDecimal, IPactInt, ICap } from '@kadena/types';
+
+interface ICapability_Coin_GAS {
+  (name: 'coin.GAS'): ICap;
+}
+
+interface ICapability_defpact_test_func {
+  /**
+  * this is defcap doc
+  */
+  (
+    __capabilityName: "user.test-module.test-cap", 
+    capabilityName: string, 
+    _capabilityName: string): ICap,
+}
+
+declare module '@kadena/client' {
+  export interface IPactModules {
+    /**
+    this is module doc    
+    */
+    "user.test-module": {
+    
+
+      "defpact":{
+        /**
+        * this is defpact doc
+        */
+        "test-func": (
+          parameterone: any,
+          parametertwo: any) => string & { capability : ICapability_defpact_test_func & ICapability_Coin_GAS} 
+      }
     }
   }
 }"
@@ -151,7 +191,7 @@ interface ICapability_defpact_test_func {
   * this is defcap doc
   */
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 
@@ -188,7 +228,7 @@ interface ICapability_Coin_GAS {
 interface ICapability_test_func {
   
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 
@@ -217,7 +257,7 @@ interface ICapability_Coin_GAS {
 interface ICapability_test_func {
   
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 
@@ -246,7 +286,7 @@ interface ICapability_Coin_GAS {
 interface ICapability_test_func {
   
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 

--- a/packages/libs/pactjs-generator/src/contract/generation/tests/generator.test.ts
+++ b/packages/libs/pactjs-generator/src/contract/generation/tests/generator.test.ts
@@ -226,4 +226,27 @@ describe('generateDts', () => {
     const dts = generateDts('user.test-module', modules);
     expect(dts).toMatchSnapshot();
   });
+
+  it('adds some _ to capabilityName to make it unique and avoid name collision if the capability function has also an argument exactly with the same name', async () => {
+    const module = `(namespace "user")
+    (module test-module governance
+      @doc "this is module doc"
+      (defcap test-cap (capabilityName:string _capabilityName:string)
+        @doc "this is defcap doc"
+        true)
+      (defpact test-func:bool (parameter-one parameter-two )
+        @doc "this is defpact doc"
+        (with-capability (test-cap "capabilityName"))
+      )
+    )
+  `;
+
+    const modules = await pactParser({
+      files: [module],
+      getContract: () => Promise.resolve(''),
+    });
+
+    const dts = generateDts('user.test-module', modules);
+    expect(dts).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
Fix the name collision between the arguments of capabilities in the generated type