### PR TITLE
[DOCS]fix: initial search

### DIFF
--- a/.changeset/forty-pumas-study.md
+++ b/.changeset/forty-pumas-study.md
@@ -1,0 +1,6 @@
+---
+'@kadena/docs': minor
+---
+
+bugfix for the initial search. when there is no tabname saved in localstorage
+the search did not trigger

--- a/packages/apps/docs/package.json
+++ b/packages/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kadena/docs",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "scripts": {
     "7d": "npx 7d pinecone-create-index --index kda-docs --environment asia-northeast1-gcp",

--- a/packages/apps/docs/src/components/Search/components/SearchResults.tsx
+++ b/packages/apps/docs/src/components/Search/components/SearchResults.tsx
@@ -83,7 +83,7 @@ export const SearchResults: FC<IProps> = ({
   }, [setIsMounted]);
 
   useEffect(() => {
-    const value = localStorage.getItem(TABNAME) as ITabs;
+    const value = (localStorage.getItem(TABNAME) as ITabs) ?? 'docs';
     if (value === null) return;
     setSelectedTabName(value);
     onTabSelect(value);


### PR DESCRIPTION
bugfix for the initial search. when there is no tabname saved in localstorage the search did not trigger