### PR TITLE
chore(docs): revision election dApp tutorial

### DIFF
--- a/.changeset/cyan-countries-joke.md
+++ b/.changeset/cyan-countries-joke.md
@@ -1,0 +1,5 @@
+---
+'@kadena/docs': patch
+---
+
+revision election dApp tutorial

--- a/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/01-getting-started.md
+++ b/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/01-getting-started.md
@@ -52,8 +52,8 @@ workspace. Kadena has developed a "PACT" extension for this editor. It features
 syntax highlighting, error reporting and code coverage reporting to improve your
 smart contract development workflow. The extension does require you to have `pact`
 and `pact-lsp` installed on your computer. You can configure the path to each
-executable in the plugin settings. If you are using another editor, you may also
-profit from just `pact-lsp` which provides the syntax highlighting. The links
+executable in the extension's settings. If you are using another editor, you may also
+profit from just `pact-lsp` which provides syntax highlighting for Pact code. The links
 to the installation instructions are listed on the
 [main page](/build/guides/election-dapp-tutorial) of this tutorial.
 
@@ -67,7 +67,7 @@ Let's explore these folders one by one.
 
 This is where the `.pact` files for your smart contracts go, as well as `.repl`
 files that will be used to test your smart contracts in isolation. You will
-notice a `./root` folder that already contains some `.pact` files. They contain
+notice a `./root` folder that already contains some `.pact` files. These files contain
 Pact modules that the smart contracts you will create in later chapters depend
 on. They only need to be there for local testing with `.repl` files. You do not
 need to deploy them to the blockchain alongside your own `.pact` files, because
@@ -81,11 +81,11 @@ For the front-end of the election website, a basic React app was created. You
 could use any other framework to create the front-end, because the connection
 with the blockchain is established through the
 [Kadena Client](https://www.npmjs.com/package/@kadena/client) npm package
-that can be imported in any JavaScript project. At the end of the line, this
+that can be imported in any JavaScript project. In the end, this
 package simply makes HTTP API requests to the blockchain.
-Inside of the React components, data is manipulated by calling service methods
-the services get a specific implementation of repositories injected, depending
-on the projects configuration. Initially, the project is configured to use
+Inside of the React components, data is manipulated by calling service methods.
+The services get a specific implementation of repositories injected, depending
+on the project's configuration. Initially, the project is configured to use
 the in-memory implementation of repositories. The in-memory repositories
 simply perform all data operations on JavaScript arrays and objects defined
 in the same file. This implementation was created for you to have a simple
@@ -99,9 +99,9 @@ repository implementation will be provided later in this chapter.
 
 In this folder you will find several JavaScript snippets that use the Kadena
 Client library to perform actions against the blockchain that are not directly
-related to the functionality of the election dApp per se, like deploy and
+related to the functionality of the election dApp per se, like deploying and
 upgrading smart contracts, creating and funding accounts, and more. You will
-learn more about these snippets in the following chapters.
+learn more about these snippets in the upcoming chapters.
 
 ## Run the front-end
 
@@ -115,7 +115,7 @@ npm install
 npm run start
 ```
 
-Open a browser window and visit `http://localhost:3000`. You will see the working
+Open a browser window and visit `http://localhost:5173`. You will see the working
 front-end of the election website. Because all data is manipulated in memory,
 you can freely click around and submit data. The state of the front-end will be
 reset as soon as you refresh the page. The website shows a list of candidates
@@ -132,5 +132,5 @@ At this point you should have a working development environment and an understan
 of the project structure. You have installed and run the front-end of the election
 website, and you have an understanding of its features. In the next chapter of this
 tutorial you will run a blockchain on your own computer using Docker. After that,
-you will be ready to start developing smart contracts and creating the Devnet
+you will be ready to start developing smart contracts and work on the Devnet
 implementations of the front-end repositories.

--- a/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/02-running-devnet.md
+++ b/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/02-running-devnet.md
@@ -87,7 +87,7 @@ Chainweaver will be executed against Devnet.
 
 In Chainweaver, expand the left navigation bar and click contracts. Select
 `Module Explorer` at the top of the right panel to reveal a list of contracts
-that are already deployed on your Devnet. Next to the search box on top of
+that are already deployed on your Devnet. Next to the search box above
 that list, change `All chains` to any particular chain to narrow down the
 list to the unique contracts that are deployed to Devnet by default:
 
@@ -119,7 +119,7 @@ documentation of the following functions:
 
  * transfer
  * transfer-create
- * get-balance
+ * details
  * create-account
 
 These are some of the first smart contract functions that you will interact
@@ -214,7 +214,7 @@ your local Devnet:
 ```
 
 Notice that the list is exactly the same as the list displayed in the module
-explorer of Chainweaver. Both these tools can be used interchangably to interact
+explorer of Chainweaver. Both these tools can be used interchangeably to interact
 with the Kadena blockchain. They both support the execution of simple read
 operations as well as the execution of complex multi-step transactions, as will
 become clear when you will be using both approaches to test the smart contracts
@@ -229,7 +229,7 @@ are deployed on the Kadena networks by default and how you can explore them usin
 either Chainweaver or the Kadena JavaScript client. In the next chapter, you will
 create an account on Devnet. This account will govern several aspects of the smart
 contracts you will create in this tutorial: the namespace, keyset definition and
-module. The account will also get exclusive permission to call certain functions in the
+modules. The account will also get exclusive permission to call certain functions in the
 election smart contract, such as adding candidates. After setting up this account,
 namespace and keyset definitions, all will be in place to deploy the smart contract
 that will become the new back-end of the election website.

--- a/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/03-admin-account.md
+++ b/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/03-admin-account.md
@@ -52,7 +52,7 @@ via the top section of the
 navigation bar on the left side of the window. When you click `+ Generate Key` on the
 top right, a new public key will be added to the list of public keys. Click `Add k: Account`
 on the right of this new public key and your k:account will be added to the accounts
-that you are watching via Chainweaver. Expand the row of the account you justed added
+that you are watching via Chainweaver. Expand the row of the account you just added
 by clicking the arrow on the left side of the account name. You will see that no KDA balance
 exists for this account on any of the chains and the information about the owner and keyset
 of the account is missing. This indicates that your account does not yet exist on Devnet.
@@ -95,16 +95,16 @@ npm run generate-types:coin:devnet
 
 Now you are ready to run the npm script that executes the snippet `./transferCreate.ts`. Open up this
 file in your editor to learn how the Kadena JavaScript client is used to call the `transfer-create`
-function of the `coin` module to create and fund your admin account. After importing the depencies
+function of the `coin` module to create and fund your admin account. After importing the dependencies
 and creating the client with the right (Devnet) configuration, the
 main function is called with information about the sender, the receiver and the amount. The amount
-of KDA to transfer to the receiver is hardcoded to 20. The receiver will be you admin account name,
+of KDA to transfer to the receiver is hardcoded to 20. The receiver will be your admin account name,
 which you will specify as an argument when running the script. The sender, `sender00`, is one
 of the pre-installed Devnet test accounts that holds some KDA on all chains. The public and private
 key for this account were copied over from GitHub. Inside the main function, the amount to transfer
-is converted to a PactDecimal, which boils down to this format: `{ decimal: '20.0' }`. Then, the
+is converted to a `PactDecimal`, which boils down to this format: `{ decimal: '20.0' }`. Then, the
 transaction is created. Creating this transaction is slightly more complex than the `list-modules`
-you learned about in the previous chapter.
+transaction you learned about in the previous chapter.
 
 Instead of passing raw Pact code as a string to `Pact.builder.execution()`, the `coin['transferCreate']`
 function is called on `Pact.modules` to generate the correct Pact code for you, based on the
@@ -126,7 +126,8 @@ admin account. Replace `k:account` with your admin account.
 npm run transfer-create:devnet -- k:account
 ```
 
-After a few seconds, `Write succeeded` should be printed in the terminal window. Verify that your account was created by checking the account details using the Kadena JavaScript client.
+After a few seconds, `Write succeeded` should be printed in the terminal window. Verify that
+your account was created by checking the account details using the Kadena JavaScript client.
 Replace `k:account` with your admin account.
 
 ```bash
@@ -134,14 +135,17 @@ npm run coin-details:devnet -- k:account
 ```
 
 This time, the script should print out the account name, the KDA balance and the receiver guard
-of the account. Chainweaver will tell the same story. Navigate to `Accounts` in the top section of the left menu bar. Expand your admin account to view the information on all chains. You will
+of the account. Chainweaver will tell the same story. Navigate to `Accounts` in the top section
+of the left menu bar. Expand your admin account to view the information on all chains. You will
 see that on chain 1 you are the owner, one keyset is defined and the balance is 20 KDA.
 
 ## Next steps
 
 In this chapter you learned how to create a key for a Kadena account using Chainweaver and to
 create and fund this account using the Kadena JavaScript client. You verified the creation
-of the account in `Accounts` view of Chainweaver and by calling the `details` function of the `coin` module on Devnet using the Kadena JavaScript client. The admin user will use its KDA
-to pay gas fees charged for deploying keysets, deploying smart contracts and sending transactions to nominate candidates for the election. In the following chapter you will learn
+of the account in `Accounts` view of Chainweaver and by calling the `details` function of the
+`coin` module on Devnet using the Kadena JavaScript client. The admin user will use its KDA
+to pay gas fees charged for deploying keysets, deploying smart contract modules and sending
+transactions to nominate candidates for the election. In the following chapter you will learn
 how to create a namespace in which you will later define an admin keyset and deploy your
 smart contracts.

--- a/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/04-namespaces.md
+++ b/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/04-namespaces.md
@@ -10,12 +10,13 @@ tags: [pact, smart contract, typescript, tutorial]
 
 # Chapter 04: Namespaces
 
-Toward the end of this tutorial you will deploy your election smart contract
-to Testnet. Everyone else who is following along with this tutorial will do the same.
-If everyone would deploy Pact modules with the same name, however, it would become impossible
-to distinguish your Pact module from all the others. Therefore, it is not allowed to
+After you have completed this entire tutorial, you may want to deploy your election
+smart contract to Testnet. Many others like you would perhaps like to do the same.
+If everyone would deploy Pact modules with the same name to the same network, however,
+it would become impossible to distinguish your Pact module from all the others. Therefore,
+it is not allowed to
 deploy a Pact module with a name that already exists on the chain you are deploying to
-and your deployment transaction will fail with an error if you would try. Fortunately,
+and your deployment transaction will fail with an error if you try. Fortunately,
 Kadena offers a solution to this problem by introducing namespaces. You can create
 your own unique namespace on the blockchain and you get to decide who can update the
 namespace or use it to define keysets and modules inside it. As long as you choose a
@@ -195,7 +196,7 @@ bottom of the `namespace.yml` file and run it.
 ### Redefine the namespace as the new admin
 
 To further prove that the namespace was successfully updated in the previous steps, it should
-be tested that the `user-keyset` will now be able to redefine the contract. You will need
+be tested that the `user-keyset` will now be able to redefine the namespace. You will need
 to load the signature of the `user-keyset` into the context of the Pact REPL and write a
 transaction to redefine the namespace. The transaction will be the same as the previous one,
 but this time it is wrapped inside an `expect` function instead of `expect-failure`.
@@ -221,21 +222,23 @@ Add the following transaction at the bottom of the `namespace.yml` file and run 
 If all is well, `Load successful` will be displayed at the bottom of the output. In conclusion,
 you defined a namespace `election` and specified a keyset that is allowed to govern the
 namespace and a keyset that is allowed to use the namespace. You wrote an automated test
-script to verify that indeed only the governance keyset can redefine the namespace. The
-namespace was redefined in a way that handed over governance permissions to another keyset.
-Great work.
+script to verify that indeed only the governance keyset can redefine the namespace. Finally, the
+namespace was redefined in such a way that governance permissions were handed over to another
+keyset. Great work!
 
 ## Exercise: Define a principal namespace
 
 Choosing an arbitrary namespace name like `election-your-name` still provides no guarantee
 that, by coincidence, this namespace is not already defined by someone else. To ensure
 that your namespace will be unique, you can create a principal namespace. The
-`create-principal-namespace` from the `ns` module creates a principle namespace name
+`create-principal-namespace` from the `ns` module creates a principal namespace name
 that is a hash of a keyset, prefixed with `n_`. In this example, you will use an `admin-keyset`
 that contains the public key of the `sender00` account, because `ns.create-principal-namespace`
 only accepts valid public keys inside the keyset. The `ns` module is readily available
 on Mainnet, Testnet and Devnet, but to use it in the Pact REPL it needs to be loaded
-from the local filesystem. The output of `ns.create-principal-namespace` called with the
+from the local filesystem. To that end, the `ns` module should be loaded from the local
+`./pact/root` folder of the project for testing purposes.The output of
+`ns.create-principal-namespace` called with the
 `admin-keyset` can be stored in a variable (`ns-name`) and passed to the `define-namespace`
 as the first argument. In the `./pact` folder create `principal-namespace.repl` file and paste the following
 code into it.
@@ -282,7 +285,7 @@ and holds KDA on chain 1. Otherwise, repeat the steps in the previous chapter to
 and fund your admin account. Chainweaver needs to remain open, because you will use
 it to sign the transaction for defining the namespace. Switch to your editor and open
 the file `./snippets/principal-namespace.ts`. The `pactCommand` variable contains the
-crucial bit of Pact code for defining a principle namespace, which you just tested in
+crucial bit of Pact code for defining a principal namespace, which you just tested in
 the Pact REPL. Also, recognize how the keyset data is added in a similar fashion as in
 the `.repl` file, with slightly different syntax. For the transaction on Devnet, a signer
 is also added, which was not required in the Pact REPL. After the transaction is defined,
@@ -311,7 +314,7 @@ If everything went well, you will see something similar to the following output.
 }
 ```
 
-Congratulations! You have defined a principle namespace on your local Devnet that
+Congratulations! You have defined a principal namespace on your local Devnet that
 can be governed and used by your admin account.
 
 ## Next steps

--- a/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/05-keysets.md
+++ b/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/05-keysets.md
@@ -83,8 +83,8 @@ Make sure that your local Devnet is running.
 If all is well, you should see the following output.
 
 ```bash
-pact/namespace.repl:2:0:Trace: Begin Tx 0: Define a namespace called 'election
-pact/namespace.repl:5:0:Trace: Commit Tx 0: Define a namespace called 'election
+pact/keyset.repl:2:0:Trace: Begin Tx 0: Define a new keyset
+pact/keyset.repl:5:0:Trace: Commit Tx 0: Define a new keyset
 Load successful
 ```
 
@@ -108,7 +108,7 @@ function call. Add the following code between the `begin-tx` and `commit-tx` lin
 ```
 
 The test will fail with the message `No such key in message: admin-keyset`. You will need
-to load the `admin-keyset` into the context of the Pact REPL so they
+to load the `admin-keyset` into the context of the Pact REPL so it
 can be read using the `read-keyset` function. Add the following lines at the top of the
 `keyset.repl` file and run it again.
 
@@ -165,8 +165,8 @@ run the file again.
 ```
 
 Finally, `Load successful` will be printed at the end of the output in your terminal,
-which means that your test has passed and you successfully defined a keyset called `election`
-in the `election` namespace using the Pact REPL.
+which means that your test has passed and you successfully defined a keyset called
+`admin-keyset` in the `election` namespace using the Pact REPL.
 
 ### Redefine the keyset with a different keyset
 
@@ -257,13 +257,14 @@ governed by an `admin-keyset` that contains the public key `other-public-key`.
 In the previous chapter you defined a principal namespace on your local Devnet. At the end
 of this chapter you will define an `admin-keyset` in that principal namespace. Before sending
 the transaction to Devnet, it is a good idea to first test if the transaction will work in the
-Pact REPL. Open the (*other*) `./pact/principal-namespace.repl` file in your editor and add the
-transaction displayed below. The main difference from the previous `Define a new keyset` transaction 
-is that the name of the keyset passed to the `define-keyset` function is not passed as the hardcoded
+Pact REPL. In the `./pact` folder, create a file `./pact/principal-namespace.repl` and add the
+transaction displayed below into it. The main difference from the previous `Define a new keyset` transaction 
+is that the name of the keyset passed to the `define-keyset` function is no longer passed as the hardcoded
 string `election.admin-keyset`. Instead, it is composed of the principal namespace name stored
 in the `ns-name` variable and the string `admin-keyset`. The `ns-name` variable, in turn, gets its
-value assigned from the return value of a call to the `ns.create-principal-namespace` function. Also note that, before calling `define-keyset` you need to enter the principal namespace first, using
-the the statement `(namespace ns-name)`. Finally, you need to add a signature for the transaction
+value assigned from the return value of a call to the `ns.create-principal-namespace` function.
+Also note that, before calling `define-keyset` you need to enter the principal namespace first, using
+the statement `(namespace ns-name)`. Finally, you need to add a signature for the transaction
 to succeed.
 
 ```pact
@@ -289,7 +290,7 @@ to succeed.
 ```
 
 At the end of the output you will see `Load successful`, which means that your test has
-passed and you successfully defined the `admin-keyset` in the principal namespace You are now
+passed and you successfully defined the `admin-keyset` in the principal namespace. You are now
 ready to define the admin keyset that holds your own admin account's public key in the principal
 namespace on your local Devnet.
 
@@ -301,7 +302,7 @@ and holds KDA on chain 1. Otherwise, repeat the steps in the previous chapters t
 and fund your admin account. Chainweaver needs to remain open, because you will use
 it to sign the transaction for defining the keyset. Switch to your editor and open
 the file `./snippets/define-keyset.ts`. The `pactCommand` variable contains the
-crucial bit of Pact code for defining the keyset in your principle namespace. The code
+crucial bit of Pact code for defining the keyset in your principal namespace. The code
 should look familiar if you followed along with the exercises in this chapter. At this point
 in thet tutorial, you should be able to explain how the the `Pact.builder` constructs the
 transaction, on what line the transaction is signed, on what line the transaction is sent to
@@ -325,7 +326,7 @@ If everything went well, you will see something similar to the following output.
 { status: 'success', data: 'Keyset defined' }
 ```
 
-Congratulations! You have defined a keyset in your principle namespace on your local Devnet.
+Congratulations! You have defined a keyset in your principal namespace on your local Devnet.
 This keyset is governed by your admin account.
 
 ## Next steps
@@ -335,7 +336,7 @@ allowing you to verify the behavior of Pact keysets on your local computer
 before defining a keyset on the blockchain. You used
 the Kadena JavaScript client to define a keyset in the principal namespace to your local Devnet.
 In the next chapter you will create the election Pact module that will become the back-end of the
-election website. The pact module will be defined in your principle namespace and it will be
+election website. The pact module will be defined in your principal namespace and it will be
 governed by the keyset you defined in this chapter. In later chapters, the keyset will also
 be used to guard high impact functions inside the election Pact module, such as nominating
 candidates that can receive votes.

--- a/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/06-smart-contract.md
+++ b/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/06-smart-contract.md
@@ -58,8 +58,8 @@ In this exercise you will test the deployment and upgrade of a Pact module in
 the Pact REPL. You will start with debugging the minimal requirements for
 deploying a Pact module until you have a working deployment. Then, you will
 refactor the Pact module to be governed with a capability instead of a keyset
-directly. In the `./pact` folder, create a `module.repl` file. Write the
-following in the file: a transaction to define a module named `election`.
+directly. In the `./pact` folder, create a `module.repl` file. Add a transaction
+that defines a module named `election` to this file, using the following code.
 
 ```pact
 (begin-tx
@@ -111,8 +111,8 @@ error: Unexpected end of input, Expected: list
 ```
 
 This error means that it is not possible to create an empty Pact module. Add a
-function `list-candidates` that will be used later to list the candidates in the
-respective database tables. For now, this function will just return an empty
+function `list-candidates` that will be used later to list the candidates stored
+in the respective database table. For now, this function will just return an empty
 list `[]`.
 
 ```pact
@@ -221,16 +221,14 @@ be publically accessible.
 
 ## Exercise: Upgrade the election Pact module
 
-The `election` module was defined with a keyset to govern the module. Every
-subsequent upgrade
-
-- i.e. change - of the module will only be allowed if the upgrade transaction is
-  signed with that keyset. In this exercise you will examine two scenarios for
-  upgrading a Pact module: with the correct keyset and with an incorrect keyset.
-  Add the following code after the last transaction in `module.repl`. This code
-  reloads the correct keyset and signature into the Pact REPL, redefines the
-  `election` module with the `list-candidates` function returns a different
-  list, and tests that `list-candidates` now returns the new list.
+The `election` module was defined with a keyset to govern it. Every
+subsequent upgrade - i.e. change - of the module will only be allowed if the upgrade
+transaction is signed with that keyset. In this exercise you will examine two scenarios for
+upgrading a Pact module: with the correct keyset and with an incorrect keyset.
+Add the following code after the last transaction in `module.repl`. This code
+reloads the correct keyset and signature into the Pact REPL, redefines the
+`election` module with the `list-candidates` function returns a different
+list, and tests that `list-candidates` now returns the new list.
 
 ```pact
 (env-data
@@ -312,6 +310,7 @@ If all is well, the last line of the output should be `Load failed`. A few lines
 up you will notice a `Keyset failure` error. This means that another keyset than
 the `election.admin-keyset` cannot update the `election` module. So, you have
 proven that you can govern a Pact module with a keyset. Remove the code to
+make sure that the `module.repl` file can load successfully again before you
 continue with the next exercise.
 
 ## Exercise: Governance with Capability
@@ -351,7 +350,7 @@ that the following requirements are met:
 
 - your admin account exists on chain 1 of Devnet
 - your admin account has a positive KDA balance
-- the `admin-keyset` is defined in your principle namespace on Devnet
+- the `admin-keyset` is defined in your principal namespace on Devnet
 
 If these requirements are not met, repeat the steps in the previous chapters.
 Create a file `election.pact` in the `./pact/` folder of your project and add
@@ -379,7 +378,7 @@ specified in the metadata of the transaction. This is necessary, because
 deploying a Pact module costs a lot of gas and the transaction will fail if you
 use the default gas limit. Finally, after signing the transaction, a preflight
 request for the signed transaction is sent to the blockchain using the Kadena
-client. This The response contains feedback about the expected success of the
+client. The response contains feedback about the expected success of the
 transaction and the amount of gas the transaction will cost. If the feedback is
 negative, the snippet will not send the actual transaction to the blockchain.
 This is economical, because you would have to pay for gas, even if a transaction
@@ -474,8 +473,8 @@ implemented governance of the module with a keyset and with a capability.
 Moreover, you verified that it is impossible for others to make changes to a
 Pact module governed by your keyset. In the next chapter, you will add a schema
 and a database table to the `election` module. The table will store the names of
-election candidates and the number of votes they received. The `list-candidates`
-function will remain public and will read data from the database table. You will
+election candidates and the number of votes they have received. The `list-candidates`
+function will remain public, but will return data from the database table. You will
 add another function to nominate candidates, guarded by the governance
 capability you defined in this chapter. The election website will come to life
 as you will connect the front-end to the `election` module on Devnet.

--- a/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/08-voting.md
+++ b/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/08-voting.md
@@ -51,7 +51,7 @@ function will execute the vote function of the election module using the Kadena 
 client. Some of the lines
 of the `vote` function have been commented out. You will gradually add these lines back in
 as you add more logic to the election Pact module. The uncommented lines in this function
-are highly similar to the `addCandidates` function in the `DevnetCandidateRepository`,
+are highly similar to the `addCandidate` function in the `DevnetCandidateRepository`,
 except for a different function being called. You will now implement the `vote` function
 in the `election` Pact module, using a test-driven approach in the Pact REPL.
 
@@ -82,8 +82,8 @@ Run `./pact/candidates.repl` to verify that your tests still pass. Also, make su
 The election website now displays a table of candidates all having 0 votes.
 Everytime someone clicks the `Vote` button in a row of the table, the number of votes displayed
 in that row should be increased by 1. The table is rendered based on the result of a call to
-the the `list-modules` function of the `election` Pact module. So, in the Pact REPL you can
-test the behavior of the new `vote` function against the return value of `list-modules`. Add
+the `list-candidates` function of the `election` Pact module. So, in the Pact REPL you can
+test the behavior of the new `vote` function against the return value of `list-candidates`. Add
 the following code to `./pact/voting.repl`, replace the namespace with your own principal
 namespace and run the file. The first two transactions load the `election` Pact module and add
 a candidate to the candidates table. Then, in the `Voting for a candidate` transaction, the
@@ -167,7 +167,7 @@ In `./pact/voting.repl`, add a line below `"Cannot vote for a non-existing candi
 specify the expected error message: `"Candidate does not exist"`.
 This first argument of `expect-failure` is the name of the test, while the second line you
 just added is the expected output of the third argument: the actual function call. Now, when
-your run the test again, it fails with the message `Failed: with-read: row not found: 2`. To
+you run the test again, it fails with the message `Failed: with-read: row not found: 2`. To
 prevent the read operation from failing with a standard message, you can leverage the built-in
 `with-default-read` function that does not throw an error if no row is found with the specified
 key, but returns a default object instead. The default will be an object containing the
@@ -203,7 +203,7 @@ will also add checks against the keyset used to sign the voting transaction.
 ### Define votes schema and table
 
 Add the following lines to `./pact/election.pact`, inside the `election` module definition,
-below the definition of the `votes` schema and table.
+below the definition of the `candidates` schema and table.
 
 ```pact
   (defschema votes-schema
@@ -270,14 +270,15 @@ The test will fail with the error
 Remember that all transactions in `./pact/voting.repl` so far are signed with the
 `admin-keyset`, as defined in `./pact/setup.repl`. This means that your admin account
 is able to cast more than one vote on `Candidate A`, which makes the election unfair. To fix
-this, insert a row into the `votes` table with the account name as key and the candidate key
-as value for the column `candidateKey`. In addition, add the account of the voter as the
+this, insert a new row into the `votes` table with the account name as key and the candidate key
+as value for the column `candidateKey`, every time the `vote` function is called. In addition,
+add the account of the voter as the
 first parameter of the `vote` function and enforce that there is no row in the `votes` table
 that is keyed with the account name, using the `with-default-read` pattern that you just used
 to prevent voting on a non-existing candidate. Create a separate function `account-voted`
 for the checking if
 an account has already voted, so the front-end of the election website can fetch this
-information to determine of the voting buttons should be enabled. Within the `vote` function,
+information to determine if the voting buttons should be enabled. Within the `vote` function,
 the result of `account-voted` is stored in a variable `double-vote` before the condition is
 enforced. Update the implementation of the `vote` function as follows.
 
@@ -319,7 +320,7 @@ add a `voter-keyset` to `env-data` in `./pact/setup.repl`.
 , 'voter-keyset: { "keys": ["voter"], "pred": "keys-all" },
 ```
 
-While you are editing this file, load the `coin` module and the interaces it implements at
+While you are editing this file, load the `coin` module and the interfaces it implements at
 the end of it. After that, create the `coin.coin-table` and `coin.allocation-table` required
 to create the voter account. Also, create the voter account and your admin account in the
 `coin` module's database. Remember to replace the admin account name with your own.
@@ -417,7 +418,7 @@ on its own behalf, leading to an increase of the number of votes on `Candidate A
 ```
 
 Run the file again and, if all is well, all tests pass, meaning that any account can cast
-only one vote on their own behalf. Congratulations, you are now ready to upgrade the `election`
+only one vote on its own behalf. Congratulations, you are now ready to upgrade the `election`
 module on Devnet.
 
 ## Upgrade election module on Devnet
@@ -462,18 +463,18 @@ sure that Chainweaver is open so you can sign the transaction. Click the `Vote` 
 behind your favorite candidate, sign the transaction and wait for the transaction to
 finish. Verify that the number of votes for the candidate
 you voted on increased by 1. After you voted, the `Vote` buttons are disabled, because
-the front-end checks if you account has already voted by making a `local` request to
+the front-end checks if your account has already voted by making a `local` request to
 the `account-voted` function of the `election` Pact module.
 
 ## Next steps
 
 Congratulations! You have completed the `election` Pact module, deployed it to your local
-Devnet and demonstrated that the front-end of election website can use it as its back-end.
+Devnet and demonstrated that the front-end of the election website can use it as its back-end.
 If you paid close attention during the signing of the transaction, though, you may have
 noticed that your admin account still has to pay for gas to cast a vote. To make the
 election accessible for everyone, however, it should be possible to cast a vote without
 having to pay anything. In the next chapter, you will add a gas station module to the
 `election` smart contract that can be funded by the election organisation so it can
-pay the gas fee for voting transaction of voters.
+pay the gas fee for voting transactions of voters.
 
 

--- a/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/09-gas-station.md
+++ b/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/09-gas-station.md
@@ -11,7 +11,7 @@ tags: [pact, smart contract, typescript, tutorial]
 # Chapter 09: Gas station
 
 In a traditional government election, all citizens usually receive a paper invitation
-to vote from their government in the tradidtional mail. They would take their invitation
+to vote from their government in the traditional mail. They would take their invitation
 to a nearby election office. There, they will receive an anonymous voting ballot from
 an election official upon showing their invitation and a matching ID. In a voting booth,
 they anonymously select the name of their favorite candidate and cast the voting ballot
@@ -21,8 +21,8 @@ of voting ballots from the stack of unused voting ballots and use them to cast e
 any given candidate. In many countries, the votes are counted and submitted manually, leaving
 even more room for human error. Even though the votes can be cast anonymously in traditional
 election, the process is inherently unreliable. It is also inconvenient for voters to physically
-vote at an election office. Moreover, a traditional election costs a lot of tax payer money
-to organisze.
+vote at an election office. Moreover, a traditional election costs a lot of taxpayer money
+to organize.
 
 An election on the blockchain would be more convenient, transparent and reliable. Namely,
 everyone who owns a smartphone or computer could vote from the comfort of their own home.
@@ -40,7 +40,7 @@ a transaction comes at the price of a gas fee. At the time of the election, some
 may have run out of money and would not be able to pay this gas fee and thus would not be
 able to vote. That is not very democratic. Kadena solves this with the concept of gas stations.
 Kadena created the first crypto gas station on a blockchain in 2020. A gas station is an
-account that exists only to make gas payments on behalf of other users under specific conditions.
+account that exists only to make gas payments on behalf of other accounts under specific conditions.
 The government could use a fraction of the traditional election budget to fund a gas station
 that can pay the gas fee for every voting transaction, allowing all citizens to vote for free.
 
@@ -87,21 +87,21 @@ via the top section of the
 navigation bar on the left side of the window. When you click `+ Generate Key` on the
 top right, a new public key will be added to the list of public keys. Click `Add k: Account`
 on the right of this new public key and your k:account will be added to the accounts
-that you are watching via Chainweaver. Expand the row of the account you justed added
+that you are watching via Chainweaver. Expand the row of the account you just added
 by clicking the arrow on the left side of the account name. You will see that no KDA balance
 exists for this account on any of the chains and the information about the owner and keyset
 of the account is missing. This indicates that your account does not yet exist on Devnet.
 
 The Kadena JavaScript client will tell you the same. Open up a terminal and change the directory
 to the `./snippets` folder in the root of your project. Execute the `./coin-details.ts`
-snippet by running the following command. Replace `k:account` with your admin account.
+snippet by running the following command. Replace `k:account` with your voter account.
 
 ```bash
 npm run coin-details:devnet -- k:account
 ```
 
 You will see an error logged to your terminal, stating `row not found`, confirming that your
-admin account indeed does not yet exist on Devnett.
+voter account indeed does not yet exist on Devnet.
 
 ### Create voter account on Devnet
 
@@ -158,7 +158,7 @@ proving that it is indeed not possible to vote with an account that has zero bal
 
 The `election-gas-station` will become the second module in your `election` smart contract.
 Create a file `./pact/election-gas-station.pact` with the following content. Replace the
-namespace with your own principle namespace. Just like the `election` module, this module
+namespace with your own principal namespace. Just like the `election` module, this module
 will be governed by the `admin-keyset`.
 
 ```pact
@@ -186,7 +186,7 @@ loads correctly. Run the file.
 ```
 
 You will notice that the module does not load correctly. Because you merely defined that
-the module should implement the `gas-payer-v1` interface, but not actually implemented
+the module should implement the `gas-payer-v1` interface, but you have not actually implemented
 that interface yet, the error
 `Error: found unimplemented member while resolving model constraints: GAS_PAYER` appears.
 You can find the signature of this capability in `./pact/root/gas-payer-v1.pact`. It is
@@ -213,7 +213,7 @@ capability with it as follows. Then, run `./pact/election-gas-station.repl` agai
 The test will now fail with
 `Error: found unimplemented member while resolving model constraints: create-gas-payer-guard`.
 Indeed, there is a function `create-gas-payer-guard` defined in the `gas-payer-v1` interface
-that still needs to be implemented. The documentation inside is a bit cryptic, but its suggests
+that still needs to be implemented. The documentation inside is a bit cryptic, but it suggests
 to require something like the `GAS_PAYER` capability without the parameters. You can use
 the `GAS` capability from the `coin` module here. After all, in Chainweaver's module explorer
 you can find that this capability is documented as `Magic capability to protect gas buy and redeem`.
@@ -264,7 +264,7 @@ Open up a terminal and change the directory to the `./snippets` folder in the ro
 your project. Execute the `./deploy-gas-station.ts` snippet by running the following command.
 Replace `k:account` with your admin account. The content of `./deploy-gas-station.ts` is
 roughly the same as `./deploy-module.ts`, except that it deploys the 
-`./pact/election-gas-station.repl` file
+`./pact/election-gas-station.repl` file.
 
 ```bash
 npm run deploy-gas-station:devnet -- k:account
@@ -283,8 +283,8 @@ If everything went well, you will see something similar to the following output.
 }
 ```
 
-Congratulations! You have added a second module to your smart contract. deployed a smart contract consisting of the `election` module that
-is governed by the `admin-keyset` in your principal namespace on your local Devnet.
+Congratulations! You have added a second module to your smart contract. You deployed the
+`election-gas-station` module that is governed by the `admin-keyset` in your principal namespace on your local Devnet.
 If you would now run the `list-modules:devnet` script, you will find your new module in the list
 of deployed modules.
 
@@ -313,7 +313,7 @@ Also, change the `senderAccount` in the transaction's metadata to `'election-gas
 
 Return to the election website and try to vote again with the voter account. The transaction will still fail
 with the error: `Failure: Tx Failed: Insufficient funds`. Apparently, the gas station does not work as it is
-supposed to yet. The reason is that the gas station module attempts to pay for gas using the `senderAccount`,
+supposed to, yet. The reason is that the gas station module attempts to pay for gas using the `senderAccount`,
 but this account does not exist. It has to be created first. It also needs to have a positive KDA balance.
 Otherwise, the transaction will still fail due to insufficient funds in the gas station account.
 
@@ -380,10 +380,10 @@ If everything went well, you should see output similar to this.
 Execute the `./transfer.ts` snippet by running the following command to transfer 1 KDA from your admin
 account to the gas station account. Replace `k:account` with your admin account. The transaction
 inside this file is similar to `./transfer-create.ts`, except that it does not use the special
-`sender00` account, but your own election admin account to transfer KDA. Therefore, the transaction
+`sender00` account, but your own election admin account to transfer KDA from. Therefore, the transaction
 needs to be signed with Chainweaver instead of a private key. Also, the `transfer` function of the
 `coin` module is used. This function requires that the receiving account already exists on the
-blockchain and will not create the account if it does not exist like `transfer-create`.
+blockchain and will not create the account if it does not exist like `transfer-create` would.
 
 ```bash
 npm run transfer:devnet -- k:account election-gas-station 1
@@ -396,7 +396,7 @@ following script again.
 npm run coin-details:devnet -- election-gas-station
 ```
 
-Now, everything should set to allow voters to vote for free because the `election-gas-station`
+Now, everything should be set to allow voters to vote for free, because the `election-gas-station`
 account can pay the gas fee charged for the voting transaction.
 
 ## Vote again
@@ -430,7 +430,7 @@ The `caps` field in the signature passed to `env-sigs` is an empty array. As a c
 signature of the transaction is not scoped to any capability and the signer automatically
 approves all capabilities required for the function execution. In the `vote` function of
 `frontend/src/repositories/vote/DevnetVoteRepository.ts` you scoped the signature of the
-transaction to two gas related capabilities, but not for the `ACCOUNT-OWNER` capability. When
+transaction to two gas related capabilities, but not to the `ACCOUNT-OWNER` capability. When
 you sign for some capabilities but not all capabilities required for execution of a transaction,
 the execution will fail at the point where a capability is required that you did not sign for.
 Therefore, you need to add a third capability to the array passed to `addSigners` in
@@ -472,12 +472,12 @@ Then, call `(enforce-below-or-at-gas-price 0.000001)` right before `(compose-cap
 ### Limit accessibility
 
 Second, any module can use your gas station as it is, which can become quite costly when the
-word spreads. Especially, since any kind of transaction is allowed and heavy transaction cost even
-more gas than lighter transaction.
+word spreads. Especially, since any kind of transaction is allowed and heavy transactions cost even
+more gas than lighter transactions.
 
 There are two types of Pact transactions: `exec` and `cont`. `cont` transaction
 is used for multi-step pacts, while `exec` is for regular transactions. Limit the usage to `exec`
-transactions by adding the following line to the start of body of the `GAS_PAYER` `defcap`.
+transactions by adding the following line to the start of the body of the `GAS_PAYER` `defcap`.
 
 ```pact
 (enforce (= "exec" (at "tx-type" (read-msg))) "Can only be used inside an exec")
@@ -521,11 +521,12 @@ Kadena's gas station mechanism allows someone else to automatically pay the gas 
 of others under certain conditions. This enables voters to vote for free via a website that uses
 a smart contract on the blockchain as its back-end. By completing this project, you are able to
 demonstrate and explain that online elections on the blockchain are more efficient, transparent
-and reliable than traditional elections. The only remaining challenge is that it is possible to
+and reliable than traditional elections. The only remaining challenge is that it is currently
+possible to
 vote more than once by simply creating multiple Kadena accounts. To comply with the law, the
 Kadena accounts that are allowed to vote should somehow be linked to the social security numbers
 of citizens of voting age as stored in legacy government systems. Or, perhaps, everyone should
-just get a Kadena account instead of a social security number at birth. Anyway there are several
+just get a Kadena account instead of a social security number at birth. Anyway, there are several
 technical and theoretical solutions for such last hurdle. Food for thought.
 
 As a next step, you could deploy the election website online and deploy the election smart contract

--- a/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/index.md
+++ b/packages/apps/docs/src/pages/build/guides/election-dapp-tutorial/index.md
@@ -15,7 +15,7 @@ the election of the new president of the Kadena Universe. All members of the Kad
 community will be able to cast one vote on any of the candidates nominated by the election
 officials. Because all votes, as well as the voting mechanism itself, are openly published
 on the blockchain, the election process is fully transparent. Everyone can check if the
-election proceeded fairly and, for instance, no double votes were cast. Nevertheless, the
+election has proceeded fairly and, for instance, no double votes were cast. Nevertheless, the
 privacy of all voters is protected, because they are voting with an anonymous Kadena account.
 Every vote is a transaction on the blockchain, which comes at the price of a gas fee to paid
 to the miners. The election organization will utilize a gas station that pays the gas for
@@ -25,13 +25,13 @@ all voting transactions, so the election is accessible for all community members
 
 The concept of a gas station is a central topic of this tutorial, but definitely not the only
 one. You will learn about creating and funding accounts. You will learn how to deal with
-permissions by leveraging keyset and capabilities. You will learn how to interact with the
+permissions by leveraging keysets and capabilities. You will learn how to interact with the
 blockchain from your code. You will be reading data from the blockchain for free and send
 transactions that cost gas. You will also learn how to deploy a smart contract and upgrade it,
 i.e. deploy changes to your smart contract. You will learn how to do this on a Dockerized Devnet
-running on your own computer, and to Kadena's Testnet. Before deploying anything you will learn
-how to develop smart contracts using the test-driven methodology. You will dive into the different
-ways to sign transactions: with keypairs, Chainweaver and other wallet providers. Along the way,
+running on your own computer. Before deploying anything you will learn
+how to develop smart contracts using the test-driven methodology. You will dive into different
+ways to sign transactions: with keypairs and Chainweaver. Along the way,
 you will learn about a wide range of tooling that is available for blockchain development in
 the Kadena platform, like the Kadena JavaScript client library, Chainweaver, the Pact command
 line executable and more.
@@ -56,19 +56,19 @@ will be provided at the top of the respective chapter page.
  * [Chapter 08: Voting](/build/guides/election-dapp-tutorial/08-voting)
  * [Chapter 09: Gas station](/build/guides/election-dapp-tutorial/09-gas-station)
 
-In the future additional chapters may be added to this tutorial. Some ideas are already floating
+In the future, additional chapters may be added to this tutorial. Some ideas are already floating
 around, but if you have any suggestions for topics you would like to see covered, please
 get in touch.
 
  * Deploying to Testnet with the functional programming approach
  * A continuous integration pipeline for deploying your dApp
- * Other signing methods than Chainweaver
+ * Other signing methods than keypair and Chainweaver
 
 ## Requirements for this tutorial
 
 Before moving on to the first chapter of this tutorial, please make sure that you have the
-required software installed on your computer. The tutorial assumes that you have basic
-working knowledge of the software listed below.
+required software installed on your computer. The tutorial assumes that you have installed
+the software listed below.
 
  - [Docker](https://docs.docker.com/get-docker/)
  - [Git](https://git-scm.com/downloads)


### PR DESCRIPTION
There were many small errors, like spelling, grammar, broken sentences, copy-paste errors, etc. that needed to be fixed to make the tutorial more professional.
