### PR TITLE
feat(pactjs-cli): add option to store parse tree on disc

### DIFF
--- a/.changeset/kind-students-promise.md
+++ b/.changeset/kind-students-promise.md
@@ -1,0 +1,5 @@
+---
+'@kadena/pactjs-cli': minor
+---
+
+add option to store modules parse tree to dist

--- a/packages/tools/pactjs-cli/src/contract-generate/generate.ts
+++ b/packages/tools/pactjs-cli/src/contract-generate/generate.ts
@@ -94,11 +94,8 @@ async function generator(
     namespace: args.namespace,
   });
 
-  if (process.env.DEBUG === 'dev') {
-    writeFileSync(
-      join(process.cwd(), 'modules.json'),
-      JSON.stringify(modules, undefined, 2),
-    );
+  if (typeof args.parseTreePath === 'string' && args.parseTreePath !== '') {
+    writeFileSync(args.parseTreePath, JSON.stringify(modules, undefined, 2));
   }
 
   const moduleDtss = new Map();
@@ -179,7 +176,7 @@ export const generate: IGenerate = (program, version) => async (args) => {
   // add doNotEdit comment to index.d.ts
   indexDts = `${doNotEdit}\n${indexDts}`;
 
-  moduleDtss.forEach((_, moduleName) => {
+  moduleDtss.forEach((content, moduleName) => {
     const importStatement: string = `import './${moduleName}';`;
     // We have used "export * ..." previously, which wasn't necessary and caused some bugs.
     const exportStatement: string = `export * from './${moduleName}';`;

--- a/packages/tools/pactjs-cli/src/contract-generate/index.ts
+++ b/packages/tools/pactjs-cli/src/contract-generate/index.ts
@@ -14,6 +14,7 @@ export interface IContractGenerateOptions {
   namespace?: string;
   api?: string;
   chain?: number;
+  parseTreePath?: string;
   network?: keyof typeof networkMap;
 }
 
@@ -35,6 +36,7 @@ const Options = z
     chain: z.number().optional(),
     namespace: z.string().optional(),
     network: z.enum(['mainnet', 'testnet']),
+    parseTreePath: z.string().optional(),
   })
   .refine(({ file, contract }) => {
     if (file === undefined && contract === undefined) {
@@ -94,6 +96,10 @@ export function contractGenerateCommand(
       '--network <network>',
       'The networkId to retrieve the contract from, e.g. "testnet". Defaults to mainnet',
       'mainnet',
+    )
+    .option(
+      '--parse-tree-path <string>',
+      'path to store parsed three; if empty the three will not be stored',
     )
     .action((args: IContractGenerateOptions) => {
       try {


### PR DESCRIPTION
Add the **--parse-tree-path** option to **pactjs contract-generate** in order to store the parse tree on disk

```bash
pactjs contract-generate --parse-tree-path ./tree.json  --contract coin --api https://api.chainweb.com/chainweb/0.0/mainnet01/chain/0/pact;
``` 