### PR TITLE
feat(client): extract capability type from string codes

### DIFF
--- a/.changeset/nine-toys-remain.md
+++ b/.changeset/nine-toys-remain.md
@@ -1,0 +1,5 @@
+---
+'@kadena/client': minor
+---
+
+Extract capability type from pure string pact code

--- a/packages/libs/client/src/composePactCommand/utils/payload.ts
+++ b/packages/libs/client/src/composePactCommand/utils/payload.ts
@@ -3,6 +3,14 @@ import type {
   IContinuationPayloadObject,
   IExecutionPayloadObject,
 } from '../../interfaces/IPactCommand';
+import type { ExtractPactModule } from '../../interfaces/type-utilities';
+
+export type AddCapabilities<T> = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [K in keyof T]: T[K] extends { capability: any }
+    ? T[K]
+    : ExtractPactModule<T[K]>;
+};
 
 interface IExec {
   <
@@ -16,7 +24,7 @@ interface IExec {
     ...codes: [...TCodes]
   ): {
     payload: { exec: Required<IExecutionPayloadObject['exec']> } & {
-      funs: [...TCodes];
+      funs: AddCapabilities<[...TCodes]>;
     };
   };
 }

--- a/packages/libs/client/src/createTransactionBuilder/createTransactionBuilder.ts
+++ b/packages/libs/client/src/createTransactionBuilder/createTransactionBuilder.ts
@@ -13,6 +13,7 @@ import {
 import type { ValidDataTypes } from '../composePactCommand/utils/addData';
 import type { ISigner } from '../composePactCommand/utils/addSigner';
 import { patchCommand } from '../composePactCommand/utils/patchCommand';
+import type { AddCapabilities } from '../composePactCommand/utils/payload';
 import type {
   IContinuationPayloadObject,
   IPactCommand,
@@ -200,7 +201,9 @@ interface IExecution {
     >,
   >(
     ...codes: [...TCodes]
-  ): IBuilder<{ payload: IExecPayload & { funs: [...TCodes] } }>;
+  ): IBuilder<{
+    payload: IExecPayload & { funs: AddCapabilities<[...TCodes]> };
+  }>;
 }
 
 /**


### PR DESCRIPTION
Using Pact.module is the recommended way for creating pact code, however using just a string is valid as well and in some scenarios is more convenient.

execution already accepts pure strings but with this update execution function can also extract capability types from the pure string codes - of course you still need to install the contract type.

```TS
const transaction = Pact.builder
    .execution(
       `(coin.transfer ${sender} ${receiver} ${amount})`
    )
    .addSigner(keyFromAccount(sender), (withCapability) => [
      withCapability('coin.GAS'),
      // this type infers from the string code
      withCapability('coin.TRANSFER', sender, receiver, amount),
    ])
    .setMeta({ chainId: '0', senderAccount: sender })
    .setNetworkId(NETWORK_ID)
    .createTransaction();
```   

this can be used with Pact.modules
```TS
const transaction = Pact.builder
    .execution(
       `(coin.transfer ${sender} ${receiver} ${amount})`,
       Pact.modules["free.my-module"]["my-function"](...),
    )
```