### PR TITLE
feat(ui): implement non-outlined and inline style notification component

### DIFF
--- a/.changeset/nine-fireants-wonder.md
+++ b/.changeset/nine-fireants-wonder.md
@@ -1,0 +1,5 @@
+---
+'@kadena/react-ui': minor
+---
+
+Added variant and inline props to Notification component

--- a/packages/apps/docs/src/components/BottomPageSection/components/Subscribe.tsx
+++ b/packages/apps/docs/src/components/BottomPageSection/components/Subscribe.tsx
@@ -51,7 +51,7 @@ export const Subscribe: FC = () => {
             </form>
 
             {Boolean(message) && (
-              <Notification.Root color="warning" expanded>
+              <Notification.Root color="warning" expanded variant="outlined">
                 {message}
               </Notification.Root>
             )}

--- a/packages/apps/docs/src/components/BottomPageSection/components/Subscribe.tsx
+++ b/packages/apps/docs/src/components/BottomPageSection/components/Subscribe.tsx
@@ -58,7 +58,7 @@ export const Subscribe: FC = () => {
           </>
         ) : (
           Boolean(message) && (
-            <Notification.Root color="positive" expanded>
+            <Notification.Root color="positive" expanded variant="outlined">
               {message}
             </Notification.Root>
           )

--- a/packages/apps/docs/src/components/Markdown/MDNotification/MDNotification.tsx
+++ b/packages/apps/docs/src/components/Markdown/MDNotification/MDNotification.tsx
@@ -22,6 +22,7 @@ export const MDNotification: FC<IProps> = ({ children, title = '', label }) => {
         title={title}
         expanded
         icon={getIcon(label)}
+        variant="outlined"
       >
         {children}
       </Notification.Root>

--- a/packages/apps/docs/src/components/Search/components/SearchResults.tsx
+++ b/packages/apps/docs/src/components/Search/components/SearchResults.tsx
@@ -104,6 +104,7 @@ export const SearchResults: FC<IProps> = ({
                 color={'negative'}
                 expanded={true}
                 icon="AlertBox"
+                variant="outlined"
               >
                 {semanticError}
               </Notification.Root>

--- a/packages/apps/graph-client/src/pages/event/[key].tsx
+++ b/packages/apps/graph-client/src/pages/event/[key].tsx
@@ -45,7 +45,7 @@ const Event: React.FC = () => {
           )}
 
           {error && (
-            <Notification.Root color="negative" icon="Close">
+            <Notification.Root color="negative" icon="Close" variant="outlined">
               Unknown error:
               <br />
               <br />

--- a/packages/apps/graph-client/src/pages/transaction/[key].tsx
+++ b/packages/apps/graph-client/src/pages/transaction/[key].tsx
@@ -43,7 +43,7 @@ const RequestKey: React.FC = () => {
             </div>
           )}
           {error && (
-            <Notification.Root color="negative" icon="Close">
+            <Notification.Root color="negative" icon="Close" variant="outlined">
               Unknown error:
               <br />
               <br />
@@ -58,20 +58,28 @@ const RequestKey: React.FC = () => {
               {/* center content inside the div */}
               <div style={{ display: 'flex', justifyContent: 'center' }}>
                 {transactionSubscription?.transaction?.badResult && (
-                  <Notification.Root color="negative" icon="Close">
+                  <Notification.Root
+                    color="negative"
+                    icon="Close"
+                    variant="outlined"
+                  >
                     Transaction failed with status:{' '}
                     {typeof transactionSubscription?.transaction?.badResult}
                   </Notification.Root>
                 )}
                 {transactionSubscription?.transaction?.goodResult && (
-                  <Notification.Root color="positive" icon="Check">
+                  <Notification.Root
+                    color="positive"
+                    icon="Check"
+                    variant="outlined"
+                  >
                     Transaction succeeded with status:{' '}
                     {transactionSubscription?.transaction?.goodResult}
                   </Notification.Root>
                 )}
                 {!transactionSubscription?.transaction?.goodResult &&
                   !transactionSubscription?.transaction?.badResult && (
-                    <Notification.Root color="warning">
+                    <Notification.Root color="warning" variant="outlined">
                       Unknown transaction status
                     </Notification.Root>
                   )}

--- a/packages/apps/tools/src/components/Global/FormStatusNotification/index.tsx
+++ b/packages/apps/tools/src/components/Global/FormStatusNotification/index.tsx
@@ -84,6 +84,7 @@ export const FormStatusNotification: FC<IFormStatusNotificationProps> = (
         expanded
         title={title ?? titles[status!]}
         onClose={onNotificationCloseClick}
+        variant="outlined"
       >
         {body ?? bodies[status!]}
         {children}

--- a/packages/apps/tools/src/pages/faucet/existing/index.tsx
+++ b/packages/apps/tools/src/pages/faucet/existing/index.tsx
@@ -146,6 +146,7 @@ const ExistingAccountFaucetPage: FC = () => {
             title={t(
               `The Faucet is not available on Mainnet. On other networks, the Faucet smart contract must be deployed to fund accounts. In the Module Explorer you can see if it's deployed: https://tools.kadena.io/transactions/module-explorer?module=user.coin-faucet&chain=1`,
             )}
+            variant="outlined"
           />
         ) : null}
       </div>

--- a/packages/apps/tools/src/pages/transactions/cross-chain-transfer-tracker/index.tsx
+++ b/packages/apps/tools/src/pages/transactions/cross-chain-transfer-tracker/index.tsx
@@ -218,6 +218,7 @@ const CrossChainTransferTracker: FC = () => {
             }}
             title="Warning"
             icon={'AlertBox'}
+            variant="outlined"
           >
             {txError}
             <Notification.Actions>

--- a/packages/libs/react-ui/src/components/Notification/Notification.css.ts
+++ b/packages/libs/react-ui/src/components/Notification/Notification.css.ts
@@ -1,4 +1,4 @@
-import { breakpoints, sprinkles } from '@theme/sprinkles.css';
+import { sprinkles } from '@theme/sprinkles.css';
 import type { ColorType } from '@theme/vars.css';
 import { vars } from '@theme/vars.css';
 import { style, styleVariants } from '@vanilla-extract/css';
@@ -52,16 +52,13 @@ export const inlineVariants = styleVariants({
   true: [
     sprinkles({
       display: 'flex',
-      flexDirection: 'column',
-    }),
-    {
-      '@media': {
-        [`screen and ${breakpoints.md}`]: {
-          alignItems: 'flex-start',
-          flexDirection: 'row',
-        },
+      alignItems: {
+        md: 'flex-start',
       },
-    },
+      flexDirection: {
+        md: 'row',
+      },
+    }),
   ],
   false: [sprinkles({ display: 'flex', flexDirection: 'column' })],
 });

--- a/packages/libs/react-ui/src/components/Notification/Notification.css.ts
+++ b/packages/libs/react-ui/src/components/Notification/Notification.css.ts
@@ -60,7 +60,7 @@ export const inlineVariants = styleVariants({
       },
     }),
   ],
-  false: [sprinkles({ display: 'flex', flexDirection: 'column' })],
+  false: [],
 });
 
 export const closeButtonClass = style([

--- a/packages/libs/react-ui/src/components/Notification/Notification.css.ts
+++ b/packages/libs/react-ui/src/components/Notification/Notification.css.ts
@@ -44,7 +44,7 @@ export const expandVariants = styleVariants({
 });
 
 export const displayVariants = styleVariants({
-  outlined: [sprinkles({ borderWidth: '$md' })],
+  outlined: [sprinkles({ borderWidth: '$sm' })],
   standard: { borderWidth: 0 },
 });
 

--- a/packages/libs/react-ui/src/components/Notification/Notification.css.ts
+++ b/packages/libs/react-ui/src/components/Notification/Notification.css.ts
@@ -1,4 +1,4 @@
-import { sprinkles } from '@theme/sprinkles.css';
+import { breakpoints, sprinkles } from '@theme/sprinkles.css';
 import type { ColorType } from '@theme/vars.css';
 import { vars } from '@theme/vars.css';
 import { style, styleVariants } from '@vanilla-extract/css';
@@ -22,7 +22,6 @@ export const containerClass = style([
     padding: '$md',
     gap: '$md',
     borderStyle: 'solid',
-    borderWidth: '$sm',
   }),
   {
     borderLeftWidth: vars.sizes.$1,
@@ -42,6 +41,29 @@ export const cardColorVariants = styleVariants(colorVariants, (color) => {
 export const expandVariants = styleVariants({
   true: [sprinkles({ width: '100%', maxWidth: '100%' })],
   false: [sprinkles({ width: 'max-content', maxWidth: 'maxContent' })],
+});
+
+export const displayVariants = styleVariants({
+  outlined: [sprinkles({ borderWidth: '$md' })],
+  standard: { borderWidth: 0 },
+});
+
+export const inlineVariants = styleVariants({
+  true: [
+    sprinkles({
+      display: 'flex',
+      flexDirection: 'column',
+    }),
+    {
+      '@media': {
+        [`screen and ${breakpoints.md}`]: {
+          alignItems: 'flex-start',
+          flexDirection: 'row',
+        },
+      },
+    },
+  ],
+  false: [sprinkles({ display: 'flex', flexDirection: 'column' })],
 });
 
 export const closeButtonClass = style([

--- a/packages/libs/react-ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/libs/react-ui/src/components/Notification/Notification.stories.tsx
@@ -21,6 +21,12 @@ const meta: Meta<
     },
   },
   argTypes: {
+    variant: {
+      options: ['standard', 'outlined'],
+      control: {
+        type: 'select',
+      },
+    },
     icon: {
       options: Object.keys(SystemIcon) as (keyof typeof SystemIcon)[],
       control: {
@@ -44,6 +50,11 @@ const meta: Meta<
       },
     },
     hasCloseButton: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    inline: {
       control: {
         type: 'boolean',
       },
@@ -73,8 +84,19 @@ export const Primary: Story = {
     expanded: false,
     color: undefined,
     text: 'Notification text to inform users about the event that occurred!',
+    variant: 'standard',
+    inline: false,
   },
-  render: ({ icon, title, hasCloseButton, expanded, color, text }) => {
+  render: ({
+    icon,
+    title,
+    hasCloseButton,
+    expanded,
+    color,
+    text,
+    variant,
+    inline,
+  }) => {
     return (
       <Notification.Root
         icon={icon}
@@ -85,6 +107,8 @@ export const Primary: Story = {
         onClose={() => {
           alert('Close button clicked');
         }}
+        variant={variant}
+        inline={inline}
       >
         {text}
         <Notification.Actions>

--- a/packages/libs/react-ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/libs/react-ui/src/components/Notification/Notification.stories.tsx
@@ -1,4 +1,4 @@
-import { colorVariants } from './Notification.css';
+import { colorVariants, displayVariants } from './Notification.css';
 
 import { SystemIcon } from '@components/Icon';
 import type { INotificationProps } from '@components/Notification';
@@ -22,7 +22,7 @@ const meta: Meta<
   },
   argTypes: {
     variant: {
-      options: ['standard', 'outlined'],
+      options: Object.keys(displayVariants) as (keyof typeof displayVariants)[],
       control: {
         type: 'select',
       },

--- a/packages/libs/react-ui/src/components/Notification/NotificationContainer.tsx
+++ b/packages/libs/react-ui/src/components/Notification/NotificationContainer.tsx
@@ -6,13 +6,17 @@ import {
   containerClass,
   contentClass,
   descriptionClass,
+  displayVariants,
   expandVariants,
+  inlineVariants,
 } from './Notification.css';
 
 import { SystemIcon } from '@components/Icon';
 import classNames from 'classnames';
 import type { FC } from 'react';
 import React from 'react';
+
+type DisplayVariants = 'standard' | 'outlined';
 
 export interface INotificationProps {
   icon?: keyof typeof SystemIcon;
@@ -22,6 +26,8 @@ export interface INotificationProps {
   color?: keyof typeof colorVariants;
   hasCloseButton?: boolean;
   onClose?: () => void;
+  variant?: DisplayVariants;
+  inline?: boolean;
 }
 
 export const NotificationContainer: FC<INotificationProps> = ({
@@ -32,22 +38,36 @@ export const NotificationContainer: FC<INotificationProps> = ({
   color = 'info',
   expanded = false,
   onClose,
+  variant = 'standard',
+  inline = false,
 }) => {
   const Icon = icon ? SystemIcon[icon] : SystemIcon.HelpCircle;
 
   const classList = classNames(
     containerClass,
     cardColorVariants[color],
+    displayVariants[variant],
     expandVariants[expanded ? 'true' : 'false'],
+    inlineVariants[inline ? 'true' : 'false'],
+  );
+
+  const contentClassList = classNames(
+    contentClass,
+    inlineVariants[inline ? 'true' : 'false'],
+  );
+
+  const descriptionClassList = classNames(
+    descriptionClass,
+    inlineVariants[inline ? 'true' : 'false'],
   );
 
   return (
     <div className={classList}>
       <Icon size="md" />
 
-      <div className={contentClass}>
+      <div className={contentClassList}>
         {title && <h4>{title}</h4>}
-        <div className={descriptionClass}>{children}</div>
+        <div className={descriptionClassList}>{children}</div>
       </div>
 
       {hasCloseButton && (

--- a/packages/libs/react-ui/src/components/Notification/NotificationContainer.tsx
+++ b/packages/libs/react-ui/src/components/Notification/NotificationContainer.tsx
@@ -16,8 +16,6 @@ import classNames from 'classnames';
 import type { FC } from 'react';
 import React from 'react';
 
-type DisplayVariants = 'standard' | 'outlined';
-
 export interface INotificationProps {
   icon?: keyof typeof SystemIcon;
   title?: string;
@@ -26,7 +24,7 @@ export interface INotificationProps {
   color?: keyof typeof colorVariants;
   hasCloseButton?: boolean;
   onClose?: () => void;
-  variant?: DisplayVariants;
+  variant?: keyof typeof displayVariants;
   inline?: boolean;
 }
 

--- a/packages/libs/react-ui/src/components/Notification/NotificationContainer.tsx
+++ b/packages/libs/react-ui/src/components/Notification/NotificationContainer.tsx
@@ -43,22 +43,21 @@ export const NotificationContainer: FC<INotificationProps> = ({
 }) => {
   const Icon = icon ? SystemIcon[icon] : SystemIcon.HelpCircle;
 
+  const inlineVariantsClass = inlineVariants[inline ? 'true' : 'false'];
+
   const classList = classNames(
     containerClass,
     cardColorVariants[color],
     displayVariants[variant],
     expandVariants[expanded ? 'true' : 'false'],
-    inlineVariants[inline ? 'true' : 'false'],
+    inlineVariantsClass,
   );
 
-  const contentClassList = classNames(
-    contentClass,
-    inlineVariants[inline ? 'true' : 'false'],
-  );
+  const contentClassList = classNames(contentClass, inlineVariantsClass);
 
   const descriptionClassList = classNames(
     descriptionClass,
-    inlineVariants[inline ? 'true' : 'false'],
+    inlineVariantsClass,
   );
 
   return (


### PR DESCRIPTION
- Introduced the variant as `standard` and `outlined`. But I'm open for discussion here whether we wanna go with outline as a boolean prop. 
- Added inline boolean prop to make the inline notification component for medium and larger screens. 

If we're agreeing to the implementation then I'll update all app/libs which are already consuming notification component

~TODO:~
- [x] Update apps/libs already consume notification component. 