### PR TITLE
Chore: Enable Turbosnap for react-ui and docs to reduce the amount of…

### DIFF
--- a/.github/workflows/chromatic-docs.yml
+++ b/.github/workflows/chromatic-docs.yml
@@ -40,3 +40,4 @@ jobs:
           projectToken: ${{ secrets.DOCS_CHROMATIC_TOKEN }}
           workingDir: /packages/apps/docs
           autoAcceptChanges: 'main'
+          onlyChanged: true # 👈 Required option to enable TurboSnap

--- a/.github/workflows/chromatic-react-ui.yml
+++ b/.github/workflows/chromatic-react-ui.yml
@@ -40,3 +40,4 @@ jobs:
           projectToken: ${{ secrets.REACT_UI_CHROMATIC_TOKEN }}
           workingDir: /packages/libs/react-ui
           autoAcceptChanges: 'main'
+          onlyChanged: true # 👈 Required option to enable TurboSnap


### PR DESCRIPTION
This PR enables [TurboSnap](https://www.chromatic.com/docs/github-actions/#enable-turbosnap) for Chromatic. This will use Webpacks dependency graph to determine if a story has been changed and only snapshot tests the changed ones. 
