### PR TITLE
[@kadena/graph] Change default timeout interval to 100ms

### DIFF
--- a/.changeset/thirty-pandas-talk.md
+++ b/.changeset/thirty-pandas-talk.md
@@ -1,0 +1,5 @@
+---
+'@kadena/graph': patch
+---
+
+Change default timeout for simulation

--- a/packages/apps/graph/README.md
+++ b/packages/apps/graph/README.md
@@ -142,7 +142,7 @@ npm run simulate -- -a <numberOfAccounts> -i <timeInterval> -t <maxAmount> -tp <
 ```
 
 - accounts - number of accounts to be created in the devnet (default: 5)
-- timeInterval - frequency of transactions in miliseconds (default: 3000)
+- timeInterval - frequency of transactions in miliseconds (default: 100)
 - maxAmount - maximum amount for a single transaction (default: 25)
 - tokenPool - amount of circulating tokens (default: 1000000)
 - seed - seed for random number generation (default: current timestamp)

--- a/packages/apps/graph/src/scripts/devnet/index.ts
+++ b/packages/apps/graph/src/scripts/devnet/index.ts
@@ -44,7 +44,7 @@ program
     new Option(
       '-i, --transferInterval <number>',
       'Transfer interval in milliseconds',
-    ).default(3000),
+    ).default(100),
   )
   .addOption(
     new Option('-t, --maxAmount <number>', 'Maximum transfer amount').default(


### PR DESCRIPTION
Due to awaiting the result of previous transactions, there's already an in-built timeout. For that reason, we are reducing the default timeout to 100ms

<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205746428272055