### PR TITLE
Expriment using iterators for client utils.

### DIFF
--- a/packages/libs/client-utils/src/core/utils/asIteraror.ts
+++ b/packages/libs/client-utils/src/core/utils/asIteraror.ts
@@ -1,0 +1,65 @@
+import type { IEmit } from './helpers';
+
+function createAsyncListener() {
+  let listener = (data?: any): void => {
+    throw new Error('no one is listening');
+  };
+  let pusher: (data?: any) => void;
+  return {
+    push: (data: any, terminate = false) => {
+      listener(data);
+      if (terminate) return;
+      return new Promise<any>((resolve) => {
+        pusher = resolve;
+      });
+    },
+    listen: () => {
+      if (pusher) pusher();
+      return new Promise<any>((resolve) => {
+        listener = resolve;
+      });
+    },
+  };
+}
+
+export function asIterator(
+  task: (emit: IEmit) => (...args: any[]) => Promise<any>,
+) {
+  const asyncBuffer = createAsyncListener();
+
+  const pipeline = task(
+    ((name: string) => (data: any) =>
+      asyncBuffer
+        .push({ done: false, value: { name, data } })
+        ?.then(() => data)) as IEmit,
+  );
+  let started = false;
+  let ended = false;
+  const start = () => {
+    if (started) return;
+    pipeline()
+      .then((result) => {
+        asyncBuffer.push({ done: false, value: result }, true) as undefined;
+        ended = true;
+      })
+      .catch((error) => {
+        asyncBuffer.push({ done: false, value: { error } }, true) as undefined;
+        ended = true;
+      });
+    started = true;
+  };
+
+  const next = async (): Promise<{ done: boolean; value: any }> => {
+    if (ended) return { done: true, value: undefined };
+    const listen = asyncBuffer.listen();
+    start();
+    return listen;
+  };
+
+  return {
+    next,
+    [Symbol.asyncIterator]: () => ({
+      next,
+    }),
+  };
+}

--- a/packages/libs/client-utils/src/core/utils/test/asIterator.test.ts
+++ b/packages/libs/client-utils/src/core/utils/test/asIterator.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { asIterator } from '../asIteraror';
+import { asyncPipe } from '../asyncPipe';
+import type { IEmit } from '../helpers';
+
+describe('asIterator', () => {
+  it('should wrap a pipeline into an async iterator', async () => {
+    const testPipeLine = asIterator((emit: IEmit) =>
+      asyncPipe(
+        emit('start'),
+        () => Promise.resolve(1),
+        emit('middle'),
+        (input) => Promise.resolve(input + 1),
+        emit('end'),
+      ),
+    );
+    const step1 = await testPipeLine.next();
+    expect(step1).toEqual({
+      done: false,
+      value: { name: 'start', data: undefined },
+    });
+    const step2 = await testPipeLine.next();
+    expect(step2).toEqual({
+      done: false,
+      value: { name: 'middle', data: 1 },
+    });
+    const step3 = await testPipeLine.next();
+    expect(step3).toEqual({
+      done: false,
+      value: { name: 'end', data: 2 },
+    });
+    const step4 = await testPipeLine.next();
+    expect(step4).toEqual({
+      done: false,
+      value: 2,
+    });
+
+    const end = await testPipeLine.next();
+    expect(end).toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    const testPipeLine2 = asIterator((emit: IEmit) =>
+      asyncPipe(
+        emit('start'),
+        () => Promise.resolve(1),
+        emit('middle'),
+        (input) => Promise.resolve(input + 1),
+        emit('end'),
+      ),
+    );
+
+    // use with for await
+    for await (const step of testPipeLine2) {
+      console.log('step', step);
+    }
+  });
+});

--- a/packages/libs/client-utils/src/core/utils/test/asIterator.test.ts
+++ b/packages/libs/client-utils/src/core/utils/test/asIterator.test.ts
@@ -8,51 +8,44 @@ describe('asIterator', () => {
     const testPipeLine = asIterator((emit: IEmit) =>
       asyncPipe(
         emit('start'),
-        () => Promise.resolve(1),
+        (a) => Promise.resolve(1 + a),
         emit('middle'),
-        (input) => Promise.resolve(input + 1),
+        (b) => Promise.resolve(b + 1),
         emit('end'),
       ),
     );
-    const step1 = await testPipeLine.next();
+    const firstInstance = testPipeLine(0);
+    const step1 = await firstInstance.next();
     expect(step1).toEqual({
       done: false,
-      value: { name: 'start', data: undefined },
+      value: { name: 'start', data: 0 },
     });
-    const step2 = await testPipeLine.next();
+    const step2 = await firstInstance.next();
     expect(step2).toEqual({
       done: false,
       value: { name: 'middle', data: 1 },
     });
-    const step3 = await testPipeLine.next();
+    const step3 = await firstInstance.next();
     expect(step3).toEqual({
       done: false,
       value: { name: 'end', data: 2 },
     });
-    const step4 = await testPipeLine.next();
+    const step4 = await firstInstance.next();
     expect(step4).toEqual({
       done: false,
       value: 2,
     });
 
-    const end = await testPipeLine.next();
+    const end = await firstInstance.next();
     expect(end).toEqual({
       done: true,
       value: undefined,
     });
 
-    const testPipeLine2 = asIterator((emit: IEmit) =>
-      asyncPipe(
-        emit('start'),
-        () => Promise.resolve(1),
-        emit('middle'),
-        (input) => Promise.resolve(input + 1),
-        emit('end'),
-      ),
-    );
+    const secondInstance = testPipeLine(2);
 
     // use with for await
-    for await (const step of testPipeLine2) {
+    for await (const step of secondInstance) {
       console.log('step', step);
     }
   });


### PR DESCRIPTION
# client-utils as Iterator
**This PR is only here for sharing the idea**
There is no plan to adopt this approach.

### Pros:
* managing an async operator with asyncIterators leads to more leanier api
* natively support in javascript with `for await`
### Cons:
* writing types for each individual yield values is not straight forward, Actually I event don't know if its possible.

## examples 
```TS
const submitIteratorClient = asIterator(submitAndListen);

const submitTask = submitIteratorClient( 
    command, 
    { host:"http://localhost:8080", sign: signWithChainWeaver }
);

const signResult = await submitTask.next(); 
// update ui or save data to db, the process is paused till you call the next function again

const preflightResult = await submitTask.next(); 
// update ui or save data to db, the process is paused till you call the next function again

const submitResult = await submitTask.next(); 
// update ui or save data to db, the process is paused till you call the next function again

const listenResult = await submitTask.next(); 
// update ui or save data to db, the process is paused till you call the next function again

const finalResult = await submitTask.next(); 
// update ui or save data to db, the process is paused till you call the next function again
```
### use for await
```TS
const submitIteratorClient = asIterator(submitAndListen);

const submitTask = submitIteratorClient( 
    command, 
    { host:"http://localhost:8080", sign: signWithChainWeaver }
);

for await (const stepResult of submitTask) {
// do something with result
}




