### PR TITLE
Add a new line in packages.json

### DIFF
--- a/.changeset/gentle-plants-judge.md
+++ b/.changeset/gentle-plants-judge.md
@@ -1,0 +1,6 @@
+---
+'@kadena-dev/scripts': patch
+---
+
+Fix generate packages json to include new line as the last line. This fixes
+linting errors on build

--- a/packages/tools/scripts/generate-packages-json.ts
+++ b/packages/tools/scripts/generate-packages-json.ts
@@ -38,7 +38,7 @@ const main = async () => {
 
   await fs.writeFile(
     join(baseDir, 'packages.json'),
-    JSON.stringify(packages, null, 2),
+    JSON.stringify(packages, null, 2) + '\n',
   );
 };
 


### PR DESCRIPTION
Whenever the release workflow is triggered one of two things can happen:

1. A Pull Request `[CI] Release ` is created, waiting to be merged.
2. All pending packages are published to the NPM registry.


This PR solves an issue in the first case. When creating the PR the workflow automatically also formats the root of the monorepo and bumps versions in the `packages.json`.  This currently leads to an issue where the build for the aforementioned pull request fails because it does not adhere to linting standards.  These standards require all JSON files to end with an empty line.

This PR adds an empty line at the end of the packages.json when bumping the versions.