### PR TITLE
fix(client): check continuation proof type before using string methods

### DIFF
--- a/.changeset/lemon-socks-sleep.md
+++ b/.changeset/lemon-socks-sleep.md
@@ -1,0 +1,6 @@
+---
+'@kadena/client': patch
+---
+
+Fix the issue with continuation to ensure that the proof is a string before
+utilizing string methods.

--- a/packages/libs/client/src/composePactCommand/utils/payload.ts
+++ b/packages/libs/client/src/composePactCommand/utils/payload.ts
@@ -47,7 +47,7 @@ export const execution: IExec = (...codes: string[]) => {
  */
 export const continuation: ICont = (options) => {
   const clone = { ...options, data: options.data ? options.data : {} };
-  if (clone.proof !== undefined) {
+  if (typeof clone.proof === 'string') {
     clone.proof = clone.proof.replace(/\"/gi, '');
   }
   return {


### PR DESCRIPTION
Fixed the issue with continuation to ensure that the proof is a string before utilizing string methods.
This will address the issue https://github.com/kadena-community/kadena.js/issues/935

