### PR TITLE
feat: adds support for a custom Chainweaver url for signWithChainweaver

### DIFF
--- a/.changeset/tender-schools-sip.md
+++ b/.changeset/tender-schools-sip.md
@@ -1,0 +1,5 @@
+---
+'@kadena/client': minor
+---
+
+Adds support for a custom url to signWithChainweaver

--- a/.changeset/tender-schools-sip.md
+++ b/.changeset/tender-schools-sip.md
@@ -1,5 +1,5 @@
 ---
-'@kadena/client': major
+'@kadena/client': minor
 ---
 
 Adds support for a custom url to signWithChainweaver

--- a/.changeset/tender-schools-sip.md
+++ b/.changeset/tender-schools-sip.md
@@ -1,5 +1,5 @@
 ---
-'@kadena/client': minor
+'@kadena/client': major
 ---
 
 Adds support for a custom url to signWithChainweaver

--- a/packages/libs/client-utils/src/example-contract/use-coin.ts
+++ b/packages/libs/client-utils/src/example-contract/use-coin.ts
@@ -1,8 +1,9 @@
-import { signWithChainweaver } from '@kadena/client';
+import { createSignWithChainweaver } from '@kadena/client';
 
 import { createAccount } from '../coin/create-account';
 
 export async function consumer() {
+  const signWithChainweaver = createSignWithChainweaver();
   const result = await createAccount(
     {
       account: 'javad',

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -39,7 +39,7 @@ export function createEckoWalletSign(): IEckoSignSingleFunction;
 
 // @public
 export function createSignWithChainweaver(options?: {
-    chainweaverUrl: string;
+    host: string;
 }): ISignFunction;
 
 // @public

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -38,7 +38,9 @@ export function createEckoWalletQuicksign(): IEckoSignFunction;
 export function createEckoWalletSign(): IEckoSignSingleFunction;
 
 // @public
-export function createSignWithChainweaver(chainweaverUrl?: string): ISignFunction;
+export function createSignWithChainweaver(options?: {
+    chainweaverUrl: string;
+}): ISignFunction;
 
 // @public
 export const createSignWithKeypair: ICreateSignWithKeypair;
@@ -406,6 +408,14 @@ export type PactReturnType<T extends (...args: any[]) => any> = T extends (...ar
 
 // @public
 export const readKeyset: (key: string) => () => string;
+
+// Warning: (ae-internal-missing-underscore) The name "signTransactions" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export const signTransactions: (chainweaverUrl: string) => ISignFunction;
+
+// @public @deprecated
+export const signWithChainweaver: ISignFunction;
 
 // @public
 export type TWalletConnectChainId = `kadena:${IPactCommand['networkId']}`;

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -38,6 +38,9 @@ export function createEckoWalletQuicksign(): IEckoSignFunction;
 export function createEckoWalletSign(): IEckoSignSingleFunction;
 
 // @public
+export function createSignWithChainweaver(chainweaverUrl?: string): ISignFunction;
+
+// @public
 export const createSignWithKeypair: ICreateSignWithKeypair;
 
 // @public
@@ -403,9 +406,6 @@ export type PactReturnType<T extends (...args: any[]) => any> = T extends (...ar
 
 // @public
 export const readKeyset: (key: string) => () => string;
-
-// @public
-export const signWithChainweaver: ISignFunction;
 
 // @public
 export type TWalletConnectChainId = `kadena:${IPactCommand['networkId']}`;

--- a/packages/libs/client/src/signing/chainweaver/signWithChainweaver.ts
+++ b/packages/libs/client/src/signing/chainweaver/signWithChainweaver.ts
@@ -13,7 +13,12 @@ import { parseTransactionCommand } from '../utils/parseTransactionCommand';
 
 const debug: Debugger = _debug('pactjs:signWithChainweaver');
 
-export const doSign = (chainweaverUrl: string) =>
+/**
+ *
+ * @internal
+ *
+ */
+export const signTransactions = (chainweaverUrl: string) =>
   (async (
     transactionList: IUnsignedCommand | Array<IUnsignedCommand | ICommand>,
   ) => {
@@ -80,11 +85,15 @@ export const doSign = (chainweaverUrl: string) =>
     }
   }) as ISignFunction;
 
-export const signWithChainweaver: ISignFunction = async (
-  transactionList: IUnsignedCommand | Array<IUnsignedCommand | ICommand>,
-) => {
-  return doSign('http://127.0.0.1:9467')(transactionList);
-};
+/**
+ * * Lets you sign with chainweaver according to {@link https://github.com/kadena-io/KIPs/blob/master/kip-0015.md | sign-v1 API}
+ *
+ * @deprecated Use {@link createSignWithChainweaver} instead
+ * @public
+ */
+export const signWithChainweaver: ISignFunction = signTransactions(
+  'http://127.0.0.1:9467',
+);
 
 /**
  * Creates the signWithChainweaver function with interface {@link ISignFunction}
@@ -96,7 +105,7 @@ export function createSignWithChainweaver(
   options = { chainweaverUrl: 'http://127.0.0.1:9467' },
 ): ISignFunction {
   const { chainweaverUrl } = options;
-  const signWithChainweaver = doSign(chainweaverUrl);
+  const signWithChainweaver = signTransactions(chainweaverUrl);
 
   return signWithChainweaver;
 }

--- a/packages/libs/client/src/signing/chainweaver/signWithChainweaver.ts
+++ b/packages/libs/client/src/signing/chainweaver/signWithChainweaver.ts
@@ -102,12 +102,13 @@ export const signWithChainweaver: ISignFunction = signTransactions(
  * @param options - object to customize behaviour.
  *   - `host: string` - the host of the chainweaver instance to use. Defaults to `http://127.0.0.1:9467`
  * @returns - {@link ISignFunction}
+ * @public
  */
 export function createSignWithChainweaver(
   options = { host: 'http://127.0.0.1:9467' },
 ): ISignFunction {
-  const { chainweaverUrl } = options;
-  const signWithChainweaver = signTransactions(chainweaverUrl);
+  const { host } = options;
+  const signWithChainweaver = signTransactions(host);
 
   return signWithChainweaver;
 }

--- a/packages/libs/client/src/signing/chainweaver/signWithChainweaver.ts
+++ b/packages/libs/client/src/signing/chainweaver/signWithChainweaver.ts
@@ -97,12 +97,14 @@ export const signWithChainweaver: ISignFunction = signTransactions(
 
 /**
  * Creates the signWithChainweaver function with interface {@link ISignFunction}
- * Lets you sign with chainweaver according to {@link https://github.com/kadena-io/KIPs/blob/master/kip-0015.md | sign-v1 API}
+ * Lets you sign with Chainweaver according to {@link https://github.com/kadena-io/KIPs/blob/master/kip-0015.md | sign-v1 API}
  *
- * @public
+ * @param options - object to customize behaviour.
+ *   - `host: string` - the host of the chainweaver instance to use. Defaults to `http://127.0.0.1:9467`
+ * @returns - {@link ISignFunction}
  */
 export function createSignWithChainweaver(
-  options = { chainweaverUrl: 'http://127.0.0.1:9467' },
+  options = { host: 'http://127.0.0.1:9467' },
 ): ISignFunction {
   const { chainweaverUrl } = options;
   const signWithChainweaver = signTransactions(chainweaverUrl);

--- a/packages/libs/client/src/signing/chainweaver/signWithChainweaver.ts
+++ b/packages/libs/client/src/signing/chainweaver/signWithChainweaver.ts
@@ -13,16 +13,8 @@ import { parseTransactionCommand } from '../utils/parseTransactionCommand';
 
 const debug: Debugger = _debug('pactjs:signWithChainweaver');
 
-/**
- * Creates the signWithChainweaver function with interface {@link ISignFunction}
- * Lets you sign with chainweaver according to {@link https://github.com/kadena-io/KIPs/blob/master/kip-0015.md | sign-v1 API}
- *
- * @public
- */
-export function createSignWithChainweaver(
-  chainweaverUrl = 'http://127.0.0.1:9467',
-): ISignFunction {
-  const signWithChainweaver: ISignFunction = (async (
+export const doSign = (chainweaverUrl: string) =>
+  (async (
     transactionList: IUnsignedCommand | Array<IUnsignedCommand | ICommand>,
   ) => {
     if (transactionList === undefined) {
@@ -87,6 +79,24 @@ export function createSignWithChainweaver(
       );
     }
   }) as ISignFunction;
+
+export const signWithChainweaver: ISignFunction = async (
+  transactionList: IUnsignedCommand | Array<IUnsignedCommand | ICommand>,
+) => {
+  return doSign('http://127.0.0.1:9467')(transactionList);
+};
+
+/**
+ * Creates the signWithChainweaver function with interface {@link ISignFunction}
+ * Lets you sign with chainweaver according to {@link https://github.com/kadena-io/KIPs/blob/master/kip-0015.md | sign-v1 API}
+ *
+ * @public
+ */
+export function createSignWithChainweaver(
+  options = { chainweaverUrl: 'http://127.0.0.1:9467' },
+): ISignFunction {
+  const { chainweaverUrl } = options;
+  const signWithChainweaver = doSign(chainweaverUrl);
 
   return signWithChainweaver;
 }

--- a/packages/libs/client/src/signing/chainweaver/tests/signWithChainweaver.test.ts
+++ b/packages/libs/client/src/signing/chainweaver/tests/signWithChainweaver.test.ts
@@ -5,7 +5,7 @@ import type { ICoin } from '../../../composePactCommand/test/coin-contract';
 import type { IQuicksignResponseOutcomes } from '../../../index';
 import { Pact } from '../../../index';
 import { getModule } from '../../../pact';
-import { signWithChainweaver } from '../signWithChainweaver';
+import { createSignWithChainweaver } from '../signWithChainweaver';
 
 const coin: ICoin = getModule('coin');
 
@@ -34,6 +34,7 @@ const post = (
 describe('signWithChainweaver', () => {
   it('throws an error when nothing is to be signed', async () => {
     try {
+      const signWithChainweaver = createSignWithChainweaver();
       await (signWithChainweaver as (arg: unknown) => {})(undefined);
     } catch (e) {
       expect(e).toBeTruthy();
@@ -46,6 +47,7 @@ describe('signWithChainweaver', () => {
     );
 
     try {
+      const signWithChainweaver = createSignWithChainweaver();
       await (signWithChainweaver as (arg: unknown) => {})([]);
     } catch (e) {
       expect(e).toBeTruthy();
@@ -83,6 +85,7 @@ describe('signWithChainweaver', () => {
       }),
     );
 
+    const signWithChainweaver = createSignWithChainweaver();
     await signWithChainweaver(unsignedTransaction);
   });
 
@@ -118,10 +121,10 @@ describe('signWithChainweaver', () => {
       post('http://my-host.kadena:9467/v1/quicksign', mockedResponse),
     );
 
-    const signedTx = await signWithChainweaver(
-      unsignedTransaction,
+    const signWithChainweaver = createSignWithChainweaver(
       'http://my-host.kadena:9467',
     );
+    const signedTx = await signWithChainweaver(unsignedTransaction);
 
     expect(signedTx.sigs).toStrictEqual([{ sig: 'sig' }]);
   });
@@ -141,6 +144,7 @@ describe('signWithChainweaver', () => {
       .createTransaction();
 
     // expected: throws an error
+    const signWithChainweaver = createSignWithChainweaver();
     await expect(signWithChainweaver(unsignedTransaction)).rejects.toThrow();
   });
 
@@ -195,6 +199,7 @@ describe('signWithChainweaver', () => {
       })
       .createTransaction();
 
+    const signWithChainweaver = createSignWithChainweaver();
     const txWithOneSig = await signWithChainweaver(unsignedTransaction);
 
     expect(txWithOneSig.sigs).toStrictEqual([
@@ -231,6 +236,7 @@ describe('signWithChainweaver', () => {
       .addSigner('gas-signer-pubkey', (withCap) => [withCap('coin.GAS')])
       .createTransaction();
 
+    const signWithChainweaver = createSignWithChainweaver();
     const signedTransaction = await signWithChainweaver(unsignedTransaction);
 
     expect(signedTransaction.sigs).toEqual([undefined]);

--- a/packages/libs/client/src/signing/chainweaver/tests/signWithChainweaver.test.ts
+++ b/packages/libs/client/src/signing/chainweaver/tests/signWithChainweaver.test.ts
@@ -268,7 +268,7 @@ describe('signWithChainweaver', () => {
     );
 
     const signWithChainweaver = createSignWithChainweaver({
-      chainweaverUrl: 'http://my-host.kadena:9467',
+      host: 'http://my-host.kadena:9467',
     });
     const signedTx = await signWithChainweaver(unsignedTransaction);
 


### PR DESCRIPTION
Adds support for adding a custom url for `signWithChainweaver`. 

Closes #1232