### PR TITLE
[chore] Enable provenance and setting of NPM token.

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -17,14 +17,13 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      NPM_TOKEN: ${{ secrets.RELEASE_ACTION_NPM_TOKEN }} # GitHub creates an .npmrc by default and will add this value
+      NPM_CONFIG_PROVENANCE: true #Enable Provenance for all packages.
 
     steps:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-
-      - name: Setup Node.js 18
-        uses: actions/setup-node@v3
 
       - uses: pnpm/action-setup@v2
         with:
@@ -44,16 +43,5 @@ jobs:
       - name: Build, lint, test all packages
         run: pnpm turbo lint build test
 
-      - name: Build, lint, test all packages
-        id: changesets
-        run: pnpm run publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_ACTION_GITHUB_TOKEN }}
-          # Needs r+w access for packages of both orgs to publish to npm
-          NPM_TOKEN: ${{ secrets.RELEASE_ACTION_NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-
-      - name: Output (debug)
-        if: steps.changesets.outputs.published == 'true'
-        # Do something more interesting when a publish happens.
-        run: echo ${{ steps.changesets.outputs.publishedPackages }}
+      - name: Manually publish all unpublished packages
+        run: changeset publish


### PR DESCRIPTION
This PR allows for manual publishing of packages on main. Should only be used when a previous publish does not work.