### PR TITLE
feat: add koala sign methods having the same api as ecko

### DIFF
--- a/.changeset/shaggy-bugs-smoke.md
+++ b/.changeset/shaggy-bugs-smoke.md
@@ -1,0 +1,5 @@
+---
+'@kadena/client': patch
+---
+
+Added koala wallet extension sign methods `createKoalaWalletSign` and `createKoalaWalletQuicksign` using the `window.koala` api

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -26,9 +26,6 @@ export const addSignatures: (transaction: IUnsignedCommand, ...signatures: {
     pubKey?: string;
 }[]) => IUnsignedCommand | ICommand;
 
-// @public (undocumented)
-export type BuiltInPredicate = 'keys-all' | 'keys-any' | 'keys-2';
-
 export { ChainId }
 
 // @public

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -26,6 +26,9 @@ export const addSignatures: (transaction: IUnsignedCommand, ...signatures: {
     pubKey?: string;
 }[]) => IUnsignedCommand | ICommand;
 
+// @public (undocumented)
+export type BuiltInPredicate = 'keys-all' | 'keys-any' | 'keys-2';
+
 export { ChainId }
 
 // @public
@@ -36,6 +39,12 @@ export function createEckoWalletQuicksign(): IEckoSignFunction;
 
 // @public
 export function createEckoWalletSign(): IEckoSignSingleFunction;
+
+// @public
+export function createKoalaWalletQuicksign(): IKoalaSignFunction;
+
+// @public
+export function createKoalaWalletSign(): IKoalaSignSingleFunction;
 
 // @public
 export function createSignWithChainweaver(options?: {
@@ -122,6 +131,16 @@ export interface ICommonEckoFunctions {
 }
 
 // @public
+export interface ICommonKoalaFunctions {
+    // (undocumented)
+    connect: (networkId: string) => Promise<boolean>;
+    // (undocumented)
+    isConnected: (networkId: string) => Promise<boolean>;
+    // (undocumented)
+    isInstalled: () => boolean;
+}
+
+// @public
 export interface IContinuationPayloadObject {
     // (undocumented)
     cont: {
@@ -168,6 +187,14 @@ export interface IExecutionPayloadObject {
 }
 
 export { IKeyPair }
+
+// @public
+export interface IKoalaSignFunction extends ISignFunction, ICommonKoalaFunctions {
+}
+
+// @public
+export interface IKoalaSignSingleFunction extends ISingleSignFunction, ICommonKoalaFunctions {
+}
 
 // @public (undocumented)
 export interface INetworkOptions {

--- a/packages/libs/client/src/signing/index.ts
+++ b/packages/libs/client/src/signing/index.ts
@@ -5,6 +5,11 @@ export {
   IEckoSignFunction,
   IEckoSignSingleFunction,
 } from './eckoWallet/eckoTypes';
+export {
+  ICommonKoalaFunctions,
+  IKoalaSignFunction,
+  IKoalaSignSingleFunction,
+} from './koalaWallet/koalaTypes';
 export { TWalletConnectChainId } from './walletconnect/walletConnectTypes';
 
 export * from './utils/addSignatures';
@@ -14,5 +19,7 @@ export * from './chainweaver/signWithChainweaver';
 export * from './eckoWallet/quicksignWithEckoWallet';
 export * from './eckoWallet/signWithEckoWallet';
 export * from './keypair/createSignWithKeypair';
+export * from './koalaWallet/quicksignWithKoalaWallet';
+export * from './koalaWallet/signWithKoalaWallet';
 export * from './walletconnect/quicksignWithWalletConnect';
 export * from './walletconnect/signWithWalletConnect';

--- a/packages/libs/client/src/signing/koalaWallet/koalaCommon.ts
+++ b/packages/libs/client/src/signing/koalaWallet/koalaCommon.ts
@@ -1,0 +1,47 @@
+import type {
+  ICommonKoalaFunctions,
+  IKoalaConnectOrStatusResponse,
+} from './koalaTypes';
+
+export const isInstalled: ICommonKoalaFunctions['isInstalled'] = () => {
+  const { koala } = window;
+  return Boolean(koala && koala.isKoala && koala.request);
+};
+
+export const isConnected: ICommonKoalaFunctions['isConnected'] = async (
+  networkId,
+) => {
+  if (!isInstalled()) {
+    return false;
+  }
+
+  const checkStatusResponse =
+    await window.koala?.request<IKoalaConnectOrStatusResponse>({
+      method: 'kda_checkStatus',
+      networkId,
+    });
+
+  return checkStatusResponse?.status === 'success';
+};
+
+export const connect: ICommonKoalaFunctions['connect'] = async (networkId) => {
+  if (!isInstalled()) {
+    throw new Error('Koala Wallet is not installed');
+  }
+
+  if (await isConnected(networkId)) {
+    return true;
+  }
+
+  const connectResponse =
+    await window.koala?.request<IKoalaConnectOrStatusResponse>({
+      method: 'kda_connect',
+      networkId,
+    });
+
+  if (connectResponse?.status === 'fail') {
+    throw new Error('User declined connection');
+  }
+
+  return true;
+};

--- a/packages/libs/client/src/signing/koalaWallet/koalaTypes.ts
+++ b/packages/libs/client/src/signing/koalaWallet/koalaTypes.ts
@@ -1,0 +1,70 @@
+import type { ICommand } from '@kadena/types';
+import type { IQuicksignResponseOutcomes } from '../../signing-api/v1/quicksign';
+import type { ISignFunction, ISingleSignFunction } from '../ISignFunction';
+
+export type KoalaStatus = 'success' | 'fail';
+
+/**
+ * Interface that describes the common functions to be used with Koala Wallet
+ * @public
+ */
+export interface ICommonKoalaFunctions {
+  isInstalled: () => boolean;
+  isConnected: (networkId: string) => Promise<boolean>;
+  connect: (networkId: string) => Promise<boolean>;
+}
+/**
+ * Interface to use when writing a signing function for Koala Wallet that accepts a single transaction
+ * @public
+ */
+export interface IKoalaSignSingleFunction
+  extends ISingleSignFunction,
+    ICommonKoalaFunctions {}
+
+/**
+ * Interface to use when writing a signing function for Koala Wallet that accepts multiple transactions
+ * @public
+ */
+export interface IKoalaSignFunction
+  extends ISignFunction,
+    ICommonKoalaFunctions {}
+
+export interface IKoalaConnectOrStatusResponse {
+  status: KoalaStatus;
+  message?: string;
+  account?: {
+    account: string;
+    publicKey: string;
+    connectedSites: string[];
+  };
+}
+
+export interface IKoalaSignResponse {
+  status: KoalaStatus;
+  signedCmd: ICommand;
+}
+
+export interface IKoalaQuicksignSuccessResponse {
+  status: 'success';
+  quickSignData: IQuicksignResponseOutcomes['responses'];
+}
+
+export interface IKoalaQuicksignFailResponse {
+  status: 'fail';
+  error: string;
+}
+
+export type IKoalaQuicksignResponse =
+  | IKoalaQuicksignSuccessResponse
+  | IKoalaQuicksignFailResponse;
+
+export interface IKoalaAccountsResponse {
+  status: KoalaStatus;
+  message?: string;
+  wallet?: {
+    account: string;
+    publicKey: string;
+    connectedSites: string[];
+    balance: number;
+  };
+}

--- a/packages/libs/client/src/signing/koalaWallet/quicksignWithKoalaWallet.ts
+++ b/packages/libs/client/src/signing/koalaWallet/quicksignWithKoalaWallet.ts
@@ -1,0 +1,85 @@
+import type { ICommand, IUnsignedCommand } from '@kadena/types';
+import { addSignatures } from '../utils/addSignatures';
+import { parseTransactionCommand } from '../utils/parseTransactionCommand';
+import { connect, isConnected, isInstalled } from './koalaCommon';
+import type { IKoalaQuicksignResponse, IKoalaSignFunction } from './koalaTypes';
+
+/**
+ * Creates the quicksignWithWalletConnect function with interface {@link ISingleSignFunction}
+ *
+ * @public
+ */
+export function createKoalaWalletQuicksign(): IKoalaSignFunction {
+  const quicksignWithKoalaWallet: IKoalaSignFunction = (async (
+    transactionList: IUnsignedCommand | Array<IUnsignedCommand | ICommand>,
+  ) => {
+    if (transactionList === undefined) {
+      throw new Error('No transaction(s) to sign');
+    }
+    const isList = Array.isArray(transactionList);
+    const transactions = isList ? transactionList : [transactionList];
+
+    const transactionHashes: string[] = [];
+
+    const { networkId } = parseTransactionCommand(transactions[0]);
+
+    const commandSigDatas = transactions.map((pactCommand) => {
+      const { cmd, hash } = pactCommand;
+      const parsedTransaction = parseTransactionCommand(pactCommand);
+      transactionHashes.push(hash);
+
+      if (networkId !== parsedTransaction.networkId) {
+        throw new Error('Network is not equal for all transactions');
+      }
+
+      return {
+        cmd,
+        sigs: parsedTransaction.signers.map((signer, i) => ({
+          pubKey: signer.pubKey,
+          sig: pactCommand.sigs[i]?.sig ?? null,
+        })),
+      };
+    });
+
+    const koalaResponse = await window.koala?.request<IKoalaQuicksignResponse>({
+      method: 'kda_requestQuickSign',
+      data: {
+        networkId,
+        commandSigDatas,
+      },
+    });
+
+    if (!koalaResponse || koalaResponse?.status === 'fail') {
+      throw new Error('Error signing transaction');
+    }
+
+    if ('quickSignData' in koalaResponse) {
+      koalaResponse.quickSignData.map((signedCommand, i) => {
+        if (signedCommand.outcome.result === 'success') {
+          if (signedCommand.outcome.hash !== transactionHashes[i]) {
+            throw new Error(
+              `Hash of the transaction signed by the wallet does not match. Our hash: ${transactionHashes[i]}, wallet hash: ${signedCommand.outcome.hash}`,
+            );
+          }
+
+          const sigs = signedCommand.commandSigData.sigs.filter(
+            (sig) => sig.sig !== null,
+          ) as { pubKey: string; sig: string }[];
+
+          // Add the signature(s) that we received from the wallet to the PactCommand(s)
+          transactions[i] = addSignatures(transactions[i], ...sigs);
+        }
+      });
+    } else {
+      throw new Error('Error signing transaction');
+    }
+
+    return isList ? transactions : transactions[0];
+  }) as IKoalaSignFunction;
+
+  quicksignWithKoalaWallet.isInstalled = isInstalled;
+  quicksignWithKoalaWallet.isConnected = isConnected;
+  quicksignWithKoalaWallet.connect = connect;
+
+  return quicksignWithKoalaWallet;
+}

--- a/packages/libs/client/src/signing/koalaWallet/quicksignWithKoalaWallet.ts
+++ b/packages/libs/client/src/signing/koalaWallet/quicksignWithKoalaWallet.ts
@@ -5,7 +5,7 @@ import { connect, isConnected, isInstalled } from './koalaCommon';
 import type { IKoalaQuicksignResponse, IKoalaSignFunction } from './koalaTypes';
 
 /**
- * Creates the quicksignWithWalletConnect function with interface {@link ISingleSignFunction}
+ * Creates the quicksignWithKoalaWallet function with interface {@link ISingleSignFunction}
  *
  * @public
  */

--- a/packages/libs/client/src/signing/koalaWallet/signWithKoalaWallet.ts
+++ b/packages/libs/client/src/signing/koalaWallet/signWithKoalaWallet.ts
@@ -1,0 +1,55 @@
+import { pactCommandToSigningRequest } from '../utils/pactCommandToSigningRequest';
+import { parseTransactionCommand } from '../utils/parseTransactionCommand';
+import { connect, isConnected, isInstalled } from './koalaCommon';
+import type {
+  IKoalaSignResponse,
+  IKoalaSignSingleFunction,
+} from './koalaTypes';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  interface Window {
+    koala?: {
+      isKadena: boolean;
+      isKoala: boolean;
+      request<T>(args: unknown): Promise<T>;
+    };
+  }
+}
+
+/**
+ * Creates the signWithKoalaWallet function with interface {@link ISingleSignFunction}
+ *
+ * @remarks
+ * It is preferred to use the {@link createKoalaWalletQuicksign} function
+ *
+ * @public
+ */
+export function createKoalaWalletSign(): IKoalaSignSingleFunction {
+  const signWithKoalaWallet: IKoalaSignSingleFunction = async (transaction) => {
+    const parsedTransaction = parseTransactionCommand(transaction);
+    const signingRequest = pactCommandToSigningRequest(parsedTransaction);
+
+    await connect(parsedTransaction.networkId);
+
+    const response = await window.koala?.request<IKoalaSignResponse>({
+      method: 'kda_requestSign',
+      data: {
+        networkId: parsedTransaction.networkId,
+        signingCmd: signingRequest,
+      },
+    });
+
+    if (response?.signedCmd === undefined) {
+      throw new Error('Error signing transaction');
+    }
+
+    return response.signedCmd;
+  };
+
+  signWithKoalaWallet.isInstalled = isInstalled;
+  signWithKoalaWallet.isConnected = isConnected;
+  signWithKoalaWallet.connect = connect;
+
+  return signWithKoalaWallet;
+}

--- a/packages/libs/client/src/signing/koalaWallet/tests/koalaCommon.test.ts
+++ b/packages/libs/client/src/signing/koalaWallet/tests/koalaCommon.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+/** @vitest-environment jsdom */
+
+import { connect, isConnected, isInstalled } from '../koalaCommon';
+
+import { TextDecoder, TextEncoder } from 'util';
+
+Object.assign(global, { TextDecoder, TextEncoder });
+
+describe('koalaCommon', () => {
+  const mockKoalaRequest = vi.fn();
+
+  Object.defineProperty(window, 'koala', {
+    value: {
+      isKoala: true,
+      isKadena: true,
+      request: mockKoalaRequest,
+    },
+    writable: true,
+  });
+
+  beforeEach(() => {
+    if (window.koala) window.koala.isKoala = true;
+    mockKoalaRequest.mockReset();
+  });
+
+  describe('isInstalled()', () => {
+    it('returns true when Koala Wallet is installed', () => {
+      const result = isInstalled();
+
+      expect(result).toBeTruthy();
+    });
+
+    it('returns false when Koala Wallet is NOT installed', () => {
+      if (window.koala) window.koala.isKoala = false;
+
+      const result = isInstalled();
+
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe('isConnected()', () => {
+    it('returns false when Koala Wallet is not installed', async () => {
+      if (window.koala) window.koala.isKoala = false;
+
+      const result = await isConnected('testnet04');
+
+      expect(result).toBeFalsy();
+    });
+
+    it('returns true when already connected', async () => {
+      // mock kda_checkStatus
+      mockKoalaRequest.mockResolvedValueOnce({
+        status: 'success',
+      });
+
+      const result = await isConnected('testnet04');
+
+      expect(result).toBeTruthy();
+    });
+  });
+
+  describe('connect()', () => {
+    it('throws when Koala Wallet is not installed', async () => {
+      if (window.koala) window.koala.isKoala = false;
+
+      try {
+        await connect('testnet04');
+      } catch (e) {
+        expect(e.message).toContain('Koala Wallet is not installed');
+      }
+    });
+
+    it('returns true when already connected', async () => {
+      // mock kda_checkStatus
+      mockKoalaRequest.mockResolvedValueOnce({
+        status: 'success',
+      });
+
+      const result = await connect('testnet04');
+
+      expect(result).toBeTruthy();
+    });
+
+    it('connects when not connected yet', async () => {
+      // mock kda_checkStatus
+      mockKoalaRequest.mockResolvedValueOnce({
+        status: 'fail',
+      });
+
+      // mock kda_connect
+      mockKoalaRequest.mockResolvedValueOnce({
+        status: 'success',
+      });
+
+      const result = await connect('testnet04');
+
+      expect(mockKoalaRequest).toHaveBeenCalledWith({
+        method: 'kda_checkStatus',
+        networkId: 'testnet04',
+      });
+
+      expect(mockKoalaRequest).toHaveBeenCalledWith({
+        method: 'kda_connect',
+        networkId: 'testnet04',
+      });
+
+      expect(result).toBeTruthy();
+    });
+
+    it('throws when the user declines the connection', async () => {
+      // mock kda_checkStatus
+      mockKoalaRequest.mockResolvedValueOnce({
+        status: 'fail',
+      });
+
+      // mock kda_connect
+      mockKoalaRequest.mockResolvedValueOnce({
+        status: 'fail',
+      });
+
+      try {
+        await connect('testnet04');
+      } catch (e) {
+        expect(e.message).toContain('User declined connection');
+      }
+    });
+  });
+});

--- a/packages/libs/client/src/signing/koalaWallet/tests/quicksignWithKoalaWallet.test.ts
+++ b/packages/libs/client/src/signing/koalaWallet/tests/quicksignWithKoalaWallet.test.ts
@@ -1,0 +1,323 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+/** @vitest-environment jsdom */
+
+import type { IPactCommand } from '../../../interfaces/IPactCommand';
+import { createTransaction } from '../../../utils/createTransaction';
+import { createKoalaWalletQuicksign } from '../quicksignWithKoalaWallet';
+
+import { TextDecoder, TextEncoder } from 'util';
+
+Object.assign(global, { TextDecoder, TextEncoder });
+
+describe('quicksignWithKoalaWallet', () => {
+  const getTransaction = (): IPactCommand => ({
+    payload: {
+      exec: {
+        code: '(coin.transfer "bonnie" "clyde" 1)',
+        data: { 'test-data': 'test-data' },
+      },
+    },
+    meta: {
+      chainId: '1',
+      gasLimit: 10000,
+      gasPrice: 1e-8,
+      sender: 'test-sender',
+      ttl: 30 * 6,
+      creationTime: 1234,
+    },
+    signers: [
+      {
+        clist: [
+          {
+            name: 'test-cap-name',
+            args: ['test-cap-arg'],
+          },
+        ],
+        pubKey: 'test-pub-key',
+      },
+    ],
+    networkId: 'testnet-id',
+    nonce: '',
+  });
+
+  const mockKoalaRequest = vi.fn();
+
+  Object.defineProperty(window, 'koala', {
+    value: {
+      isKoala: true,
+      isKadena: true,
+      request: mockKoalaRequest,
+    },
+    writable: true,
+  });
+
+  beforeEach(() => {
+    mockKoalaRequest.mockReset();
+  });
+
+  afterAll(() => {
+    mockKoalaRequest.mockRestore();
+  });
+
+  it('throws when no transactions are passed', async () => {
+    const quicksignWithKoalaWallet = createKoalaWalletQuicksign();
+
+    // @ts-expect-error - Expected 1 arguments, but got 0.
+    await expect(() => quicksignWithKoalaWallet()).rejects.toThrowError(
+      'No transaction(s) to sign',
+    );
+  });
+
+  it('signs a transaction', async () => {
+    mockKoalaRequest.mockResolvedValue({
+      status: 'success',
+      quickSignData: [
+        {
+          outcome: {
+            result: 'success',
+            hash: 'test-hash',
+          },
+          commandSigData: {
+            cmd: 'test-cmd',
+            sigs: [
+              {
+                caps: [
+                  {
+                    args: ['test-cap-arg'],
+                    name: 'test-cap-name',
+                  },
+                ],
+                pubKey: 'test-pub-key',
+                sig: 'test-sig',
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const quicksignWithKoalaWallet = createKoalaWalletQuicksign();
+    const transaction = getTransaction();
+    const unsignedTransaction = createTransaction(transaction);
+    unsignedTransaction.hash = 'test-hash';
+    const result = await quicksignWithKoalaWallet(unsignedTransaction);
+
+    expect(window.koala?.request).toHaveBeenCalledWith({
+      method: 'kda_requestQuickSign',
+      data: {
+        networkId: 'testnet-id',
+        commandSigDatas: [
+          {
+            cmd: '{"payload":{"exec":{"code":"(coin.transfer \\"bonnie\\" \\"clyde\\" 1)","data":{"test-data":"test-data"}}},"meta":{"chainId":"1","gasLimit":10000,"gasPrice":1e-8,"sender":"test-sender","ttl":180,"creationTime":1234},"signers":[{"clist":[{"name":"test-cap-name","args":["test-cap-arg"]}],"pubKey":"test-pub-key"}],"networkId":"testnet-id","nonce":""}',
+            sigs: [
+              {
+                pubKey: 'test-pub-key',
+                sig: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual({
+      cmd: '{"payload":{"exec":{"code":"(coin.transfer \\"bonnie\\" \\"clyde\\" 1)","data":{"test-data":"test-data"}}},"meta":{"chainId":"1","gasLimit":10000,"gasPrice":1e-8,"sender":"test-sender","ttl":180,"creationTime":1234},"signers":[{"clist":[{"name":"test-cap-name","args":["test-cap-arg"]}],"pubKey":"test-pub-key"}],"networkId":"testnet-id","nonce":""}',
+      hash: 'test-hash',
+      sigs: [{ sig: 'test-sig' }],
+    });
+  });
+
+  it('signs multiple transactions', async () => {
+    mockKoalaRequest.mockResolvedValue({
+      status: 'success',
+      quickSignData: [
+        {
+          outcome: {
+            result: 'success',
+            hash: 'test-hash',
+          },
+          commandSigData: {
+            cmd: 'test-cmd',
+            sigs: [
+              {
+                caps: [
+                  {
+                    args: ['test-cap-arg'],
+                    name: 'test-cap-name',
+                  },
+                ],
+                pubKey: 'test-pub-key',
+                sig: 'test-sig',
+              },
+            ],
+          },
+        },
+        {
+          outcome: {
+            result: 'success',
+            hash: 'test-hash-2',
+          },
+          commandSigData: {
+            cmd: 'test-cmd-2',
+            sigs: [
+              {
+                caps: [
+                  {
+                    args: ['test-cap-arg'],
+                    name: 'test-cap-name',
+                  },
+                ],
+                pubKey: 'test-pub-key-2',
+                sig: 'test-sig-2',
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const quicksignWithKoalaWallet = createKoalaWalletQuicksign();
+    const transaction = getTransaction();
+    const unsignedTransactions = [
+      createTransaction(transaction),
+      createTransaction({
+        ...getTransaction(),
+        signers: [
+          {
+            clist: [
+              {
+                name: 'test-cap-name',
+                args: ['test-cap-arg'],
+              },
+            ],
+            pubKey: 'test-pub-key-2',
+          },
+        ],
+      }),
+    ];
+    unsignedTransactions[0].hash = 'test-hash';
+    unsignedTransactions[1].hash = 'test-hash-2';
+    const result = await quicksignWithKoalaWallet(unsignedTransactions);
+
+    expect(window.koala?.request).toHaveBeenCalledWith({
+      method: 'kda_requestQuickSign',
+      data: {
+        networkId: 'testnet-id',
+        commandSigDatas: [
+          {
+            cmd: '{"payload":{"exec":{"code":"(coin.transfer \\"bonnie\\" \\"clyde\\" 1)","data":{"test-data":"test-data"}}},"meta":{"chainId":"1","gasLimit":10000,"gasPrice":1e-8,"sender":"test-sender","ttl":180,"creationTime":1234},"signers":[{"clist":[{"name":"test-cap-name","args":["test-cap-arg"]}],"pubKey":"test-pub-key"}],"networkId":"testnet-id","nonce":""}',
+            sigs: [
+              {
+                pubKey: 'test-pub-key',
+                sig: null,
+              },
+            ],
+          },
+          {
+            cmd: '{"payload":{"exec":{"code":"(coin.transfer \\"bonnie\\" \\"clyde\\" 1)","data":{"test-data":"test-data"}}},"meta":{"chainId":"1","gasLimit":10000,"gasPrice":1e-8,"sender":"test-sender","ttl":180,"creationTime":1234},"signers":[{"clist":[{"name":"test-cap-name","args":["test-cap-arg"]}],"pubKey":"test-pub-key-2"}],"networkId":"testnet-id","nonce":""}',
+            sigs: [
+              {
+                pubKey: 'test-pub-key-2',
+                sig: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(result).toEqual([
+      {
+        cmd: '{"payload":{"exec":{"code":"(coin.transfer \\"bonnie\\" \\"clyde\\" 1)","data":{"test-data":"test-data"}}},"meta":{"chainId":"1","gasLimit":10000,"gasPrice":1e-8,"sender":"test-sender","ttl":180,"creationTime":1234},"signers":[{"clist":[{"name":"test-cap-name","args":["test-cap-arg"]}],"pubKey":"test-pub-key"}],"networkId":"testnet-id","nonce":""}',
+        hash: 'test-hash',
+        sigs: [{ sig: 'test-sig' }],
+      },
+      {
+        cmd: '{"payload":{"exec":{"code":"(coin.transfer \\"bonnie\\" \\"clyde\\" 1)","data":{"test-data":"test-data"}}},"meta":{"chainId":"1","gasLimit":10000,"gasPrice":1e-8,"sender":"test-sender","ttl":180,"creationTime":1234},"signers":[{"clist":[{"name":"test-cap-name","args":["test-cap-arg"]}],"pubKey":"test-pub-key-2"}],"networkId":"testnet-id","nonce":""}',
+        hash: 'test-hash-2',
+        sigs: [{ sig: 'test-sig-2' }],
+      },
+    ]);
+  });
+
+  it('throws when there is no signing response', async () => {
+    const quicksignWithKoalaWallet = createKoalaWalletQuicksign();
+    const transaction = getTransaction();
+
+    await expect(() =>
+      quicksignWithKoalaWallet(createTransaction(transaction)),
+    ).rejects.toThrowError('Error signing transaction');
+  });
+
+  it('throws when there is no quickSignData in the response from Koala', async () => {
+    mockKoalaRequest.mockResolvedValue({
+      status: 'success',
+    });
+
+    const quicksignWithKoalaWallet = createKoalaWalletQuicksign();
+    const transaction = getTransaction();
+    const unsignedTransaction = createTransaction(transaction);
+
+    await expect(() =>
+      quicksignWithKoalaWallet(unsignedTransaction),
+    ).rejects.toThrowError('Error signing transaction');
+  });
+
+  it('throws when there are no responses', async () => {
+    const quicksignWithKoalaWallet = createKoalaWalletQuicksign();
+    const transaction = getTransaction();
+    await expect(() =>
+      quicksignWithKoalaWallet(createTransaction(transaction)),
+    ).rejects.toThrowError('Error signing transaction');
+  });
+
+  it('throws when the hash of the unsigned and signed transaction do not match', async () => {
+    mockKoalaRequest.mockResolvedValue({
+      status: 'success',
+      quickSignData: [
+        {
+          outcome: {
+            result: 'success',
+            hash: 'test-hash-different',
+          },
+          commandSigData: {
+            cmd: 'test-cmd',
+            sigs: [
+              {
+                caps: [
+                  {
+                    args: ['test-cap-arg'],
+                    name: 'test-cap-name',
+                  },
+                ],
+                pubKey: 'test-pub-key',
+                sig: 'test-sig',
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const quicksignWithKoalaWallet = createKoalaWalletQuicksign();
+    const transaction = getTransaction();
+
+    await expect(() =>
+      quicksignWithKoalaWallet(createTransaction(transaction)),
+    ).rejects.toThrowError(
+      'Hash of the transaction signed by the wallet does not match. Our hash',
+    );
+  });
+
+  it('throws when the networks of the transactions are not the same', async () => {
+    const quicksignWithKoalaWallet = createKoalaWalletQuicksign();
+    const transaction = getTransaction();
+
+    await expect(() =>
+      quicksignWithKoalaWallet([
+        createTransaction(transaction),
+        createTransaction({ ...transaction, networkId: 'testnet-id-2' }),
+      ]),
+    ).rejects.toThrowError('Network is not equal for all transactions');
+  });
+});

--- a/packages/libs/client/src/signing/koalaWallet/tests/signWithKoalaWallet.test.ts
+++ b/packages/libs/client/src/signing/koalaWallet/tests/signWithKoalaWallet.test.ts
@@ -1,0 +1,168 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+/** @vitest-environment jsdom */
+
+import type {
+  IExecutionPayloadObject,
+  IPactCommand,
+} from '../../../interfaces/IPactCommand';
+import { createTransaction } from '../../../utils/createTransaction';
+import { createKoalaWalletSign } from '../signWithKoalaWallet';
+
+import { TextDecoder, TextEncoder } from 'util';
+
+type Transaction = IPactCommand & { payload: IExecutionPayloadObject };
+
+Object.assign(global, { TextDecoder, TextEncoder });
+
+describe('signWithKoalaWallet', () => {
+  const getTransaction = (): Transaction => ({
+    payload: {
+      exec: {
+        code: '(coin.transfer "bonnie" "clyde" 1)',
+        data: {
+          test: 'test-data',
+        },
+      },
+    },
+    meta: {
+      chainId: '0',
+      gasLimit: 2300,
+      gasPrice: 0.00000001,
+      sender: 'test-sender',
+      ttl: 3600,
+      creationTime: 123456789,
+    },
+    signers: [
+      {
+        pubKey: '',
+        clist: [
+          {
+            name: 'cap.test-cap-name',
+            args: ['test-cap-arg'],
+          },
+        ],
+      },
+    ],
+    networkId: 'test-network-id',
+    nonce: 'kjs-test',
+  });
+
+  const mockKoalaRequest = vi.fn();
+
+  Object.defineProperty(window, 'koala', {
+    value: {
+      isKadena: true,
+      isKoala: true,
+      request: mockKoalaRequest,
+    },
+    writable: true,
+  });
+
+  beforeEach(() => {
+    mockKoalaRequest.mockReset();
+  });
+
+  afterAll(() => {
+    mockKoalaRequest.mockRestore();
+  });
+
+  it('signs a transaction', async () => {
+    mockKoalaRequest.mockResolvedValue({
+      status: 'success',
+      signedCmd: { cmd: 'test-cmd', sigs: [{ sig: 'test-sig' }] },
+    });
+
+    const signWithKoalaWallet = createKoalaWalletSign();
+    const transaction = getTransaction();
+    const signedTransaction = await signWithKoalaWallet(
+      createTransaction(transaction),
+    );
+
+    expect(mockKoalaRequest).toHaveBeenCalledWith({
+      method: 'kda_requestSign',
+      data: {
+        networkId: 'test-network-id',
+        signingCmd: {
+          code: transaction.payload.exec.code,
+          data: transaction.payload.exec.data,
+          caps: [
+            {
+              role: 'test-cap-name',
+              description: 'Description for cap.test-cap-name',
+              cap: {
+                name: 'cap.test-cap-name',
+                args: ['test-cap-arg'],
+              },
+            },
+          ],
+          nonce: transaction.nonce,
+          chainId: transaction.meta.chainId,
+          gasLimit: transaction.meta.gasLimit,
+          gasPrice: transaction.meta.gasPrice,
+          sender: transaction.meta.sender,
+          ttl: transaction.meta.ttl,
+        },
+      },
+    });
+
+    expect(signedTransaction.cmd).toBe('test-cmd');
+
+    expect(signedTransaction).toEqual({
+      cmd: 'test-cmd',
+      sigs: [{ sig: 'test-sig' }],
+    });
+  });
+
+  it('throws when there is no signing response', async () => {
+    const signWithKoalaWallet = createKoalaWalletSign();
+
+    const transaction = getTransaction();
+    //@ts-expect-error The operand of a 'delete' operator must be optional.
+    delete transaction.payload.exec;
+
+    await expect(() =>
+      signWithKoalaWallet(createTransaction(transaction)),
+    ).rejects.toThrowError('`cont` transactions are not supported');
+  });
+
+  it('adds an empty clist when signer.clist is undefined', async () => {
+    mockKoalaRequest.mockResolvedValue({
+      status: 'success',
+      signedCmd: { cmd: 'test-cmd', sigs: [{ sig: 'test-sig' }] },
+    });
+
+    const signWithKoalaWallet = createKoalaWalletSign();
+
+    const transaction = getTransaction();
+    delete transaction.signers[0].clist;
+
+    await signWithKoalaWallet(createTransaction(transaction));
+
+    expect(window.koala?.request).toHaveBeenCalledWith({
+      method: 'kda_requestSign',
+      data: {
+        networkId: 'test-network-id',
+        signingCmd: {
+          code: transaction.payload.exec.code,
+          data: transaction.payload.exec.data,
+          caps: [],
+          nonce: transaction.nonce,
+          chainId: transaction.meta.chainId,
+          gasLimit: transaction.meta.gasLimit,
+          gasPrice: transaction.meta.gasPrice,
+          sender: transaction.meta.sender,
+          ttl: transaction.meta.ttl,
+        },
+      },
+    });
+  });
+
+  it('throws when signing cont command', async () => {
+    const transaction = getTransaction();
+    const signWithKoalaWallet = createKoalaWalletSign();
+
+    await expect(() =>
+      signWithKoalaWallet(createTransaction(transaction)),
+    ).rejects.toThrowError('Error signing transaction');
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->
A copy of `eckoWallet` with all types and methods renamed to `Koala` using `window.koala` instead of `window.kadena`