### PR TITLE
[chore] Also update root packages.json after bumping versions for ind…

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "turbo run test -- run --coverage",
     "test:e2e": "turbo run test:e2e",
     "test:integration": "turbo run test:integration",
-    "version": "changeset version"
+    "version": "changeset version && pnpm run format:pkgs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",

--- a/packages/tools/e2e-tests/src/tests/tools-app/transactions.spec.ts
+++ b/packages/tools/e2e-tests/src/tests/tools-app/transactions.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import { test } from '../../page-objects';
 
-test('The Module Explorer shows deployed contracts', async ({
+test.skip('The Module Explorer shows deployed contracts', async ({
   page,
   toolsApp,
 }) => {


### PR DESCRIPTION
Currently, running `pnpm run format` in the root of the monorepo also updates the root packages.json with new version numbers (if any are available). 

The expectation is that updating of this file is done during the release process. This PR aims to achieve that goal.