### PR TITLE
Generate provenance statement during npm publish

### DIFF
--- a/.changeset/small-singers-brush.md
+++ b/.changeset/small-singers-brush.md
@@ -1,0 +1,13 @@
+---
+'@kadena/chainweb-stream-client': minor
+'@kadena/chainweb-node-client': minor
+'@kadena/cryptography-utils': minor
+'@kadena/pactjs-generator': minor
+'@kadena/chainwebjs': minor
+'@kadena/client': minor
+'@kadena/pactjs': minor
+'@kadena/types': minor
+'@kadena/docs': minor
+---
+
+Generate provenance statement during npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     name: Changelog PR or Release
     if: ${{ github.repository_owner == 'kadena-community' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -56,6 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_ACTION_GITHUB_TOKEN }}
           # Needs r+w access for packages of both orgs to publish to npm
           NPM_TOKEN: ${{ secrets.RELEASE_ACTION_NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Output (debug)
         if: steps.changesets.outputs.published == 'true'

--- a/packages/libs/chainweb-node-client/package.json
+++ b/packages/libs/chainweb-node-client/package.json
@@ -65,5 +65,8 @@
     "prettier": "~3.0.0",
     "prettier-plugin-packagejson": "^2.4.5",
     "typescript": "5.2.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/libs/chainweb-stream-client/package.json
+++ b/packages/libs/chainweb-stream-client/package.json
@@ -54,5 +54,8 @@
     "prettier": "~3.0.0",
     "prettier-plugin-packagejson": "^2.4.5",
     "typescript": "5.2.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/libs/chainwebjs/package.json
+++ b/packages/libs/chainwebjs/package.json
@@ -81,5 +81,8 @@
     "prettier": "~3.0.0",
     "prettier-plugin-packagejson": "^2.4.5",
     "typescript": "5.2.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/libs/client/package.json
+++ b/packages/libs/client/package.json
@@ -62,5 +62,8 @@
     "prettier-plugin-packagejson": "^2.4.5",
     "ts-node": "~10.8.2",
     "typescript": "5.2.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/libs/cryptography-utils/package.json
+++ b/packages/libs/cryptography-utils/package.json
@@ -61,5 +61,8 @@
     "prettier": "~3.0.0",
     "prettier-plugin-packagejson": "^2.4.5",
     "typescript": "5.2.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/libs/pactjs-generator/package.json
+++ b/packages/libs/pactjs-generator/package.json
@@ -57,5 +57,8 @@
     "prettier-plugin-packagejson": "^2.4.5",
     "ts-node": "~10.8.2",
     "typescript": "5.2.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/libs/pactjs/package.json
+++ b/packages/libs/pactjs/package.json
@@ -59,5 +59,8 @@
     "prettier": "~3.0.0",
     "prettier-plugin-packagejson": "^2.4.5",
     "typescript": "5.2.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/libs/types/package.json
+++ b/packages/libs/types/package.json
@@ -52,5 +52,8 @@
     "prettier": "~3.0.0",
     "prettier-plugin-packagejson": "^2.4.5",
     "typescript": "5.2.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }


### PR DESCRIPTION
Adds the badge in the npm registry, so consumers know where the package was built and by whom. See the resources below for more details.

Example package: https://www.npmjs.com/package/sigstore (the green checkmark next to the version, linking to the bottom of the page with more details/links).

Resources:

- https://github.blog/2023-04-19-introducing-npm-package-provenance/
- https://github.blog/changelog/2023-09-26-npm-provenance-general-availability/
- https://docs.npmjs.com/generating-provenance-statements
