### PR TITLE
fix(@kadena/react-ui): Update Card Component

### DIFF
--- a/.changeset/sweet-cougars-invite.md
+++ b/.changeset/sweet-cougars-invite.md
@@ -1,0 +1,7 @@
+---
+'@kadena/react-ui': minor
+---
+
+Updated the Card component's styles and removed the `stacked` prop. Users can add the
+Divider component within a Card to achieve the same result as using the
+deprecated `stacked` prop.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: pnpm run lint
 
       - name: Build, lint, test all packages
-        run: pnpm turbo lint build test
+        run: pnpm turbo lint build test --force
 
   integration-tests:
     name: INT - ${{ matrix.package }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: pnpm run lint
 
       - name: Build, lint, test all packages
-        run: pnpm turbo lint build test --force
+        run: pnpm turbo lint build test
 
   integration-tests:
     name: INT - ${{ matrix.package }}

--- a/packages/libs/react-ui/src/components/Card/Card.css.ts
+++ b/packages/libs/react-ui/src/components/Card/Card.css.ts
@@ -1,8 +1,6 @@
 import { sprinkles } from '@theme/sprinkles.css';
 import { darkThemeClass, vars } from '@theme/vars.css';
-import { createVar, style } from '@vanilla-extract/css';
-
-const textColor = createVar();
+import { style } from '@vanilla-extract/css';
 
 export const container = style([
   sprinkles({
@@ -36,47 +34,11 @@ export const fullWidthClass = style({
   width: '100%',
 });
 
-export const stackClass = style([
-  sprinkles({ marginY: 0 }),
-  {
-    selectors: {
-      '&:first-child': {
-        borderRadius: `${vars.radii.$sm} ${vars.radii.$sm} 0 0`,
-        borderBottom: 'none',
-      },
-      '&:last-child': {
-        borderRadius: `0 0 ${vars.radii.$sm} ${vars.radii.$sm}`,
-        borderTop: 'none',
-      },
-      '&:not(:last-child)': {
-        marginBottom: 0,
-      },
-      '&:not(:first-child)': {
-        marginTop: 0,
-      },
-      '&:not(:last-child):before': {
-        content: '',
-        position: 'absolute',
-        left: vars.sizes.$lg,
-        bottom: 0,
-        height: '1px',
-        width: `calc(100% - ${vars.sizes.$lg} - ${vars.sizes.$lg})`,
-        borderBottom: `${vars.borderWidths.$md} solid ${vars.colors.$neutral2}`,
-      },
-    },
-  },
-]);
-
 export const disabledClass = style([
   sprinkles({
-    backgroundColor: '$neutral1',
     pointerEvents: 'none',
   }),
   {
-    border: `${vars.borderWidths.$md} solid ${vars.colors.$borderSubtle}`,
-
-    vars: {
-      [textColor]: vars.colors.$neutral3,
-    },
+    opacity: 0.5,
   },
 ]);

--- a/packages/libs/react-ui/src/components/Card/Card.stories.tsx
+++ b/packages/libs/react-ui/src/components/Card/Card.stories.tsx
@@ -1,6 +1,8 @@
 import { Button } from '@components/Button';
 import type { ICardProps } from '@components/Card';
 import { Card } from '@components/Card';
+import { Stack } from '@components/Layout';
+import { Heading, Text } from '@components/Typography';
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
@@ -15,17 +17,6 @@ const meta: Meta<ICardProps> = {
   },
   component: Card,
   argTypes: {
-    stack: {
-      control: {
-        type: 'boolean',
-      },
-      description:
-        'If true, the component vertically stacks multiple card together and applies styles that combine them into a single card with separators.',
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
     fullWidth: {
       control: {
         type: 'boolean',
@@ -37,6 +28,7 @@ const meta: Meta<ICardProps> = {
         defaultValue: { summary: 'false' },
       },
     },
+
     disabled: {
       control: {
         type: 'boolean',
@@ -56,30 +48,31 @@ type Story = StoryObj<ICardProps>;
 export const Primary: Story = {
   name: 'Card',
   args: {
-    stack: false,
     fullWidth: false,
     disabled: false,
   },
-  render: ({ stack, fullWidth, disabled }) => {
+  render: ({ fullWidth, disabled }) => {
     return (
       <>
-        <Card stack={stack} fullWidth={fullWidth} disabled={disabled}>
-          <h4>Getting Started is Simple</h4>
-          <div>
-            Learn Kadena&apos;s core concepts & tools for development in 15
-            minutes
-          </div>
-
-          <Button title={'Button'}>Hello World Tutorial</Button>
-        </Card>
-        <Card stack={stack} fullWidth={fullWidth} disabled={disabled}>
-          <h4>Getting Started is Simple</h4>
-          <div>
-            Learn Kadena&apos;s core concepts & tools for development in 15
-            minutes
-          </div>
-
-          <Button title={'Button'}>Hello World Tutorial</Button>
+        <Card fullWidth={fullWidth} disabled={disabled}>
+          <Stack
+            direction="column"
+            gap="$2"
+            alignItems="flex-start"
+            marginBottom="$6"
+            maxWidth="$maxContentWidth"
+          >
+            <Heading as="h5">Intro to Kadena</Heading>
+            <Text>
+              Kadena is the only platform offering a complete decentralized
+              infrastructure for builders. Combining a revolutionary chain
+              architecture with the tools needed for widespread adoption, your
+              teams get the full capabilities of blockchain with the ability to
+              go from concept to launch in days vs. months by not having to
+              build from scratch. Learn about our core concepts.
+            </Text>
+          </Stack>
+          <Button title={'Button'}>Kadena Docs</Button>
         </Card>
       </>
     );

--- a/packages/libs/react-ui/src/components/Card/Card.test.tsx
+++ b/packages/libs/react-ui/src/components/Card/Card.test.tsx
@@ -1,13 +1,12 @@
 import { Card } from '@components/Card';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, test } from 'vitest';
 
 describe('Card', () => {
   test('renders correctly', () => {
-    const { getByTestId } = render(<Card>Hello, Card!</Card>);
+    render(<Card>Hello, Card!</Card>);
 
-    const cardContainer = getByTestId('kda-card');
-    expect(cardContainer).toBeInTheDocument();
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
   });
 });

--- a/packages/libs/react-ui/src/components/Card/Card.test.tsx
+++ b/packages/libs/react-ui/src/components/Card/Card.test.tsx
@@ -7,6 +7,6 @@ describe('Card', () => {
   test('renders correctly', () => {
     render(<Card>Hello, Card!</Card>);
 
-    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Hello, Card!')).toBeInTheDocument();
   });
 });

--- a/packages/libs/react-ui/src/components/Card/Card.tsx
+++ b/packages/libs/react-ui/src/components/Card/Card.tsx
@@ -1,50 +1,19 @@
 import className from 'classnames';
 import type { FC } from 'react';
 import React from 'react';
-import {
-  container,
-  disabledClass,
-  fullWidthClass,
-  stackClass,
-} from './Card.css';
+import { container, disabledClass, fullWidthClass } from './Card.css';
 
 export interface ICardProps {
   children: React.ReactNode;
   fullWidth?: boolean;
-  stack?: boolean;
   disabled?: boolean;
 }
 
-export const Card: FC<ICardProps> = ({
-  children,
-  fullWidth,
-  stack,
-  disabled,
-}) => {
+export const Card: FC<ICardProps> = ({ children, disabled, fullWidth }) => {
   const classList = className(container, {
-    [stackClass]: stack,
     [fullWidthClass]: fullWidth,
     [disabledClass]: disabled,
   });
 
-  // if disabled, also disable all the children
-  if (disabled) {
-    return (
-      <div className={classList} data-testid="kda-card">
-        {React.Children.map(children, (child) => {
-          if (React.isValidElement(child)) {
-            const filteredChild = { ...child, props: child.props };
-            return React.cloneElement(filteredChild, { disabled: true });
-          }
-          return child;
-        })}
-      </div>
-    );
-  }
-
-  return (
-    <div className={classList} data-testid="kda-card">
-      {children}
-    </div>
-  );
+  return <div className={classList}>{children}</div>;
 };


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->

- Removed the `stacked` prop as it wasn't being used at all and can be easily achieved by using the `Divider` within the `Card` component
- Updated the disabled state to look closer to existing designs
