### PR TITLE
fix: remove vscode workspace settings to allow custom definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,9 @@ packages/*/*/temp
 .idea
 .idea/*
 
+# Vscode files
+.vscode/settings.json
+
 # Turborepo
 .turbo
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "files.associations": {
-    "*.json": "jsonc"
-  },
-  "graphql-config.load.rootDir": "packages/apps/graph"
-}


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->
The workspace guidelines suggest setting up your editor environment yourself, but having this settings file checked into git goes against that. Unless someone has a good solutions I'm afraid vscode does not give it to you both ways, either you provide a well rounded configuration that works for everyone, or you have no configuration checked in.
