### PR TITLE
Fix/parser issues

### DIFF
--- a/.changeset/hungry-peas-shop.md
+++ b/.changeset/hungry-peas-shop.md
@@ -1,0 +1,5 @@
+---
+'@kadena/pactjs-generator': patch
+---
+
+Update the pact-grammar to support a list as a valid function's return type.

--- a/.changeset/large-clouds-search.md
+++ b/.changeset/large-clouds-search.md
@@ -1,0 +1,6 @@
+---
+'@kadena/pactjs-generator': patch
+---
+
+Fix the name collision between the arguments of capabilities in the generated
+type

--- a/packages/libs/pactjs-generator/src/contract/generation/generator.ts
+++ b/packages/libs/pactjs-generator/src/contract/generation/generator.ts
@@ -76,7 +76,16 @@ function genFunCapsInterface(func: IFunction): string {
   const interfaceName = getFuncCapInterfaceName(func);
 
   const cap = func.allExtractedCaps.map((cap) => {
-    let parameters = [`name: "${cap.fullModuleName}.${cap.name}"`];
+    let capabilityName = 'capabilityName';
+    while (
+      cap.capability.parameters &&
+      cap.capability.parameters.find((p) => p.name === capabilityName)
+    ) {
+      // make sure we don't have a name collision
+      capabilityName = `_${capabilityName}`;
+    }
+
+    let parameters = [`${capabilityName}: "${cap.fullModuleName}.${cap.name}"`];
     if (cap.capability.parameters) {
       const args = getParameters(cap.capability.parameters);
       parameters = [...parameters, ...args];

--- a/packages/libs/pactjs-generator/src/contract/generation/generator.ts
+++ b/packages/libs/pactjs-generator/src/contract/generation/generator.ts
@@ -1,4 +1,4 @@
-import type { IFunction, IModule } from '../parsing/pactParser';
+import type { IFunction, IModule, IType } from '../parsing/pactParser';
 import { getModuleFullName } from '../parsing/utils/utils';
 
 import { EOL } from 'os';
@@ -13,9 +13,7 @@ const keywordsMap: Record<string, string> = {
   object: 'object',
 };
 
-const mapType = (
-  inputType?: string | { kind: string; value: string },
-): string => {
+const mapType = (inputType?: string | IType): string => {
   if (inputType === undefined) {
     return 'any';
   }
@@ -25,9 +23,10 @@ const mapType = (
 
   if (typeof inputType === 'object' && inputType.kind === 'module')
     return 'PactReference';
+  const isList = inputType.isList ? '[]' : '';
   // TODO: import the schema as interface to return kind instead of any
-  // return inputType.kind;
-  return keywordsMap[inputType.kind] ?? 'any';
+  const type = keywordsMap[inputType.kind] ?? 'any';
+  return `${type}${isList}`;
 };
 
 const getFuncCapInterfaceName = (func: IFunction): string => {

--- a/packages/libs/pactjs-generator/src/contract/generation/tests/__snapshots__/generator.test.ts.snap
+++ b/packages/libs/pactjs-generator/src/contract/generation/tests/__snapshots__/generator.test.ts.snap
@@ -37,7 +37,7 @@ interface ICapability_test_func {
   * this is defcap doc
   */
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 
@@ -73,7 +73,7 @@ interface ICapability_test_func {
   * this is defcap doc
   */
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 
@@ -90,6 +90,46 @@ declare module '@kadena/client' {
         parameterone: object,
         parametertwo: boolean) => string & { capability : ICapability_test_func & ICapability_Coin_GAS} 
 
+    }
+  }
+}"
+`;
+
+exports[`generateDts adds some _ to capabilityName to make it unique and avoid name collision if the capability function has also an argument exactly with the same name 1`] = `
+"
+import type { PactReference } from '@kadena/client';
+import type { IPactDecimal, IPactInt, ICap } from '@kadena/types';
+
+interface ICapability_Coin_GAS {
+  (name: 'coin.GAS'): ICap;
+}
+
+interface ICapability_defpact_test_func {
+  /**
+  * this is defcap doc
+  */
+  (
+    __capabilityName: "user.test-module.test-cap", 
+    capabilityName: string, 
+    _capabilityName: string): ICap,
+}
+
+declare module '@kadena/client' {
+  export interface IPactModules {
+    /**
+    this is module doc    
+    */
+    "user.test-module": {
+    
+
+      "defpact":{
+        /**
+        * this is defpact doc
+        */
+        "test-func": (
+          parameterone: any,
+          parametertwo: any) => string & { capability : ICapability_defpact_test_func & ICapability_Coin_GAS} 
+      }
     }
   }
 }"
@@ -151,7 +191,7 @@ interface ICapability_defpact_test_func {
   * this is defcap doc
   */
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 
@@ -188,7 +228,7 @@ interface ICapability_Coin_GAS {
 interface ICapability_test_func {
   
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 
@@ -217,7 +257,7 @@ interface ICapability_Coin_GAS {
 interface ICapability_test_func {
   
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 
@@ -246,7 +286,7 @@ interface ICapability_Coin_GAS {
 interface ICapability_test_func {
   
   (
-    name: "user.test-module.test-cap", 
+    capabilityName: "user.test-module.test-cap", 
     name: string): ICap,
 }
 

--- a/packages/libs/pactjs-generator/src/contract/generation/tests/__snapshots__/generator.test.ts.snap
+++ b/packages/libs/pactjs-generator/src/contract/generation/tests/__snapshots__/generator.test.ts.snap
@@ -245,6 +245,29 @@ declare module '@kadena/client' {
 }"
 `;
 
+exports[`generateDts should generate the function also if return type is a list 1`] = `
+"
+import type { PactReference } from '@kadena/client';
+import type { IPactDecimal, IPactInt, ICap } from '@kadena/types';
+
+interface ICapability_Coin_GAS {
+  (name: 'coin.GAS'): ICap;
+}
+
+declare module '@kadena/client' {
+  export interface IPactModules {
+    
+    "user.test-module": {
+      /**
+      * Get all events
+      */
+      "get-events-list": () => string & { capability : ICapability_Coin_GAS} 
+
+    }
+  }
+}"
+`;
+
 exports[`generateDts use any type if function parameters dont have a type 1`] = `
 "
 import type { PactReference } from '@kadena/client';

--- a/packages/libs/pactjs-generator/src/contract/generation/tests/generator.test.ts
+++ b/packages/libs/pactjs-generator/src/contract/generation/tests/generator.test.ts
@@ -226,4 +226,27 @@ describe('generateDts', () => {
     const dts = generateDts('user.test-module', modules);
     expect(dts).toMatchSnapshot();
   });
+
+  it('adds some _ to capabilityName to make it unique and avoid name collision if the capability function has also an argument exactly with the same name', async () => {
+    const module = `(namespace "user")
+    (module test-module governance
+      @doc "this is module doc"
+      (defcap test-cap (capabilityName:string _capabilityName:string)
+        @doc "this is defcap doc"
+        true)
+      (defpact test-func:bool (parameter-one parameter-two )
+        @doc "this is defpact doc"
+        (with-capability (test-cap "capabilityName"))
+      )
+    )
+  `;
+
+    const modules = await pactParser({
+      files: [module],
+      getContract: () => Promise.resolve(''),
+    });
+
+    const dts = generateDts('user.test-module', modules);
+    expect(dts).toMatchSnapshot();
+  });
 });

--- a/packages/libs/pactjs-generator/src/contract/generation/tests/generator.test.ts
+++ b/packages/libs/pactjs-generator/src/contract/generation/tests/generator.test.ts
@@ -249,4 +249,23 @@ describe('generateDts', () => {
     const dts = generateDts('user.test-module', modules);
     expect(dts).toMatchSnapshot();
   });
+
+  it('should generate the function also if return type is a list', async () => {
+    const module = `(namespace "user")
+    (module test-module governance
+      (defun get-events-list:[object{networking-event-schema}] ()
+        @doc "Get all events"
+        (select networking-events-table (where "deleted-at" (= -1)))
+      )
+    )
+`;
+
+    const modules = await pactParser({
+      files: [module],
+      getContract: () => Promise.resolve(''),
+    });
+
+    const dts = generateDts('user.test-module', modules);
+    expect(dts).toMatchSnapshot();
+  });
 });

--- a/packages/libs/pactjs-generator/src/contract/parsing/pactParser.ts
+++ b/packages/libs/pactjs-generator/src/contract/parsing/pactParser.ts
@@ -6,23 +6,29 @@ import { functionCalls, parser } from './utils/pactGrammar';
 import type { IModuleLike } from './utils/utils';
 import { getModuleFullName } from './utils/utils';
 
+export interface IType {
+  kind: string;
+  value: string;
+  isList?: true;
+}
+
 interface ISchema {
   name: string;
   doc?: string;
   properties?: Array<{
     name: string;
-    type: string | { kind: string; value: string };
+    type: string | IType;
   }>;
 }
 
 interface IMethod {
   name: string;
   kind: string; // 'defun' | 'defcap' | 'defpact'; // need to fix typing
-  returnType?: string | { kind: string; value: string };
+  returnType?: string | IType;
   doc?: string;
   parameters?: Array<{
     name: string;
-    type: string | { kind: string; value: string };
+    type: string | IType;
   }>;
 }
 

--- a/packages/libs/pactjs-generator/src/contract/parsing/tests/pactParser.test.ts
+++ b/packages/libs/pactjs-generator/src/contract/parsing/tests/pactParser.test.ts
@@ -163,4 +163,32 @@ describe('pactParser', () => {
     expect(testModule.functions).toHaveLength(1);
     expect(testModule.functions![0].name).toBe('test_fun');
   });
+
+  it('parses a function with list as return type', async () => {
+    const contract = `
+      (module test_module GOVERNANCE
+        (defun get-events-list:[object{networking-event-schema}] ()
+          @doc "Get all events"
+          (with-capability (OPS)
+            (select networking-events-table (where "deleted-at" (= -1)))
+          )
+        )
+      )
+      `;
+
+    const getContract = (): Promise<string> => Promise.resolve('');
+    const modules = await pactParser({ files: [contract], getContract });
+    expect(Object.keys(modules)).toHaveLength(1);
+    const testModule = modules.test_module;
+    expect(testModule).toBeDefined();
+    expect(testModule.name).toBe('test_module');
+    expect(testModule.kind).toBe('module');
+    expect(testModule.functions).toHaveLength(1);
+    expect(testModule.functions![0].name).toBe('get-events-list');
+    expect(testModule.functions![0].returnType).toEqual({
+      kind: 'object',
+      value: 'networking-event-schema',
+      isList: true,
+    });
+  });
 });

--- a/packages/libs/pactjs-generator/src/contract/parsing/utils/pactGrammar.ts
+++ b/packages/libs/pactjs-generator/src/contract/parsing/utils/pactGrammar.ts
@@ -26,16 +26,22 @@ import {
 
 const kind = oneOf(atom, id('module'));
 
-// :string :object{schema-one} {kind:object,value:schema-one} | string
-export const typeRule = seq(
-  id(':'),
-  oneOf(
-    // types with interface/schema
-    seq($('kind', kind), id('{'), $('value', oneOf(dotedAtom, atom)), id('}')),
-    // primary types
-    $(atom),
-  ),
+const list = (rule: IParser) =>
+  seq(
+    $('isList', () => true),
+    id('['),
+    rule,
+    id(']'),
+  );
+const typeItem = oneOf(
+  // types with interface/schema
+  seq($('kind', kind), id('{'), $('value', oneOf(dotedAtom, atom)), id('}')),
+  // primary types
+  $(atom),
 );
+
+// :string :object{schema-one} :[object{schema-one}] => {kind:object,value:schema-one} | string
+export const typeRule = seq(id(':'), oneOf(list(typeItem), typeItem));
 
 // (defun|defcap name (a:string,b:object{schema-one},c) @doc "test doc")
 export const method = <T extends IParser>(


### PR DESCRIPTION
* Fix the name collision between the arguments of capabilities in the generated type
* Update the pact-grammar to support a list as a valid function's return type.