### PR TITLE
fix(react-ui): add content wrapper and set max width for notification component

### DIFF
--- a/.changeset/three-shrimps-give.md
+++ b/.changeset/three-shrimps-give.md
@@ -1,0 +1,5 @@
+---
+'@kadena/react-ui': minor
+---
+
+Add max-width to notification content

--- a/packages/libs/react-ui/src/components/Notification/Notification.css.ts
+++ b/packages/libs/react-ui/src/components/Notification/Notification.css.ts
@@ -22,9 +22,21 @@ export const containerClass = style([
     padding: '$md',
     gap: '$md',
     borderStyle: 'solid',
+    justifyContent: 'center',
   }),
   {
     borderLeftWidth: vars.sizes.$1,
+  },
+]);
+
+export const containerWrapperClass = style([
+  sprinkles({
+    display: 'flex',
+    width: '100%',
+    alignItems: 'flex-start',
+  }),
+  {
+    maxWidth: 1440,
   },
 ]);
 

--- a/packages/libs/react-ui/src/components/Notification/Notification.css.ts
+++ b/packages/libs/react-ui/src/components/Notification/Notification.css.ts
@@ -20,7 +20,6 @@ export const containerClass = style([
     alignItems: 'flex-start',
     borderRadius: '$sm',
     padding: '$md',
-    gap: '$md',
     borderStyle: 'solid',
     justifyContent: 'center',
   }),
@@ -34,6 +33,7 @@ export const containerWrapperClass = style([
     display: 'flex',
     width: '100%',
     alignItems: 'flex-start',
+    gap: '$md',
   }),
   {
     maxWidth: 1440,

--- a/packages/libs/react-ui/src/components/Notification/NotificationContainer.tsx
+++ b/packages/libs/react-ui/src/components/Notification/NotificationContainer.tsx
@@ -4,6 +4,7 @@ import {
   closeButtonClass,
   colorVariants,
   containerClass,
+  containerWrapperClass,
   contentClass,
   descriptionClass,
   displayVariants,
@@ -60,22 +61,24 @@ export const NotificationContainer: FC<INotificationProps> = ({
 
   return (
     <div className={classList}>
-      <Icon size="md" />
+      <div className={containerWrapperClass}>
+        <Icon size="md" />
 
-      <div className={contentClassList}>
-        {title && <h4>{title}</h4>}
-        <div className={descriptionClassList}>{children}</div>
+        <div className={contentClassList}>
+          {title && <h4>{title}</h4>}
+          <div className={descriptionClassList}>{children}</div>
+        </div>
+
+        {hasCloseButton && (
+          <button
+            className={closeButtonClass}
+            onClick={onClose}
+            aria-label="Close Notification"
+          >
+            <SystemIcon.Close size="md" />
+          </button>
+        )}
       </div>
-
-      {hasCloseButton && (
-        <button
-          className={closeButtonClass}
-          onClick={onClose}
-          aria-label="Close Notification"
-        >
-          <SystemIcon.Close size="md" />
-        </button>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
https://www.figma.com/file/TS5LF7mCIh3fcl27Jgmqx9/%3Ckda-notification-%2F%3E?type=design&node-id=945-1052&mode=design&t=4WR0njYHNmzPIGTu-0 

For larger screens we don't want the content also to be fluid, instead of want to set the maxWidth for the content wrapper