### PR TITLE
Fixed PactNumber to prevent the creation of scientific notation for large numbers

### DIFF
--- a/.changeset/little-flowers-return.md
+++ b/.changeset/little-flowers-return.md
@@ -1,0 +1,6 @@
+---
+'@kadena/pactjs': patch
+---
+
+Fixed PactNumber to prevent the creation of scientific notation for large
+numbers.

--- a/packages/libs/pactjs/package.json
+++ b/packages/libs/pactjs/package.json
@@ -42,7 +42,7 @@
     "test": "heft test"
   },
   "dependencies": {
-    "bignumber.js": "^9.0.2"
+    "bignumber.js": "^9.1.2"
   },
   "devDependencies": {
     "@kadena-dev/eslint-config": "workspace:*",

--- a/packages/libs/pactjs/src/PactNumber.ts
+++ b/packages/libs/pactjs/src/PactNumber.ts
@@ -1,6 +1,11 @@
 /// <reference path="./extend-bignumber.ts" />
 import BigNumber from 'bignumber.js';
 
+// Configure BigNumber to prevent exponential notation (Scientific notation) for numbers.
+// The library supports a maximum of 1e9 digits, which I believe is sufficient for our use case.
+// It is highly unlikely that someone would pass a number with more than 1,000,000,000 digits.
+BigNumber.config({ EXPONENTIAL_AT: [-1e9, 1e9] });
+
 // In order to extend BigNumber methods correctly, I had to add the PactNumber methods to
 // the prototype of BigNumber. Then, something like this works:
 // const decimal = new PactNumber('0.9').plus("1").toPactDecimal()

--- a/packages/libs/pactjs/src/tests/PactNumber.test.ts
+++ b/packages/libs/pactjs/src/tests/PactNumber.test.ts
@@ -114,4 +114,27 @@ describe('Pact Number', () => {
     const pactDecimal = actual.minus('0.9').toPactDecimal();
     expect(pactDecimal).toStrictEqual({ decimal: '0.0007199254740991192919' });
   });
+
+  it('does not return scientific notation for large integer', () => {
+    const number = new PactNumber(
+      '0x584712a2542d5c1ab3cd25dec0b14e53aef270e6948140656a8fbf3d2829c729',
+    );
+    const int = number.toPactInteger();
+
+    expect(int).toEqual({
+      int: '39929105424737202205146861475763790532040240744253228361760383139526688229161',
+    });
+  });
+
+  it('does not return scientific notation for large decimals', () => {
+    const number = new PactNumber(
+      '3.9929105424737202205146861475763790532040240744253228361760383139526688229161',
+    );
+    const decimal = number.toPactDecimal();
+
+    expect(decimal).toEqual({
+      decimal:
+        '3.9929105424737202205146861475763790532040240744253228361760383139526688229161',
+    });
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1165,8 +1165,8 @@ importers:
   packages/libs/pactjs:
     dependencies:
       bignumber.js:
-        specifier: ^9.0.2
-        version: 9.0.2
+        specifier: ^9.1.2
+        version: 9.1.2
     devDependencies:
       '@kadena-dev/eslint-config':
         specifier: workspace:*
@@ -14726,12 +14726,8 @@ packages:
   /big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
-  /bignumber.js@9.0.2:
-    resolution: {integrity: sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==}
-    dev: false
-
-  /bignumber.js@9.1.1:
-    resolution: {integrity: sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==}
+  /bignumber.js@9.1.2:
+    resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
     dev: false
 
   /binary-extensions@2.2.0:
@@ -15977,7 +15973,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.29)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.88.2(@swc/core@1.3.80)(esbuild@0.18.20)
+      webpack: 5.88.2(webpack-cli@4.9.2)
 
   /css-minimizer-webpack-plugin@3.4.1(webpack@5.88.2):
     resolution: {integrity: sha512-1u6D71zeIfgngN2XNRJefc/hY7Ybsxd74Jm4qngIXyUEk7fss3VUzuHxLAq/R8NAba4QU9OUSaMZlbpRc7bM4Q==}
@@ -19708,7 +19704,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.3.80)(esbuild@0.18.20)
+      webpack: 5.88.2(webpack-cli@4.9.2)
 
   /htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
@@ -22150,7 +22146,7 @@ packages:
   /json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
     dependencies:
-      bignumber.js: 9.1.1
+      bignumber.js: 9.1.2
     dev: false
 
   /json-buffer@3.0.1:


### PR DESCRIPTION
Fixed PactNumber to prevent the creation of scientific notation for large numbers.
This PR will address the issues https://github.com/kadena-community/kadena.js/issues/519
