### PR TITLE
feat: added vscode settings for format on save

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,6 +8,7 @@
     "eamodio.gitlens",
     "christian-kohler.path-intellisense",
     "prisma.prisma",
-    "graphql.vscode-graphql"
+    "graphql.vscode-graphql",
+    "rohit-gohri.format-code-action"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,16 @@
 {
+  "eslint.format.enable": true,
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "graphql-config.load.rootDir": "packages/apps/graph",
+  "[typescript][typescriptreact]": {
+    "editor.formatOnSave": false,
+    "editor.codeActionsOnSave": [
+      "source.formatDocument",
+      "source.fixAll.eslint"
+    ]
+  },
   "files.associations": {
     "*.json": "jsonc"
-  },
-  "graphql-config.load.rootDir": "packages/apps/graph"
+  }
 }


### PR DESCRIPTION
These are the settings I personally use to try and match the repositories formatting rules.

It uses a vscode extension `format-code-action` to be able to format as part of `editor.codeActionsOnSave` which enables both eslint fix and prettier format. The alternative way to doing this would be the prettier plugin for eslint, but that is slower and requires extra configuration per project.

We could limit format on save per file type, but currently it will run for everything prettier supports, and also run eslint-fix for typescript files.