### PR TITLE
[@kadena/graph] More GraphQL types extend Node, and use of Promise optimizations

### DIFF
--- a/.changeset/quick-islands-care.md
+++ b/.changeset/quick-islands-care.md
@@ -1,0 +1,7 @@
+---
+'@kadena/graph': patch
+---
+
+acount and chainAccount now implement the Node type, meaning that they can be
+used in the node and nodes queries. Besides this, several optimizations with
+async data retrieval.

--- a/packages/apps/graph/generated-schema.graphql
+++ b/packages/apps/graph/generated-schema.graphql
@@ -31,11 +31,12 @@ type BlockTransactionsConnectionEdge {
   node: Transaction!
 }
 
-type ChainModuleAccount {
+type ChainModuleAccount implements Node {
   accountName: String!
   balance: Float!
   chainId: ID!
   guard: Guard!
+  id: ID!
   moduleName: String!
   transactions(after: String, before: String, first: Int, last: Int): ChainModuleAccountTransactionsConnection!
   transfers(after: String, before: String, first: Int, last: Int): ChainModuleAccountTransfersConnection!

--- a/packages/apps/graph/generated-schema.graphql
+++ b/packages/apps/graph/generated-schema.graphql
@@ -104,10 +104,10 @@ type MinerKey implements Node {
   key: String!
 }
 
-type ModuleAccount {
+type ModuleAccount implements Node {
   accountName: String!
   chainAccounts: [ChainModuleAccount!]!
-  id: String!
+  id: ID!
   moduleName: String!
   totalBalance: Decimal!
   transactions(after: String, before: String, first: Int, last: Int): ModuleAccountTransactionsConnection!

--- a/packages/apps/graph/src/graph/Query/account.ts
+++ b/packages/apps/graph/src/graph/Query/account.ts
@@ -1,5 +1,6 @@
 import { builder } from '../builder';
 import Account from '../objects/ModuleAccount';
+import { ModuleAccountName } from '../types/graphql-types';
 
 builder.queryField('account', (t) => {
   return t.field({
@@ -10,7 +11,7 @@ builder.queryField('account', (t) => {
     type: Account,
     resolve(__parent, args) {
       return {
-        id: `Account:${args.accountName}`,
+        __typename: ModuleAccountName,
         accountName: args.accountName,
         moduleName: args.moduleName,
         chainAccounts: [],

--- a/packages/apps/graph/src/graph/Query/chainAccount.ts
+++ b/packages/apps/graph/src/graph/Query/chainAccount.ts
@@ -2,6 +2,7 @@ import { getAccountDetails } from '@services/node-service';
 import { normalizeError } from '@utils/errors';
 import { builder } from '../builder';
 import ChainModuleAccount from '../objects/ChainModuleAccount';
+import { ChainModuleAccountName } from '../types/graphql-types';
 
 builder.queryField('chainAccount', (t) => {
   return t.field({
@@ -22,6 +23,7 @@ builder.queryField('chainAccount', (t) => {
 
         return accountDetails
           ? {
+              __typename: ChainModuleAccountName,
               chainId: args.chainId,
               accountName: args.accountName,
               moduleName: args.moduleName,

--- a/packages/apps/graph/src/graph/objects/ChainModuleAccount.ts
+++ b/packages/apps/graph/src/graph/objects/ChainModuleAccount.ts
@@ -9,8 +9,8 @@ export default builder.node(
   builder.objectRef<ChainModuleAccount>('ChainModuleAccount'),
   {
     id: {
-      resolve(parent, __args, __context, info) {
-        return `${info.parentType}/${parent.chainId}/${parent.moduleName}/${parent.accountName}`;
+      resolve(parent) {
+        return `ChainModuleAccount/${parent.chainId}/${parent.moduleName}/${parent.accountName}`;
       },
       parse(id) {
         return {
@@ -21,12 +21,12 @@ export default builder.node(
       },
     },
     isTypeOf: () => true,
-    async loadOne(id) {
+    async loadOne({ chainId, moduleName, accountName }) {
       try {
         return getChainModuleAccount({
-          chainId: id.chainId,
-          moduleName: id.moduleName,
-          accountName: id.accountName,
+          chainId: chainId,
+          moduleName: moduleName,
+          accountName: accountName,
         });
       } catch (error) {
         throw normalizeError(error);

--- a/packages/apps/graph/src/graph/objects/ChainModuleAccount.ts
+++ b/packages/apps/graph/src/graph/objects/ChainModuleAccount.ts
@@ -32,21 +32,6 @@ export default builder.node(
         throw normalizeError(error);
       }
     },
-    async loadMany(ids) {
-      try {
-        return await Promise.all(
-          ids.map(async (id) => {
-            return await getChainModuleAccount({
-              chainId: id.chainId,
-              moduleName: id.moduleName,
-              accountName: id.accountName,
-            });
-          }),
-        );
-      } catch (error) {
-        throw normalizeError(error);
-      }
-    },
     fields: (t) => ({
       chainId: t.exposeID('chainId'),
       accountName: t.exposeString('accountName'),

--- a/packages/apps/graph/src/graph/objects/ChainModuleAccount.ts
+++ b/packages/apps/graph/src/graph/objects/ChainModuleAccount.ts
@@ -1,81 +1,129 @@
 import { prismaClient } from '@db/prismaClient';
+import { getChainModuleAccount } from '@services/account-service';
 import { normalizeError } from '@utils/errors';
 import { builder } from '../builder';
 import { accountDetailsLoader } from '../data-loaders/account-details';
+import { ChainModuleAccount } from '../types/graphql-types';
 
-export default builder.objectType('ChainModuleAccount', {
-  fields: (t) => ({
-    chainId: t.exposeID('chainId'),
-    accountName: t.exposeString('accountName'),
-    moduleName: t.exposeString('moduleName'),
-    guard: t.field({
-      type: 'Guard',
-      async resolve(parent) {
-        const accountDetails = await accountDetailsLoader.load({
-          moduleName: parent.moduleName,
-          accountName: parent.accountName,
-          chainId: parent.chainId,
-        });
-
+export default builder.node(
+  builder.objectRef<ChainModuleAccount>('ChainModuleAccount'),
+  {
+    id: {
+      resolve(parent, __args, __context, info) {
+        return `${info.parentType}/${parent.chainId}/${parent.moduleName}/${parent.accountName}`;
+      },
+      parse(id) {
         return {
-          keys: accountDetails.guard.keys,
-          predicate: accountDetails.guard.pred,
+          chainId: id.split('/')[1],
+          accountName: id.split('/')[3],
+          moduleName: id.split('/')[2],
         };
       },
-    }),
-    balance: t.exposeFloat('balance'),
-    transactions: t.prismaConnection({
-      type: 'Transaction',
-      cursor: 'blockHash_requestKey',
-      async resolve(query, parent) {
-        try {
-          return await prismaClient.transaction.findMany({
-            ...query,
-            where: {
-              senderAccount: parent.accountName,
-              events: {
-                some: {
-                  moduleName: parent.moduleName,
-                },
-              },
-              chainId: parseInt(parent.chainId),
-            },
-            orderBy: {
-              height: 'desc',
-            },
-          });
-        } catch (error) {
-          throw normalizeError(error);
-        }
-      },
-    }),
-    transfers: t.prismaConnection({
-      type: 'Transfer',
-      cursor: 'blockHash_chainId_orderIndex_moduleHash_requestKey',
-      async resolve(query, parent) {
-        try {
-          return await prismaClient.transfer.findMany({
-            ...query,
-            where: {
-              OR: [
-                {
-                  senderAccount: parent.accountName,
-                },
-                {
-                  receiverAccount: parent.accountName,
-                },
-              ],
+    },
+    isTypeOf: () => true,
+    async loadOne(id) {
+      try {
+        return getChainModuleAccount({
+          chainId: id.chainId,
+          moduleName: id.moduleName,
+          accountName: id.accountName,
+        });
+      } catch (error) {
+        throw normalizeError(error);
+      }
+    },
+    async loadMany(ids) {
+      try {
+        return await Promise.all(
+          ids.map(async (id) => {
+            return await getChainModuleAccount({
+              chainId: id.chainId,
+              moduleName: id.moduleName,
+              accountName: id.accountName,
+            });
+          }),
+        );
+      } catch (error) {
+        throw normalizeError(error);
+      }
+    },
+    fields: (t) => ({
+      chainId: t.exposeID('chainId'),
+      accountName: t.exposeString('accountName'),
+      moduleName: t.exposeString('moduleName'),
+      guard: t.field({
+        type: 'Guard',
+        async resolve(parent) {
+          try {
+            const accountDetails = await accountDetailsLoader.load({
               moduleName: parent.moduleName,
-              chainId: parseInt(parent.chainId),
-            },
-            orderBy: {
-              height: 'desc',
-            },
-          });
-        } catch (error) {
-          throw normalizeError(error);
-        }
-      },
+              accountName: parent.accountName,
+              chainId: parent.chainId,
+            });
+
+            return {
+              keys: accountDetails.guard.keys,
+              predicate: accountDetails.guard.pred,
+            };
+          } catch (error) {
+            throw normalizeError(error);
+          }
+        },
+      }),
+      balance: t.exposeFloat('balance'),
+      transactions: t.prismaConnection({
+        type: 'Transaction',
+        cursor: 'blockHash_requestKey',
+        async resolve(query, parent) {
+          try {
+            return await prismaClient.transaction.findMany({
+              ...query,
+              where: {
+                senderAccount: parent.accountName,
+                events: {
+                  some: {
+                    moduleName: parent.moduleName,
+                  },
+                },
+                chainId: parseInt(parent.chainId),
+              },
+              orderBy: {
+                height: 'desc',
+              },
+            });
+          } catch (error) {
+            throw normalizeError(error);
+          }
+        },
+      }),
+      transfers: t.prismaConnection({
+        type: 'Transfer',
+        cursor: 'blockHash_chainId_orderIndex_moduleHash_requestKey',
+        async resolve(query, parent) {
+          try {
+            return await prismaClient.transfer.findMany({
+              ...query,
+              where: {
+                OR: [
+                  {
+                    senderAccount: parent.accountName,
+                  },
+                  {
+                    receiverAccount: parent.accountName,
+                  },
+                ],
+                moduleName: parent.moduleName,
+                chainId: parseInt(parent.chainId),
+              },
+              orderBy: {
+                height: 'desc',
+              },
+            });
+          } catch (error) {
+            throw normalizeError(error);
+          }
+        },
+      }),
     }),
-  }),
-});
+  },
+);

--- a/packages/apps/graph/src/graph/objects/ChainModuleAccount.ts
+++ b/packages/apps/graph/src/graph/objects/ChainModuleAccount.ts
@@ -15,8 +15,8 @@ export default builder.node(
       parse(id) {
         return {
           chainId: id.split('/')[1],
-          accountName: id.split('/')[3],
           moduleName: id.split('/')[2],
+          accountName: id.split('/')[3],
         };
       },
     },

--- a/packages/apps/graph/src/graph/objects/ModuleAccount.ts
+++ b/packages/apps/graph/src/graph/objects/ModuleAccount.ts
@@ -49,14 +49,18 @@ export default builder.node(builder.objectRef<ModuleAccount>('ModuleAccount'), {
     //   return acc;
     // }, 0);
 
-    return {
-      accountName: '',
-      moduleName: '',
-      chainAccounts: [],
-      totalBalance: 0,
-      transactions: [],
-      transfers: [],
-    };
+    try {
+      return {
+        accountName,
+        moduleName,
+        chainAccounts: [],
+        totalBalance: 0,
+        transactions: [],
+        transfers: [],
+      };
+    } catch (error) {
+      throw normalizeError(error);
+    }
   },
   fields: (t) => ({
     accountName: t.exposeString('accountName'),

--- a/packages/apps/graph/src/graph/objects/ModuleAccount.ts
+++ b/packages/apps/graph/src/graph/objects/ModuleAccount.ts
@@ -4,11 +4,61 @@ import { chainIds } from '@utils/chains';
 import { normalizeError } from '@utils/errors';
 import { builder } from '../builder';
 import { accountDetailsLoader } from '../data-loaders/account-details';
-import type { ChainModuleAccount } from '../types/graphql-types';
+import type { ChainModuleAccount, ModuleAccount } from '../types/graphql-types';
 
-export default builder.objectType('ModuleAccount', {
+export default builder.node(builder.objectRef<ModuleAccount>('ModuleAccount'), {
+  id: {
+    resolve(parent) {
+      return `ModuleAccount/${parent.moduleName}/${parent.accountName}`;
+    },
+    parse(id) {
+      return {
+        moduleName: id.split('/')[1],
+        accountName: id.split('/')[2],
+      };
+    },
+  },
+  isTypeOf: () => true,
+  async loadOne({ moduleName, accountName }) {
+    // const chainAccounts = (
+    //   await Promise.all(
+    //     chainIds.map(async (chainId) => {
+    //       return await getChainModuleAccount({
+    //         chainId: chainId,
+    //         moduleName,
+    //         accountName,
+    //       });
+    //     }),
+    //   )
+    // ).filter((chainAccount) => chainAccount !== null) as ChainModuleAccount[];
+
+    // const totalBalance = (
+    //   await Promise.all(
+    //     chainIds.map(async (chainId) => {
+    //       return accountDetailsLoader.load({
+    //         moduleName,
+    //         accountName,
+    //         chainId: chainId,
+    //       });
+    //     }),
+    //   )
+    // ).reduce((acc, accountDetails) => {
+    //   if (accountDetails !== null) {
+    //     return acc + accountDetails.balance;
+    //   }
+    //   return acc;
+    // }, 0);
+
+    return {
+      accountName: '',
+      moduleName: '',
+      chainAccounts: [],
+      totalBalance: 0,
+      transactions: [],
+      transfers: [],
+    };
+  },
   fields: (t) => ({
-    id: t.exposeString('id'),
     accountName: t.exposeString('accountName'),
     moduleName: t.exposeString('moduleName'),
     chainAccounts: t.field({

--- a/packages/apps/graph/src/graph/objects/ModuleAccount.ts
+++ b/packages/apps/graph/src/graph/objects/ModuleAccount.ts
@@ -5,162 +5,141 @@ import { normalizeError } from '@utils/errors';
 import { builder } from '../builder';
 import { accountDetailsLoader } from '../data-loaders/account-details';
 import type { ChainModuleAccount, ModuleAccount } from '../types/graphql-types';
+import {
+  ChainModuleAccountName,
+  ModuleAccountName,
+} from '../types/graphql-types';
 
-export default builder.node(builder.objectRef<ModuleAccount>('ModuleAccount'), {
-  id: {
-    resolve(parent) {
-      return `ModuleAccount/${parent.moduleName}/${parent.accountName}`;
-    },
-    parse(id) {
-      return {
-        moduleName: id.split('/')[1],
-        accountName: id.split('/')[2],
-      };
-    },
-  },
-  isTypeOf: () => true,
-  async loadOne({ moduleName, accountName }) {
-    // const chainAccounts = (
-    //   await Promise.all(
-    //     chainIds.map(async (chainId) => {
-    //       return await getChainModuleAccount({
-    //         chainId: chainId,
-    //         moduleName,
-    //         accountName,
-    //       });
-    //     }),
-    //   )
-    // ).filter((chainAccount) => chainAccount !== null) as ChainModuleAccount[];
-
-    // const totalBalance = (
-    //   await Promise.all(
-    //     chainIds.map(async (chainId) => {
-    //       return accountDetailsLoader.load({
-    //         moduleName,
-    //         accountName,
-    //         chainId: chainId,
-    //       });
-    //     }),
-    //   )
-    // ).reduce((acc, accountDetails) => {
-    //   if (accountDetails !== null) {
-    //     return acc + accountDetails.balance;
-    //   }
-    //   return acc;
-    // }, 0);
-
-    try {
-      return {
-        accountName,
-        moduleName,
-        chainAccounts: [],
-        totalBalance: 0,
-        transactions: [],
-        transfers: [],
-      };
-    } catch (error) {
-      throw normalizeError(error);
-    }
-  },
-  fields: (t) => ({
-    accountName: t.exposeString('accountName'),
-    moduleName: t.exposeString('moduleName'),
-    chainAccounts: t.field({
-      type: ['ChainModuleAccount'],
-      async resolve(parent) {
-        try {
-          return (
-            await Promise.all(
-              chainIds.map(async (chainId) => {
-                return await getChainModuleAccount({
-                  chainId: chainId,
-                  moduleName: parent.moduleName,
-                  accountName: parent.accountName,
-                });
-              }),
-            )
-          ).filter(
-            (chainAccount) => chainAccount !== null,
-          ) as ChainModuleAccount[];
-        } catch (error) {
-          throw normalizeError(error);
-        }
+export default builder.node(
+  builder.objectRef<ModuleAccount>(ModuleAccountName),
+  {
+    id: {
+      resolve(parent) {
+        return `${ModuleAccountName}/${parent.moduleName}/${parent.accountName}`;
       },
-    }),
-    totalBalance: t.field({
-      type: 'Decimal',
-      async resolve(parent) {
-        try {
-          return (
-            await Promise.all(
-              chainIds.map(async (chainId) => {
-                return accountDetailsLoader.load({
-                  moduleName: parent.moduleName,
-                  accountName: parent.accountName,
-                  chainId: chainId,
-                });
-              }),
-            )
-          ).reduce((acc, accountDetails) => {
-            if (accountDetails !== null) {
-              return acc + accountDetails.balance;
-            }
-            return acc;
-          }, 0);
-        } catch (error) {
-          throw normalizeError(error);
-        }
-      },
-    }),
-    transactions: t.prismaConnection({
-      type: 'Transaction',
-      cursor: 'blockHash_requestKey',
-      async resolve(query, parent) {
-        try {
-          return await prismaClient.transaction.findMany({
-            ...query,
-            where: {
-              senderAccount: parent.accountName,
-              events: {
-                some: {
-                  moduleName: parent.moduleName,
+      // Do not use parse here since there is a bug in the pothos relay plugin which can cause incorrect results. Parse the ID directly in the loadOne function.
+    },
+    isTypeOf(source) {
+      return (source as any).__typename === ModuleAccountName;
+    },
+    async loadOne(id) {
+      try {
+        const moduleName = id.split('/')[1];
+        const accountName = id.split('/')[2];
+
+        return {
+          __typename: ModuleAccountName,
+          accountName,
+          moduleName,
+          chainAccounts: [],
+          totalBalance: 0,
+          transactions: [],
+          transfers: [],
+        };
+      } catch (error) {
+        throw normalizeError(error);
+      }
+    },
+    fields: (t) => ({
+      accountName: t.exposeString('accountName'),
+      moduleName: t.exposeString('moduleName'),
+      chainAccounts: t.field({
+        type: [ChainModuleAccountName],
+        async resolve(parent) {
+          try {
+            return (
+              await Promise.all(
+                chainIds.map(async (chainId) => {
+                  return await getChainModuleAccount({
+                    chainId: chainId,
+                    moduleName: parent.moduleName,
+                    accountName: parent.accountName,
+                  });
+                }),
+              )
+            ).filter(
+              (chainAccount) => chainAccount !== null,
+            ) as ChainModuleAccount[];
+          } catch (error) {
+            throw normalizeError(error);
+          }
+        },
+      }),
+      totalBalance: t.field({
+        type: 'Decimal',
+        async resolve(parent) {
+          try {
+            return (
+              await Promise.all(
+                chainIds.map(async (chainId) => {
+                  return accountDetailsLoader.load({
+                    moduleName: parent.moduleName,
+                    accountName: parent.accountName,
+                    chainId: chainId,
+                  });
+                }),
+              )
+            ).reduce((acc, accountDetails) => {
+              if (accountDetails !== null) {
+                return acc + accountDetails.balance;
+              }
+              return acc;
+            }, 0);
+          } catch (error) {
+            throw normalizeError(error);
+          }
+        },
+      }),
+      transactions: t.prismaConnection({
+        type: 'Transaction',
+        cursor: 'blockHash_requestKey',
+        async resolve(query, parent) {
+          try {
+            return await prismaClient.transaction.findMany({
+              ...query,
+              where: {
+                senderAccount: parent.accountName,
+                events: {
+                  some: {
+                    moduleName: parent.moduleName,
+                  },
                 },
               },
-            },
-            orderBy: {
-              height: 'desc',
-            },
-          });
-        } catch (error) {
-          throw normalizeError(error);
-        }
-      },
+              orderBy: {
+                height: 'desc',
+              },
+            });
+          } catch (error) {
+            throw normalizeError(error);
+          }
+        },
+      }),
+      transfers: t.prismaConnection({
+        type: 'Transfer',
+        cursor: 'blockHash_chainId_orderIndex_moduleHash_requestKey',
+        async resolve(query, parent) {
+          try {
+            return await prismaClient.transfer.findMany({
+              ...query,
+              where: {
+                OR: [
+                  {
+                    senderAccount: parent.accountName,
+                  },
+                  {
+                    receiverAccount: parent.accountName,
+                  },
+                ],
+              },
+              orderBy: {
+                height: 'desc',
+              },
+            });
+          } catch (error) {
+            throw normalizeError(error);
+          }
+        },
+      }),
     }),
-    transfers: t.prismaConnection({
-      type: 'Transfer',
-      cursor: 'blockHash_chainId_orderIndex_moduleHash_requestKey',
-      async resolve(query, parent) {
-        try {
-          return await prismaClient.transfer.findMany({
-            ...query,
-            where: {
-              OR: [
-                {
-                  senderAccount: parent.accountName,
-                },
-                {
-                  receiverAccount: parent.accountName,
-                },
-              ],
-            },
-            orderBy: {
-              height: 'desc',
-            },
-          });
-        } catch (error) {
-          throw normalizeError(error);
-        }
-      },
-    }),
-  }),
-});
+  },
+);

--- a/packages/apps/graph/src/graph/types/graphql-types.ts
+++ b/packages/apps/graph/src/graph/types/graphql-types.ts
@@ -6,8 +6,12 @@ export interface Guard {
   predicate: 'keys-all' | 'keys-any' | 'keys-two';
 }
 
+export const ChainModuleAccountName: 'ChainModuleAccount' =
+  'ChainModuleAccount';
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface ChainModuleAccount {
+  __typename: typeof ChainModuleAccountName;
   chainId: string;
   moduleName: string;
   accountName: string;
@@ -17,8 +21,11 @@ export interface ChainModuleAccount {
   transfers: Transfer[];
 }
 
+export const ModuleAccountName: 'ModuleAccount' = 'ModuleAccount';
+
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface ModuleAccount {
+  __typename: typeof ModuleAccountName;
   moduleName: string;
   accountName: string;
   chainAccounts: ChainModuleAccount[];

--- a/packages/apps/graph/src/graph/types/graphql-types.ts
+++ b/packages/apps/graph/src/graph/types/graphql-types.ts
@@ -19,7 +19,6 @@ export interface ChainModuleAccount {
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface ModuleAccount {
-  id: string;
   moduleName: string;
   accountName: string;
   chainAccounts: ChainModuleAccount[];

--- a/packages/apps/graph/src/services/account-service.ts
+++ b/packages/apps/graph/src/services/account-service.ts
@@ -1,0 +1,33 @@
+import { accountDetailsLoader } from '../graph/data-loaders/account-details';
+import { ChainModuleAccount } from '../graph/types/graphql-types';
+
+export async function getChainModuleAccount({
+  chainId,
+  moduleName,
+  accountName,
+}: {
+  chainId: string;
+  moduleName: string;
+  accountName: string;
+}): Promise<ChainModuleAccount | null> {
+  const accountDetails = await accountDetailsLoader.load({
+    moduleName,
+    accountName,
+    chainId,
+  });
+
+  return accountDetails !== null
+    ? {
+        chainId,
+        accountName,
+        moduleName,
+        guard: {
+          keys: accountDetails.guard.keys,
+          predicate: accountDetails.guard.pred,
+        },
+        balance: accountDetails.balance,
+        transactions: [],
+        transfers: [],
+      }
+    : null;
+}

--- a/packages/apps/graph/src/services/account-service.ts
+++ b/packages/apps/graph/src/services/account-service.ts
@@ -1,5 +1,6 @@
 import { accountDetailsLoader } from '../graph/data-loaders/account-details';
-import { ChainModuleAccount } from '../graph/types/graphql-types';
+import type { ChainModuleAccount } from '../graph/types/graphql-types';
+import { ChainModuleAccountName } from '../graph/types/graphql-types';
 
 export async function getChainModuleAccount({
   chainId,
@@ -18,6 +19,7 @@ export async function getChainModuleAccount({
 
   return accountDetails !== null
     ? {
+        __typename: ChainModuleAccountName,
         chainId,
         accountName,
         moduleName,

--- a/packages/apps/graph/src/utils/chains.ts
+++ b/packages/apps/graph/src/utils/chains.ts
@@ -1,0 +1,1 @@
+export const chainIds = [...Array(20).keys()].map((i) => i.toString());


### PR DESCRIPTION
- Use an ObjectRef instead of a SchemaType to define the Node.
- Add an `id` option to build the unique identifier. Pothos will base64 encode it for you. Do not use parse as there is a bug in the pothos relay plugin which can cause the return of duplicate/incorrect data.
- Add an `isTypeOf` function that checks if the incoming object is actually the type that is being described.
- Add a `loadOne` function to support the `node` and `nodes` query. You don't need to add `loadMany` to support `nodes`, only if specific logic is required that differs from a loadOne.