### PR TITLE
Add repository urls where missing

### DIFF
--- a/packages/tools/eslint-config/package.json
+++ b/packages/tools/eslint-config/package.json
@@ -2,6 +2,11 @@
   "name": "@kadena-dev/eslint-config",
   "version": "1.0.1",
   "description": "Kadena monorepo eslint-config",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/tools/eslint-config"
+  },
   "license": "MIT",
   "files": [
     "mixins",

--- a/packages/tools/eslint-plugin/package.json
+++ b/packages/tools/eslint-plugin/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@kadena-dev/eslint-plugin",
   "version": "0.0.7",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/tools/eslint-plugin"
+  },
   "main": "src/index.js",
   "files": [
     "src"

--- a/packages/tools/shared-config/package.json
+++ b/packages/tools/shared-config/package.json
@@ -2,5 +2,10 @@
   "name": "@kadena-dev/shared-config",
   "version": "1.0.0",
   "description": "Shared configurations",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/tools/shared-config"
+  },
   "license": "MIT"
 }


### PR DESCRIPTION
Should fix the issue in CI when publishing:

```
error an error occurred while publishing @kadena-dev/eslint-config: E422 422 Unprocessable Entity - PUT https://registry.npmjs.org/@kadena-dev%2feslint-config - Failed to validate repository information: package.json: "repository.url" is "undefined", expected to match "https://github.com/kadena-community/kadena.js" from provenance 
🦋  error npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
🦋  error npm notice publish Signed provenance statement with source and build information from GitHub Actions
🦋  error npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=45533571
🦋  error npm ERR! code E422
🦋  error npm ERR! 422 Unprocessable Entity - PUT https://registry.npmjs.org/@kadena-dev%2feslint-config - Failed to validate repository information: package.json: "repository.url" is "undefined", expected to match "https://github.com/kadena-community/kadena.js" from provenance
🦋  error 
🦋  error npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/2023-10-26T12_56_42_328Z-debug-0.log
🦋  error 
🦋  error an error occurred while publishing @kadena-dev/eslint-plugin: E422 422 Unprocessable Entity - PUT https://registry.npmjs.org/@kadena-dev%2feslint-plugin - Failed to validate repository information: package.json: "repository.url" is "undefined", expected to match "https://github.com/kadena-community/kadena.js" from provenance 
🦋  error npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
🦋  error npm notice publish Signed provenance statement with source and build information from GitHub Actions
🦋  error npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=45533595
🦋  error npm ERR! code E422
🦋  error npm ERR! 422 Unprocessable Entity - PUT https://registry.npmjs.org/@kadena-dev%2feslint-plugin - Failed to validate repository information: package.json: "repository.url" is "undefined", expected to match "https://github.com/kadena-community/kadena.js" from provenance
🦋  error 
🦋  error npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/2023-10-26T12_56_47_9[70](https://github.com/kadena-community/kadena.js/actions/runs/6654240847/job/18081879057#step:9:71)Z-debug-0.log
🦋  error 
🦋  error an error occurred while publishing @kadena-dev/shared-config: E422 422 Unprocessable Entity - PUT https://registry.npmjs.org/@kadena-dev%2fshared-config - Failed to validate repository information: package.json: "repository.url" is "undefined", expected to match "https://github.com/kadena-community/kadena.js" from provenance 
🦋  error npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
🦋  error npm notice publish Signed provenance statement with source and build information from GitHub Actions
🦋  error npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=45533604
🦋  error npm ERR! code E422
🦋  error npm ERR! 422 Unprocessable Entity - PUT https://registry.npmjs.org/@kadena-dev%2fshared-config - Failed to validate repository information: package.json: "repository.url" is "undefined", expected to match "https://github.com/kadena-community/kadena.js" from provenance
🦋  error 
🦋  error npm ERR! A complete log of this run can be found in: /home/runner/.npm/_logs/2023-10-26T12_56_49_5[82](https://github.com/kadena-community/kadena.js/actions/runs/6654240847/job/18081879057#step:9:83)Z-debug-0.log
🦋  error
```