### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,12 @@
 # About code owners: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-/*.*                                            @alber70g @webpro
-/*.md                                           @webpro
+/*.*                                            @alber70g
 /.changeset
-/common                                         @alber70g @webpro
+/common                                         @alber70g
 /pnpm-lock.yaml
 /packages/apps/graph                            @alber70g @MRVDH @nil-amrutlal-dept
 /packages/apps/graph-client                     @alber70g @MRVDH @nil-amrutlal-dept
-/packages/apps/kadena-docs                      @sstraatemans @eileenmguo @realdreamer
+/packages/apps/docs                             @sstraatemans @eileenmguo @realdreamer
 /packages/libs/chainweb-stream-client           @Takadenoshi
 /packages/libs/bootstrap-lib                    @alber70g
 /packages/libs/client                           @alber70g @javadkh2
@@ -19,4 +18,3 @@
 /packages/tools/eslint-config                   @alber70g
 /packages/tools/eslint-plugin                   @alber70g
 /packages/tools/heft-rig                        @alber70g
-/packages/tools/markdown                        @webpro

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,17 +4,17 @@
 /.changeset
 /common                                         @alber70g
 /pnpm-lock.yaml
+/packages/apps/docs                             @sstraatemans @eileenmguo @realdreamer
 /packages/apps/graph                            @alber70g @MRVDH @nil-amrutlal-dept
 /packages/apps/graph-client                     @alber70g @MRVDH @nil-amrutlal-dept
-/packages/apps/docs                             @sstraatemans @eileenmguo @realdreamer
-/packages/libs/chainweb-stream-client           @Takadenoshi
 /packages/libs/bootstrap-lib                    @alber70g
+/packages/libs/chainweb-stream-client           @Takadenoshi
 /packages/libs/client                           @alber70g @javadkh2
 /packages/libs/kadena.js                        @alber70g
 /packages/libs/pactjs-generator                 @alber70g
 /packages/libs/react-ui                         @eileenmguo @sstraatemans @timoheddes
 /packages/libs/types                            @alber70g
-/packages/tools/pactjs-cli                      @alber70g
 /packages/tools/eslint-config                   @alber70g
 /packages/tools/eslint-plugin                   @alber70g
 /packages/tools/heft-rig                        @alber70g
+/packages/tools/pactjs-cli                      @alber70g


### PR DESCRIPTION
Noticed the `kadena-docs` dir wasn't updated to `docs`. Which maybe raises the question whether an owner is actually necessary?

Also removed myself. It doesn't change too much, most of it is still owned by @alber70g and the `markdown` package is now an "outlaw" just like many other packages (this is fine, PRs just need one approval from anyone).