### PR TITLE
[@kadena/client] add `signWithKeypair` functionality

### DIFF
--- a/.changeset/gold-stingrays-camp.md
+++ b/.changeset/gold-stingrays-camp.md
@@ -1,0 +1,6 @@
+---
+'@kadena/client': minor
+---
+
+Add feature to allow signing with keypair:
+`signedTx = createSignWithKeypair(keyOrKeys: IKeypair | IKeypair[])(transaction)`

--- a/.changeset/gold-stingrays-camp.md
+++ b/.changeset/gold-stingrays-camp.md
@@ -3,4 +3,9 @@
 ---
 
 Add feature to allow signing with keypair:
-`signedTx = createSignWithKeypair(keyOrKeys: IKeypair | IKeypair[])(transaction)`
+
+```ts
+const signWithKeystore = createSignWithKeypair([keyPair, keyPair2]);
+const [signedTx1, signedTx2] = await signWithKeystore([tx1, tx2]);
+const signedTx3 = await signWithKeystore(tx3);
+```

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -37,6 +37,9 @@ export function createEckoWalletQuicksign(): IEckoSignFunction;
 export function createEckoWalletSign(): IEckoSignSingleFunction;
 
 // @public
+export const createSignWithKeypair: ICreateSignWithKeypair;
+
+// @public
 export const createTransaction: (pactCommand: Partial<IPactCommand>) => IUnsignedCommand;
 
 // @public
@@ -130,6 +133,14 @@ export interface ICreateClient {
 }
 
 // @public
+export interface ICreateSignWithKeypair {
+    // (undocumented)
+    (key: IKeypair): ISignFunction;
+    // (undocumented)
+    (keys: IKeypair[]): ISignFunction;
+}
+
+// @public
 export interface IEckoSignFunction extends ISignFunction, ICommonEckoFunctions {
 }
 
@@ -144,6 +155,14 @@ export interface IExecutionPayloadObject {
         code?: string;
         data?: Record<string, unknown>;
     };
+}
+
+// @public
+export interface IKeypair {
+    // (undocumented)
+    publicKey: string;
+    // (undocumented)
+    secretKey: string;
 }
 
 // @public (undocumented)

--- a/packages/libs/client/src/signing/index.ts
+++ b/packages/libs/client/src/signing/index.ts
@@ -5,6 +5,8 @@ export {
 } from './eckoWallet/eckoTypes';
 export { TWalletConnectChainId } from './walletconnect/walletConnectTypes';
 export { ISingleSignFunction, ISignFunction } from './ISignFunction';
+export { IUnsignedCommand } from '@kadena/types';
+export { IKeypair } from './keypair/createSignWithKeypair';
 
 export * from './utils/isSignedTransaction';
 export * from './utils/addSignatures';
@@ -14,3 +16,4 @@ export * from './eckoWallet/signWithEckoWallet';
 export * from './eckoWallet/quicksignWithEckoWallet';
 export * from './walletconnect/signWithWalletConnect';
 export * from './walletconnect/quicksignWithWalletConnect';
+export * from './keypair/createSignWithKeypair';

--- a/packages/libs/client/src/signing/keypair/createSignWithKeypair.ts
+++ b/packages/libs/client/src/signing/keypair/createSignWithKeypair.ts
@@ -1,0 +1,78 @@
+import { signHash } from '@kadena/cryptography-utils';
+import type { IUnsignedCommand } from '@kadena/types';
+
+import type { IPactCommand } from '../../interfaces/IPactCommand';
+import type { ISignFunction, ISingleSignFunction } from '../ISignFunction';
+import { addSignatures } from '../utils/addSignatures';
+import { parseTransactionCommand } from '../utils/parseTransactionCommand';
+
+import type { Debugger } from 'debug';
+import _debug from 'debug';
+
+const debug: Debugger = _debug('pactjs:signWithKeypair');
+
+export interface IKeypair {
+  publicKey: string;
+  secretKey: string;
+}
+
+/**
+ * Sign with public/private key-pair according to {@link https://github.com/kadena-io/KIPs/blob/master/kip-0015.md | sign-v1 API}
+ *
+ * @public
+ */
+export const createSignWithKeypair: (
+  keyOrKeys: IKeypair | IKeypair[],
+) => ISignFunction & ISingleSignFunction = (
+  keyOrKeys,
+): ISignFunction & ISingleSignFunction => {
+  const keypairs: IKeypair[] = Array.isArray(keyOrKeys)
+    ? keyOrKeys
+    : [keyOrKeys];
+  return (async (transactionList) => {
+    if (transactionList === undefined) {
+      throw new Error('No transaction(s) to sign');
+    }
+
+    const isList = Array.isArray(transactionList);
+    const transactions = isList ? transactionList : [transactionList];
+
+    const signedTransactions = transactions.map((tx) => {
+      const parsedTransaction = parseTransactionCommand(tx);
+      const relevantKeypairs = getRelevantKeypairs(parsedTransaction, keypairs);
+
+      if (relevantKeypairs.length === 0) {
+        throw new Error(
+          'The keypair(s) provided are not relevant to the transaction',
+        );
+      }
+
+      return signWithKeypairs(tx, relevantKeypairs);
+    });
+
+    return isList ? signedTransactions : signedTransactions[0];
+  }) as ISignFunction & ISingleSignFunction;
+};
+
+function getRelevantKeypairs(
+  tx: IPactCommand,
+  keypairs: IKeypair[],
+): IKeypair[] {
+  const relevantKeypairs = keypairs.filter((keypair) =>
+    tx.signers.some(({ pubKey }) => pubKey === keypair.publicKey),
+  );
+  debug('relevant keypairs', relevantKeypairs);
+  return relevantKeypairs;
+}
+
+function signWithKeypairs(
+  tx: IUnsignedCommand,
+  relevantKeypairs: IKeypair[],
+): IUnsignedCommand {
+  return relevantKeypairs.reduce((tx, keypair) => {
+    const { sig, pubKey } = signHash(tx.hash, keypair);
+
+    debug(`adding signature from keypair: pubkey: ${keypair.publicKey}`);
+    return addSignatures(tx, { sig: sig!, pubKey });
+  }, tx);
+}

--- a/packages/libs/client/src/signing/keypair/tests/signWithKeypair.test.ts
+++ b/packages/libs/client/src/signing/keypair/tests/signWithKeypair.test.ts
@@ -1,10 +1,5 @@
 import type { ICoin } from '../../../composePactCommand/test/coin-contract';
-import type {
-  IQuicksignResponse,
-  IQuicksignResponseOutcomes,
-  ISignFunction,
-  ISingleSignFunction,
-} from '../../../index';
+import type { ISignFunction, ISingleSignFunction } from '../../../index';
 import { Pact } from '../../../index';
 import { getModule } from '../../../pact';
 import type { IKeypair } from '../createSignWithKeypair';

--- a/packages/libs/client/src/signing/keypair/tests/signWithKeypair.test.ts
+++ b/packages/libs/client/src/signing/keypair/tests/signWithKeypair.test.ts
@@ -1,5 +1,5 @@
 import type { ICoin } from '../../../composePactCommand/test/coin-contract';
-import type { ISignFunction, ISingleSignFunction } from '../../../index';
+import type { ISignFunction } from '../../../index';
 import { Pact } from '../../../index';
 import { getModule } from '../../../pact';
 import type { IKeypair } from '../createSignWithKeypair';
@@ -13,10 +13,9 @@ const keyPair: IKeypair = {
 const coin: ICoin = getModule('coin');
 
 describe('createSignWithKeypair', () => {
-  let signWithKeypair: ISignFunction & ISingleSignFunction;
+  let signWithKeypair: ISignFunction;
   beforeAll(() => {
-    signWithKeypair = createSignWithKeypair(keyPair) as ISignFunction &
-      ISingleSignFunction;
+    signWithKeypair = createSignWithKeypair(keyPair) as ISignFunction;
   });
 
   it('returns a function to sign with', async () => {
@@ -25,7 +24,7 @@ describe('createSignWithKeypair', () => {
 });
 
 describe('signWithKeypair', () => {
-  let signWithKeypair: ISignFunction & ISingleSignFunction;
+  let signWithKeypair: ISignFunction;
   beforeAll(() => {
     signWithKeypair = createSignWithKeypair(keyPair);
   });

--- a/packages/libs/client/src/signing/keypair/tests/signWithKeypair.test.ts
+++ b/packages/libs/client/src/signing/keypair/tests/signWithKeypair.test.ts
@@ -1,0 +1,235 @@
+import type { ICoin } from '../../../composePactCommand/test/coin-contract';
+import type {
+  IQuicksignResponse,
+  IQuicksignResponseOutcomes,
+  ISignFunction,
+  ISingleSignFunction,
+} from '../../../index';
+import { Pact } from '../../../index';
+import { getModule } from '../../../pact';
+import type { IKeypair } from '../createSignWithKeypair';
+import { createSignWithKeypair } from '../createSignWithKeypair';
+
+const keyPair: IKeypair = {
+  publicKey: '09e82da78d531e2d16852a923e9fe0f80f3b67a9b8d92c7f05e4782222252e12',
+  secretKey: '76e1cabaa58a33321982e434f355dc7a4cfbee092a4ac1c7aac26302ba80d992',
+};
+
+const coin: ICoin = getModule('coin');
+
+describe('createSignWithKeypair', () => {
+  let signWithKeypair: ISignFunction & ISingleSignFunction;
+  beforeAll(() => {
+    signWithKeypair = createSignWithKeypair(keyPair) as ISignFunction &
+      ISingleSignFunction;
+  });
+
+  it('returns a function to sign with', async () => {
+    expect(typeof signWithKeypair).toBe('function');
+  });
+});
+
+describe('signWithKeypair', () => {
+  let signWithKeypair: ISignFunction & ISingleSignFunction;
+  beforeAll(() => {
+    signWithKeypair = createSignWithKeypair(keyPair);
+  });
+
+  it('throws an error when nothing is to be signed', async () => {
+    try {
+      await (signWithKeypair as unknown as () => {})();
+    } catch (e) {
+      expect(e.message).toContain('No transaction(s) to sign');
+    }
+  });
+
+  it('throws when an error is returned', async () => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (createSignWithKeypair as any)(undefined);
+    } catch (e) {
+      expect(e).toBeTruthy();
+    }
+  });
+
+  it('adds signatures in multisig fashion to the transactions', async () => {
+    const keyPair2: IKeypair = {
+      publicKey:
+        '815224b7316e0053635a91fea90f1f5bb474831b257be1aaaf2129ff989824d8',
+      secretKey:
+        '63568bda80b8ff430a5816b0292b456362c8d426ddda08a249e0cb9c005d2502',
+    };
+    const signWithKeypair2 = createSignWithKeypair(keyPair2);
+
+    const unsignedTransaction = Pact.builder
+      .execution(coin.transfer('k:from', 'k:to', { decimal: '1.0' }))
+      .addSigner(keyPair.publicKey, (withCap) => [withCap('coin.GAS')])
+      .addSigner(keyPair2.publicKey, (withCap) => [
+        withCap('coin.TRANSFER', 'k:from', 'k:to', { decimal: '1.234' }),
+      ])
+      .setMeta({
+        senderAccount: '',
+        chainId: '0',
+        creationTime: 0,
+      })
+      .setNonce('my-nonce')
+      .createTransaction();
+
+    const txWithOneSig = await signWithKeypair(unsignedTransaction);
+
+    expect(txWithOneSig.sigs).toStrictEqual([
+      {
+        sig: '5bdcceab829c628afc2afe28d18e5efdc724f0ebc18e1aa10b03c07123f23bdd698a197aba39fc035c0a71c5c821f2f8e12fd6fb138dc33e6d2323b3bbd1b40e',
+      },
+      undefined,
+    ]);
+
+    const signedTx = await signWithKeypair2(txWithOneSig);
+    expect(signedTx.sigs).toEqual([
+      {
+        sig: '5bdcceab829c628afc2afe28d18e5efdc724f0ebc18e1aa10b03c07123f23bdd698a197aba39fc035c0a71c5c821f2f8e12fd6fb138dc33e6d2323b3bbd1b40e',
+      },
+      {
+        sig: 'b921a16a15e2ffa36bda28fb1dcb98ef75e83d94ac2f2736013981d73759ead51945b1df21de254429772cdd6bfe8ea3c63001dfd06a2e0b0322abd3de2c7600',
+      },
+    ]);
+  });
+
+  it('tries to sign with the wrong keypair', async () => {
+    const keyPair2: IKeypair = {
+      publicKey:
+        '815224b7316e0053635a91fea90f1f5bb474831b257be1aaaf2129ff989824d8',
+      secretKey:
+        '63568bda80b8ff430a5816b0292b456362c8d426ddda08a249e0cb9c005d2502',
+    };
+    const signWithKeypair2 = createSignWithKeypair(keyPair2);
+
+    const unsignedTransaction = Pact.builder
+      .execution(coin.transfer('k:from', 'k:to', { decimal: '1.0' }))
+      .addSigner(keyPair.publicKey, (withCap) => [withCap('coin.GAS')])
+      .createTransaction();
+
+    try {
+      await signWithKeypair2(unsignedTransaction);
+    } catch (error) {
+      expect(error.message).toContain(
+        'The keypair(s) provided are not relevant to the transaction',
+      );
+      return;
+    }
+    // should not end up here
+    expect(true).toBe(false);
+  });
+
+  it('signs with two keypairs when one is required', async () => {
+    const keyPair2: IKeypair = {
+      publicKey:
+        '815224b7316e0053635a91fea90f1f5bb474831b257be1aaaf2129ff989824d8',
+      secretKey:
+        '63568bda80b8ff430a5816b0292b456362c8d426ddda08a249e0cb9c005d2502',
+    };
+
+    const unsignedTransaction = Pact.builder
+      .execution(coin.transfer('k:from', 'k:to', { decimal: '1.0' }))
+      .addSigner(keyPair.publicKey, (withCap) => [withCap('coin.GAS')])
+      .setMeta({
+        senderAccount: '',
+        chainId: '0',
+        creationTime: 0,
+      })
+      .setNonce('my-nonce')
+      .createTransaction();
+
+    const signWithKeystore = createSignWithKeypair([keyPair, keyPair2]);
+    const signedTx = await signWithKeystore(unsignedTransaction);
+
+    expect(signedTx.sigs).toEqual([
+      {
+        sig: 'fbc3819d977cf8f770c5fc6b5a75a3099969a7945cec6a5d2bd1e7dd0130a68935d52f1cfce62046db885370511904e00a9a9d2fee84f653f5d324dce9a82a00',
+      },
+    ]);
+  });
+
+  it('signs with two keypairs', async () => {
+    const keyPair2: IKeypair = {
+      publicKey:
+        '815224b7316e0053635a91fea90f1f5bb474831b257be1aaaf2129ff989824d8',
+      secretKey:
+        '63568bda80b8ff430a5816b0292b456362c8d426ddda08a249e0cb9c005d2502',
+    };
+
+    const unsignedTransaction = Pact.builder
+      .execution(coin.transfer('k:from', 'k:to', { decimal: '1.0' }))
+      .addSigner(keyPair.publicKey, (withCap) => [withCap('coin.GAS')])
+      .addSigner(keyPair2.publicKey, (withCap) => [
+        withCap('coin.TRANSFER', 'k:from', 'k:to', { decimal: '1.234' }),
+      ])
+      .setMeta({
+        senderAccount: '',
+        chainId: '0',
+        creationTime: 0,
+      })
+      .setNonce('my-nonce')
+      .createTransaction();
+
+    const signWithKeystore = createSignWithKeypair([keyPair, keyPair2]);
+    const signedTx = await signWithKeystore(unsignedTransaction);
+
+    expect(signedTx.sigs).toEqual([
+      {
+        sig: '5bdcceab829c628afc2afe28d18e5efdc724f0ebc18e1aa10b03c07123f23bdd698a197aba39fc035c0a71c5c821f2f8e12fd6fb138dc33e6d2323b3bbd1b40e',
+      },
+      {
+        sig: 'b921a16a15e2ffa36bda28fb1dcb98ef75e83d94ac2f2736013981d73759ead51945b1df21de254429772cdd6bfe8ea3c63001dfd06a2e0b0322abd3de2c7600',
+      },
+    ]);
+  });
+
+  it('signs multiple transactions with multiple keys passed to `createSignWithKeypair`', async () => {
+    const keyPair2: IKeypair = {
+      publicKey:
+        '815224b7316e0053635a91fea90f1f5bb474831b257be1aaaf2129ff989824d8',
+      secretKey:
+        '63568bda80b8ff430a5816b0292b456362c8d426ddda08a249e0cb9c005d2502',
+    };
+
+    const tx1 = Pact.builder
+      .execution(coin.transfer('k:from', 'k:to', { decimal: '1.0' }))
+      .setMeta({
+        senderAccount: '',
+        chainId: '0',
+        creationTime: 0,
+      })
+      .setNonce('my-nonce')
+      .addSigner(keyPair2.publicKey, (withCap) => [
+        withCap('coin.TRANSFER', 'k:from', 'k:to', { decimal: '1.234' }),
+      ])
+      .createTransaction();
+
+    const tx2 = Pact.builder
+      .execution(coin.transfer('k:from', 'k:to', { decimal: '1.0' }))
+      .setMeta({
+        senderAccount: '',
+        chainId: '0',
+        creationTime: 0,
+      })
+      .setNonce('my-nonce')
+      .addSigner(keyPair.publicKey, (withCap) => [withCap('coin.GAS')])
+      .createTransaction();
+
+    const signWithKeystore = createSignWithKeypair([keyPair, keyPair2]);
+    const [signedTx1, signedTx2] = await signWithKeystore([tx1, tx2]);
+
+    expect(signedTx1.sigs).toEqual([
+      {
+        sig: '522264b48dfefacd06ac6edc4b72e37629f946dbb464396b069b035d7c11e0b4852ea0c9ef4da8aeafb964ed348c1d0a416d9736af87e8d936bbb2c1bc7d5c0e',
+      },
+    ]);
+
+    expect(signedTx2.sigs).toEqual([
+      {
+        sig: 'fbc3819d977cf8f770c5fc6b5a75a3099969a7945cec6a5d2bd1e7dd0130a68935d52f1cfce62046db885370511904e00a9a9d2fee84f653f5d324dce9a82a00',
+      },
+    ]);
+  });
+});

--- a/packages/libs/client/src/signing/utils/addSignatures.ts
+++ b/packages/libs/client/src/signing/utils/addSignatures.ts
@@ -10,7 +10,7 @@ import _debug from 'debug';
 const debug: Debugger = _debug('@kadena/client:signing:addSignature');
 
 /**
- * adds signatures to an {@link IUnsignedCommand | unsigned command}
+ * adds signatures to an {@link @kadena/types#IUnsignedCommand | unsigned command}
  *
  * @public
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -952,7 +948,7 @@ importers:
         version: 3.1.5
       debug:
         specifier: ~4.3.4
-        version: 4.3.4(supports-color@5.5.0)
+        version: 4.3.4
     devDependencies:
       '@kadena-dev/eslint-config':
         specifier: workspace:*
@@ -974,7 +970,7 @@ importers:
         version: link:../types
       '@rushstack/eslint-config':
         specifier: ~3.3.0
-        version: 3.3.0(eslint@8.45.0)(typescript@5.1.6)
+        version: 3.3.0(eslint@8.45.0)(typescript@5.2.2)
       '@rushstack/heft':
         specifier: ~0.50.6
         version: 0.50.6(@types/node@16.0.0)
@@ -1001,7 +997,7 @@ importers:
         version: 2.4.5(prettier@3.0.0)
       ts-node:
         specifier: ~10.8.2
-        version: 10.8.2(@types/node@16.0.0)(typescript@5.1.6)
+        version: 10.8.2(@types/node@16.0.0)(typescript@5.2.2)
 
   packages/libs/client-examples:
     dependencies:
@@ -1270,7 +1266,7 @@ importers:
         version: 2.4.5(prettier@3.0.0)
       ts-jest:
         specifier: ~29.1.0
-        version: 29.1.0(@babel/core@7.22.15)(jest@29.6.4)(typescript@5.1.6)
+        version: 29.1.0(@babel/core@7.22.9)(esbuild@0.18.20)(jest@29.6.1)(typescript@5.1.6)
       ts-node:
         specifier: ~10.8.2
         version: 10.8.2(@types/node@16.0.0)(typescript@5.1.6)
@@ -1545,7 +1541,7 @@ importers:
         version: 8.45.0
       eslint-import-resolver-typescript:
         specifier: 3.5.5
-        version: 3.5.5(@typescript-eslint/parser@5.59.11)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
+        version: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
       eslint-plugin-import:
         specifier: ~2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.59.11)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
@@ -1714,7 +1710,7 @@ importers:
         version: 9.0.0(eslint@8.45.0)
       eslint-import-resolver-typescript:
         specifier: 3.5.5
-        version: 3.5.5(@typescript-eslint/parser@5.23.0)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
+        version: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
       eslint-plugin-import:
         specifier: ~2.27.5
         version: 2.27.5(@typescript-eslint/parser@5.23.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
@@ -1886,7 +1882,7 @@ importers:
         version: 2.4.5(prettier@3.0.0)
       ts-jest:
         specifier: ~29.1.0
-        version: 29.1.0(@babel/core@7.22.15)(jest@29.6.4)(typescript@5.1.6)
+        version: 29.1.0(@babel/core@7.22.9)(esbuild@0.18.20)(jest@29.6.1)(typescript@5.1.6)
       ts-node:
         specifier: ~10.8.2
         version: 10.8.2(@types/node@16.0.0)(typescript@5.1.6)
@@ -6124,7 +6120,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       espree: 9.6.1
       globals: 13.20.0
       ignore: 5.2.4
@@ -6997,7 +6993,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -7196,7 +7192,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.6.3
-      jest-config: 29.6.4(@types/node@16.18.48)(ts-node@10.8.2)
+      jest-config: 29.6.4(@types/node@16.0.0)(ts-node@10.8.2)
       jest-haste-map: 29.6.4
       jest-message-util: 29.6.3
       jest-regex-util: 29.6.3
@@ -7238,7 +7234,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.6.3
-      jest-config: 29.6.4(@types/node@16.18.48)(ts-node@10.8.2)
+      jest-config: 29.6.4(@types/node@16.0.0)(ts-node@10.8.2)
       jest-haste-map: 29.6.4
       jest-message-util: 29.6.3
       jest-regex-util: 29.6.3
@@ -7896,7 +7892,7 @@ packages:
       npmlog: 5.0.1
       rimraf: 3.0.2
       semver: 7.5.4
-      tar: 6.1.15
+      tar: 6.2.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8506,7 +8502,7 @@ packages:
       '@percy/logger': 1.24.0
       content-disposition: 0.5.4
       cross-spawn: 7.0.3
-      extract-zip: 2.0.1
+      extract-zip: 2.0.1(supports-color@8.1.1)
       fast-glob: 3.3.1
       micromatch: 4.0.5
       mime-types: 2.1.35
@@ -9452,6 +9448,29 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@rushstack/eslint-config@3.3.0(eslint@8.45.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-7eqoCDc52QK07yTDD7txyv1/5kt5jPfo4NnLgqX3NlMNBCMWSuWTJyCPXLZiwVLWAOjcPSxN8/10WuEIQkGMiw==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '>=4.7.0'
+    dependencies:
+      '@rushstack/eslint-patch': 1.3.0
+      '@rushstack/eslint-plugin': 0.12.0(eslint@8.45.0)(typescript@5.2.2)
+      '@rushstack/eslint-plugin-packlets': 0.7.0(eslint@8.45.0)(typescript@5.2.2)
+      '@rushstack/eslint-plugin-security': 0.6.0(eslint@8.45.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 5.59.11(@typescript-eslint/parser@5.59.11)(eslint@8.45.0)(typescript@5.2.2)
+      '@typescript-eslint/experimental-utils': 5.59.11(eslint@8.45.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.59.11(eslint@8.45.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.2.2)
+      eslint: 8.45.0
+      eslint-plugin-promise: 6.0.1(eslint@8.45.0)
+      eslint-plugin-react: 7.27.1(eslint@8.45.0)
+      eslint-plugin-tsdoc: 0.2.17
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@rushstack/eslint-config@3.3.0(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-7eqoCDc52QK07yTDD7txyv1/5kt5jPfo4NnLgqX3NlMNBCMWSuWTJyCPXLZiwVLWAOjcPSxN8/10WuEIQkGMiw==}
     peerDependencies:
@@ -9493,6 +9512,19 @@ packages:
       - supports-color
       - typescript
 
+  /@rushstack/eslint-plugin-packlets@0.7.0(eslint@8.45.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-ftvrRvN7a5dfpDidDtrqJHH25JvL4huqk3a0S4zv5Rlh1kz6sfPvaKosDQowzEHBIWLvAtTN+P8ygWoyL0/XYw==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.2.4
+      '@typescript-eslint/experimental-utils': 5.59.11(eslint@8.45.0)(typescript@5.2.2)
+      eslint: 8.45.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@rushstack/eslint-plugin-packlets@0.7.0(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-ftvrRvN7a5dfpDidDtrqJHH25JvL4huqk3a0S4zv5Rlh1kz6sfPvaKosDQowzEHBIWLvAtTN+P8ygWoyL0/XYw==}
     peerDependencies:
@@ -9517,6 +9549,19 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  /@rushstack/eslint-plugin-security@0.6.0(eslint@8.45.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-gJFBGoCCofU34GGFtR3zEjymEsRr2wDLu2u13mHVcDzXyZ3EDlt6ImnJtmn8VRDLGjJ7QFPOiYMSZQaArxWmGg==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.2.4
+      '@typescript-eslint/experimental-utils': 5.59.11(eslint@8.45.0)(typescript@5.2.2)
+      eslint: 8.45.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
 
   /@rushstack/eslint-plugin-security@0.6.0(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-gJFBGoCCofU34GGFtR3zEjymEsRr2wDLu2u13mHVcDzXyZ3EDlt6ImnJtmn8VRDLGjJ7QFPOiYMSZQaArxWmGg==}
@@ -9555,6 +9600,19 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  /@rushstack/eslint-plugin@0.12.0(eslint@8.45.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-kDB35khQeoDjabzHkHDs/NgvNNZzogkoU/UfrXnNSJJlcCxOxmhyscUQn5OptbixiiYCOFZh9TN9v2yGBZ3vJQ==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.2.4
+      '@typescript-eslint/experimental-utils': 5.59.11(eslint@8.45.0)(typescript@5.2.2)
+      eslint: 8.45.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
 
   /@rushstack/eslint-plugin@0.12.0(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-kDB35khQeoDjabzHkHDs/NgvNNZzogkoU/UfrXnNSJJlcCxOxmhyscUQn5OptbixiiYCOFZh9TN9v2yGBZ3vJQ==}
@@ -10658,7 +10716,7 @@ packages:
       glob: 10.3.4
       handlebars: 4.7.8
       lazy-universal-dotenv: 4.0.0
-      node-fetch: 2.7.0
+      node-fetch: 2.6.12
       picomatch: 2.3.1
       pkg-dir: 5.0.0
       pretty-hrtime: 1.0.3
@@ -12431,6 +12489,34 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@typescript-eslint/eslint-plugin@5.59.11(@typescript-eslint/parser@5.59.11)(eslint@8.45.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.6.2
+      '@typescript-eslint/parser': 5.59.11(eslint@8.45.0)(typescript@5.2.2)
+      '@typescript-eslint/scope-manager': 5.59.11
+      '@typescript-eslint/type-utils': 5.59.11(eslint@8.45.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.59.11(eslint@8.45.0)(typescript@5.2.2)
+      debug: 4.3.4
+      eslint: 8.45.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.4
+      natural-compare-lite: 1.4.0
+      semver: 7.5.4
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/eslint-plugin@5.59.11(@typescript-eslint/parser@5.59.11)(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-XxuOfTkCUiOSyBWIvHlUraLw/JT/6Io1365RO6ZuI88STKMavJZPNMU0lFcUTeQXEhHiv64CbxYxBNoDVSmghg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -12514,6 +12600,19 @@ packages:
       - supports-color
       - typescript
 
+  /@typescript-eslint/experimental-utils@5.59.11(eslint@8.45.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-GkQGV0UF/V5Ra7gZMBmiD1WrYUFOJNvCZs+XQnUyJoxmqfWMXVNyB2NVCPRKefoQcpvTv9UpJyfCvsJFs8NzzQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@typescript-eslint/utils': 5.59.11(eslint@8.45.0)(typescript@5.2.2)
+      eslint: 8.45.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
   /@typescript-eslint/experimental-utils@5.59.11(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-GkQGV0UF/V5Ra7gZMBmiD1WrYUFOJNvCZs+XQnUyJoxmqfWMXVNyB2NVCPRKefoQcpvTv9UpJyfCvsJFs8NzzQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -12585,6 +12684,26 @@ packages:
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
+
+  /@typescript-eslint/parser@5.59.11(eslint@8.45.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.59.11
+      '@typescript-eslint/types': 5.59.11
+      '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.2.2)
+      debug: 4.3.4
+      eslint: 8.45.0
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@typescript-eslint/parser@5.59.11(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-s9ZF3M+Nym6CAZEkJJeO2TFHHDsKAM3ecNkLuH4i4s8/RCPnF5JRip2GyviYkeEAcwGMJxkqG9h2dAsnA1nZpA==}
@@ -12698,6 +12817,26 @@ packages:
       typescript: 5.1.6
     transitivePeerDependencies:
       - supports-color
+
+  /@typescript-eslint/type-utils@5.59.11(eslint@8.45.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-LZqVY8hMiVRF2a7/swmkStMYSoXMFlzL6sXV6U/2gL5cwnLWQgLEG8tjWPpaE4rMIdZ6VKWwcffPlo1jPfk43g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.59.11(eslint@8.45.0)(typescript@5.2.2)
+      debug: 4.3.4
+      eslint: 8.45.0
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@typescript-eslint/type-utils@5.59.11(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-LZqVY8hMiVRF2a7/swmkStMYSoXMFlzL6sXV6U/2gL5cwnLWQgLEG8tjWPpaE4rMIdZ6VKWwcffPlo1jPfk43g==}
@@ -12850,6 +12989,27 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@typescript-eslint/typescript-estree@5.59.11(typescript@5.2.2):
+    resolution: {integrity: sha512-YupOpot5hJO0maupJXixi6l5ETdrITxeo5eBOeuV7RSKgYdU3G5cxO49/9WRnJq9EMrB7AuTSLH/bqOsXi7wPA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.59.11
+      '@typescript-eslint/visitor-keys': 5.59.11
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.1.6):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -12943,6 +13103,26 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  /@typescript-eslint/utils@5.59.11(eslint@8.45.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-didu2rHSOMUdJThLk4aZ1Or8IcO3HzCw/ZvEjTTIfjIrcdd5cvSIwwDy2AOlE7htSNp7QIZ10fLMyRCveesMLg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.45.0)
+      '@types/json-schema': 7.0.12
+      '@types/semver': 7.5.0
+      '@typescript-eslint/scope-manager': 5.59.11
+      '@typescript-eslint/types': 5.59.11
+      '@typescript-eslint/typescript-estree': 5.59.11(typescript@5.2.2)
+      eslint: 8.45.0
+      eslint-scope: 5.1.1
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
 
   /@typescript-eslint/utils@5.59.11(eslint@8.48.0)(typescript@5.1.6):
     resolution: {integrity: sha512-didu2rHSOMUdJThLk4aZ1Or8IcO3HzCw/ZvEjTTIfjIrcdd5cvSIwwDy2AOlE7htSNp7QIZ10fLMyRCveesMLg==}
@@ -15648,6 +15828,7 @@ packages:
   /commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+    requiresBuild: true
 
   /common-path-prefix@3.0.0:
     resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
@@ -16411,6 +16592,17 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 8.1.1
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -17358,7 +17550,7 @@ packages:
       eslint: 8.45.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.11)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.23.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.45.0)
       eslint-plugin-react: 7.31.11(eslint@8.45.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.45.0)
@@ -17420,53 +17612,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.23.0)(eslint-plugin-import@2.27.5)(eslint@8.45.0):
-    resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      eslint-plugin-import: '*'
-    dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
-      enhanced-resolve: 5.15.0
-      eslint: 8.45.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.23.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.23.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
-      get-tsconfig: 4.6.2
-      globby: 13.2.2
-      is-core-module: 2.12.1
-      is-glob: 4.0.3
-      synckit: 0.8.5
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: false
-
-  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.59.11)(eslint-plugin-import@2.27.5)(eslint@8.45.0):
-    resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      eslint-plugin-import: '*'
-    dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
-      enhanced-resolve: 5.15.0
-      eslint: 8.45.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.59.11)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.11)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
-      get-tsconfig: 4.6.2
-      globby: 13.2.2
-      is-core-module: 2.12.1
-      is-glob: 4.0.3
-      synckit: 0.8.5
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-
   /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0):
     resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -17478,7 +17623,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.45.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.11)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.23.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0)
       get-tsconfig: 4.6.2
       globby: 13.2.2
       is-core-module: 2.12.1
@@ -17515,10 +17660,9 @@ packages:
       debug: 3.2.7(supports-color@8.1.1)
       eslint: 8.45.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.23.0)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.59.11)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
@@ -17545,9 +17689,10 @@ packages:
       debug: 3.2.7(supports-color@8.1.1)
       eslint: 8.45.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.11)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.45.0)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0):
     resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
@@ -17624,7 +17769,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    dev: false
 
   /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.11)(eslint-import-resolver-typescript@3.5.5)(eslint@8.45.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
@@ -17657,6 +17801,7 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: true
 
   /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.23.0)(eslint@8.45.0)(jest@27.5.1)(typescript@5.1.6):
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
@@ -17990,7 +18135,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -18392,20 +18537,6 @@ packages:
       debug: 2.6.9
       mkdirp: 0.5.6
       yauzl: 2.10.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-    dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -19193,7 +19324,7 @@ packages:
       foreground-child: 3.1.1
       jackspeak: 2.2.2
       minimatch: 9.0.3
-      minipass: 7.0.2
+      minipass: 7.0.3
       path-scurry: 1.10.1
 
   /glob@10.3.4:
@@ -21015,7 +21146,6 @@ packages:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
-    dev: true
 
   /jest-config@29.6.4(@types/node@16.18.48)(ts-node@10.8.2):
     resolution: {integrity: sha512-JWohr3i9m2cVpBumQFv2akMEnFEPVOh+9L2xIBJhJ0zOaci2ZXuKJj0tgMKQCBZAKA09H049IR4HVS/43Qb19A==}
@@ -21056,6 +21186,7 @@ packages:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    dev: true
 
   /jest-diff@27.5.1:
     resolution: {integrity: sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==}
@@ -23933,10 +24064,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /minipass@7.0.2:
-    resolution: {integrity: sha512-eL79dXrE1q9dBbDCLg7xfn/vl7MS4F1gvJAgjJrQli/jbQWdUttuVawphqpffoIYfRdq78LHx6GP4bU/EQ2ATA==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   /minipass@7.0.3:
     resolution: {integrity: sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -24256,18 +24383,6 @@ packages:
     dependencies:
       whatwg-url: 5.0.0
     dev: false
-
-  /node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      whatwg-url: 5.0.0
-    dev: true
 
   /node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -25016,7 +25131,7 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       lru-cache: 10.0.0
-      minipass: 7.0.2
+      minipass: 7.0.3
 
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
@@ -26927,7 +27042,7 @@ packages:
       source-map-loader: 3.0.2(webpack@5.88.2)
       style-loader: 3.3.3(webpack@5.88.2)
       tailwindcss: 3.3.3
-      terser-webpack-plugin: 5.3.9(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.80)(esbuild@0.18.20)(webpack@5.88.2)
       typescript: 5.1.6
       webpack: 5.88.2(webpack-cli@4.9.2)
       webpack-dev-server: 4.15.1(debug@4.3.4)(webpack@5.88.2)
@@ -29104,20 +29219,6 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
-  /tar@6.1.15:
-    resolution: {integrity: sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==}
-    engines: {node: '>=10'}
-    requiresBuild: true
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-    dev: true
-    optional: true
-
   /tar@6.2.0:
     resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
     engines: {node: '>=10'}
@@ -29223,29 +29324,6 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.19.4
       webpack: 5.88.2(@swc/core@1.3.80)(esbuild@0.18.20)
-
-  /terser-webpack-plugin@5.3.9(webpack@5.88.2):
-    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.19
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.19.4
-      webpack: 5.88.2(webpack-cli@4.9.2)
 
   /terser@5.19.2:
     resolution: {integrity: sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==}
@@ -29477,40 +29555,6 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /ts-jest@29.1.0(@babel/core@7.22.15)(jest@29.6.4)(typescript@5.1.6):
-    resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3 <6'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.15
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.6.4(@types/node@16.0.0)(ts-node@10.8.2)
-      jest-util: 29.6.2
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.4
-      typescript: 5.1.6
-      yargs-parser: 21.1.1
-    dev: true
-
   /ts-jest@29.1.0(@babel/core@7.22.9)(esbuild@0.18.20)(jest@29.6.1)(typescript@5.1.6):
     resolution: {integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -29595,6 +29639,37 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  /ts-node@10.8.2(@types/node@16.0.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-LYdGnoGddf1D6v8REPtIH+5iq/gTDuZqv2/UJUU7tKjuEU8xVZorBM+buCGNjj+pGEud+sOoM4CX3/YzINpENA==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 16.0.0
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.2.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /ts-toolbelt@9.6.0:
     resolution: {integrity: sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==}
     dev: true
@@ -29663,6 +29738,16 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.1.6
+
+  /tsutils@3.21.0(typescript@5.2.2):
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 5.2.2
+    dev: true
 
   /tsx@3.12.8:
     resolution: {integrity: sha512-Lt9KYaRGF023tlLInPj8rgHwsZU8qWLBj4iRXNWxTfjIkU7canGL806AqKear1j722plHuiYNcL2ZCo6uS9UJA==}
@@ -30931,7 +31016,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.80)(esbuild@0.18.20)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-cli: 4.9.2(webpack@5.88.2)
       webpack-sources: 3.2.3
@@ -31576,3 +31661,7 @@ packages:
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
- feat(client): adds `createSignWithKeypair` and allows `signWithKeypair`

This new function allows you to sign with:
- one keypair, one transaction
- one keypair, multiple transactions
- multiple keypairs, one transaction
- multiple keypairs, multiple transactions, multiple times

An example of the most comprehensive variant:

```typescript
const signWithKeystore = createSignWithKeypair([keyPair, keyPair2]);
const [signedTx1, signedTx2] = await signWithKeystore([tx1, tx2]);
const signedTx3 = await signWithKeystore(tx3);
```
