### PR TITLE
Fix client predicate type

### DIFF
--- a/.changeset/pretty-balloons-love.md
+++ b/.changeset/pretty-balloons-love.md
@@ -1,0 +1,6 @@
+---
+'@kadena/client': patch
+'@kadena/client-utils': patch
+---
+
+Fix pred type for keysets

--- a/packages/libs/client-utils/src/coin/create-account.ts
+++ b/packages/libs/client-utils/src/coin/create-account.ts
@@ -15,7 +15,7 @@ interface ICreateAccountCommandInput {
   account: string;
   keyset: {
     keys: string[];
-    pred: 'keys-all' | 'keys-two' | 'keys-one';
+    pred: 'keys-all' | 'keys-2' | 'keys-any';
   };
   gasPayer: { account: string; publicKeys: string[] };
   chainId: ChainId;

--- a/packages/libs/client-utils/src/coin/rotate.ts
+++ b/packages/libs/client-utils/src/coin/rotate.ts
@@ -15,7 +15,7 @@ interface IRotateCommandInput {
   account: { account: string; publicKeys: string[] };
   newguard: {
     keys: string[];
-    pred: 'keys-all' | 'keys-two' | 'keys-one';
+    pred: 'keys-all' | 'keys-2' | 'keys-any';
   };
   gasPayer: { account: string; publicKeys: string[] };
   chainId: ChainId;

--- a/packages/libs/client-utils/src/coin/transfer-create.ts
+++ b/packages/libs/client-utils/src/coin/transfer-create.ts
@@ -17,7 +17,7 @@ interface ICreateTransferInput {
     account: string;
     keyset: {
       keys: string[];
-      pred: 'keys-all' | 'keys-two' | 'keys-one';
+      pred: 'keys-all' | 'keys-2' | 'keys-any';
     };
   };
   amount: string;

--- a/packages/libs/client-utils/src/coin/transfer-crosschain.ts
+++ b/packages/libs/client-utils/src/coin/transfer-crosschain.ts
@@ -17,7 +17,7 @@ interface ICrossChainInput {
     account: string;
     keyset: {
       keys: string[];
-      pred: 'keys-all' | 'keys-two' | 'keys-one';
+      pred: 'keys-all' | 'keys-2' | 'keys-any';
     };
   };
   amount: string;

--- a/packages/libs/client/src/composePactCommand/README.md
+++ b/packages/libs/client/src/composePactCommand/README.md
@@ -166,11 +166,11 @@ const command = {
 
 add keyset to the data part
 
-| parameter     | type                                             | description                                  |
-| ------------- | ------------------------------------------------ | -------------------------------------------- |
-| name          | string                                           | name of the keyset                           |
-| pred          | "keys-all" \| "keys-one" \| "keys-two" \| string | type of pred                                 |
-| ...publicKeys | string[]                                         | list of the public keys to add to the keyset |
+| parameter     | type                                           | description                                  |
+| ------------- | ---------------------------------------------- | -------------------------------------------- |
+| name          | string                                         | name of the keyset                           |
+| pred          | "keys-all" \| "keys-any" \| "keys-2" \| string | type of pred                                 |
+| ...publicKeys | string[]                                       | list of the public keys to add to the keyset |
 
 <details>
 <summary>examples</summary>
@@ -180,7 +180,7 @@ const command = composePactCommand(
   execution(
     coin.transfer(readKeyset("senderKey"), "bob", { decimal: "1.1" })
   ),
-  addKeyset("senderKey","keys-one", "the_public_key")
+  addKeyset("senderKey","keys-any", "the_public_key")
 )()
 
 //
@@ -190,7 +190,7 @@ const command = {
     data: {
       senderKey: {
         publicKeys: ['the_public_key'],
-        pred: "keys-one"
+        pred: "keys-any"
       }
     }
   }

--- a/packages/libs/client/src/composePactCommand/utils/addData.ts
+++ b/packages/libs/client/src/composePactCommand/utils/addData.ts
@@ -62,7 +62,7 @@ export const addData: (
   };
 
 export interface IAddKeyset {
-  <TKey extends string, PRED extends 'keys-all' | 'keys-one' | 'keys-two'>(
+  <TKey extends string, PRED extends 'keys-all' | 'keys-any' | 'keys-2'>(
     key: TKey,
     pred: PRED,
     ...publicKeys: string[]

--- a/packages/libs/client/src/composePactCommand/utils/tests/addKeyset.test.ts
+++ b/packages/libs/client/src/composePactCommand/utils/tests/addKeyset.test.ts
@@ -3,13 +3,13 @@ import { addKeyset } from '../addKeyset';
 
 describe('addKeyset', () => {
   it('returns keyset data format', () => {
-    expect(addKeyset('test', 'keys-one', 'p1', 'p2')({})).toEqual({
+    expect(addKeyset('test', 'keys-any', 'p1', 'p2')({})).toEqual({
       payload: {
         exec: {
           data: {
             test: {
               keys: ['p1', 'p2'],
-              pred: 'keys-one',
+              pred: 'keys-any',
             },
           },
         },

--- a/packages/libs/client/src/createTransactionBuilder/createTransactionBuilder.ts
+++ b/packages/libs/client/src/createTransactionBuilder/createTransactionBuilder.ts
@@ -58,7 +58,7 @@ interface ISetNonce<TCommand> {
 }
 
 interface IAddKeyset<TCommand> {
-  <TKey extends string, PRED extends 'keys-all' | 'keys-one' | 'keys-two'>(
+  <TKey extends string, PRED extends 'keys-all' | 'keys-any' | 'keys-2'>(
     key: TKey,
     pred: PRED,
     ...publicKeys: string[]


### PR DESCRIPTION
Set the type to correct values "keys-all" | "keys-any" | "keys-2"
