### PR TITLE
fix(@kadena/react-ui): Fix KodeMono font

### DIFF
--- a/.changeset/slow-schools-compete.md
+++ b/.changeset/slow-schools-compete.md
@@ -1,0 +1,5 @@
+---
+'@kadena/react-ui': patch
+---
+
+Fixed the KodeMono font

--- a/packages/libs/react-ui/.storybook/preview.ts
+++ b/packages/libs/react-ui/.storybook/preview.ts
@@ -1,3 +1,4 @@
+import { KodeMono } from '@kadena/fonts';
 import { DocsContainer } from '@storybook/addon-docs';
 import { type Preview } from '@storybook/react';
 import { themes } from '@storybook/theming';
@@ -6,6 +7,7 @@ import { useDarkMode } from 'storybook-dark-mode';
 import { darkThemeClass } from '../src/styles';
 import { colorPalette } from '../src/styles/colors';
 import '../src/styles/global.css';
+KodeMono();
 
 const preview: Preview = {
   parameters: {

--- a/packages/libs/react-ui/src/index.ts
+++ b/packages/libs/react-ui/src/index.ts
@@ -1,6 +1,5 @@
 import { KodeMono } from '@kadena/fonts';
 import './styles/global.css';
-
 KodeMono();
 
 export type {

--- a/packages/libs/react-ui/src/index.ts
+++ b/packages/libs/react-ui/src/index.ts
@@ -1,4 +1,7 @@
+import { KodeMono } from '@kadena/fonts';
 import './styles/global.css';
+
+KodeMono();
 
 export type {
   IAccordionProps,

--- a/packages/libs/react-ui/src/styles/global.css.ts
+++ b/packages/libs/react-ui/src/styles/global.css.ts
@@ -1,5 +1,4 @@
 // NOTE: Refer to https://www.joshwcomeau.com/css/custom-css-reset/ for more detailed explanation
-import { KodeMono } from '@kadena/fonts';
 import { globalFontFace, globalStyle } from '@vanilla-extract/css';
 import { breakpoints } from './themeUtils';
 import { vars } from './vars.css';
@@ -7,7 +6,6 @@ import { vars } from './vars.css';
 /*
     0. Add fonts
 */
-KodeMono();
 globalFontFace('Haas Grotesk Display', {
   fontWeight: 300,
   src: "url(https://fonts.gstatic.com/s/inter/v12/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1ZL7W0Q5nw.woff2) format('woff2')",


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->

The KodeMono font wasn't working becuase it was being loaded in a css file. This moves it to the component index file so that when someone imports a component, the font will be applied
