### PR TITLE
[chore] return complete response, instead of extracting result status

### DIFF
--- a/packages/libs/client-utils/etc/client-utils-coin.api.md
+++ b/packages/libs/client-utils/etc/client-utils-coin.api.md
@@ -10,12 +10,9 @@ import { ICommandResult } from '@kadena/chainweb-node-client';
 import { ILocalCommandResult } from '@kadena/chainweb-node-client';
 import type { INetworkOptions } from '@kadena/client';
 import type { IPactCommand } from '@kadena/client';
-import { IPactDecimal } from '@kadena/types';
-import { IPactInt } from '@kadena/types';
 import { IPartialPactCommand } from '@kadena/client/lib/interfaces/IPactCommand';
 import type { ISignFunction } from '@kadena/client';
 import { ITransactionDescriptor } from '@kadena/client';
-import { PactValue } from '@kadena/types';
 
 // Warning: (ae-forgotten-export) The symbol "ICreateAccountCommandInput" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "IClientConfig" needs to be exported by the entry point index.d.ts
@@ -34,7 +31,7 @@ data: ITransactionDescriptor;
 }, {
 event: "listen";
 data: ICommandResult;
-}], [], Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>>;
+}], [], Promise<ICommandResult> | Promise<undefined>>;
 
 // @alpha (undocumented)
 export const createAccountCommand: ({ account, keyset, gasPayer, chainId, contract, }: ICreateAccountCommandInput) => (cmd?: (Partial<IPartialPactCommand> | (() => Partial<IPartialPactCommand>)) | undefined) => Partial<IPartialPactCommand>;
@@ -45,10 +42,10 @@ export const createAccountCommand: ({ account, keyset, gasPayer, chainId, contra
 export const createCrossChainCommand: ({ sender, receiver, amount, targetChainId, gasPayer, chainId, contract, }: Omit<ICrossChainInput, 'targetChainGasPayer'>) => (cmd?: (Partial<IPartialPactCommand> | (() => Partial<IPartialPactCommand>)) | undefined) => Partial<IPartialPactCommand>;
 
 // @alpha (undocumented)
-export const details: (account: string, networkId: string, chainId: ChainId, host?: IClientConfig['host'], contract?: string) => Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>;
+export const details: (account: string, networkId: string, chainId: ChainId, host?: IClientConfig['host'], contract?: string) => Promise<ICommandResult> | Promise<undefined>;
 
 // @alpha (undocumented)
-export const getBalance: (account: string, networkId: string, chainId: ChainId, host?: IClientConfig['host'], contract?: string) => Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>;
+export const getBalance: (account: string, networkId: string, chainId: ChainId, host?: IClientConfig['host'], contract?: string) => Promise<ICommandResult> | Promise<undefined>;
 
 // Warning: (ae-forgotten-export) The symbol "IRotateCommandInput" needs to be exported by the entry point index.d.ts
 //
@@ -65,7 +62,7 @@ data: ITransactionDescriptor;
 }, {
 event: "listen";
 data: ICommandResult;
-}], [], Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>>;
+}], [], Promise<ICommandResult> | Promise<undefined>>;
 
 // @alpha (undocumented)
 export const rotateCommand: ({ account, newguard, gasPayer, chainId, contract, }: IRotateCommandInput) => (cmd?: (Partial<IPartialPactCommand> | (() => Partial<IPartialPactCommand>)) | undefined) => Partial<IPartialPactCommand>;
@@ -85,7 +82,7 @@ data: ITransactionDescriptor;
 }, {
 event: "listen";
 data: ICommandResult;
-}], [], Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>>;
+}], [], Promise<ICommandResult> | Promise<undefined>>;
 
 // @alpha (undocumented)
 export const transferCommand: ({ sender, receiver, amount, gasPayer, chainId, contract, }: ITransferInput) => (cmd?: (Partial<IPartialPactCommand> | (() => Partial<IPartialPactCommand>)) | undefined) => Partial<IPartialPactCommand>;
@@ -105,7 +102,7 @@ data: ITransactionDescriptor;
 }, {
 event: "listen";
 data: ICommandResult;
-}], [], Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>>;
+}], [], Promise<ICommandResult> | Promise<undefined>>;
 
 // @alpha (undocumented)
 export const transferCreateCommand: ({ sender, receiver, amount, gasPayer, chainId, contract, }: ICreateTransferInput) => (cmd?: (Partial<IPartialPactCommand> | (() => Partial<IPartialPactCommand>)) | undefined) => Partial<IPartialPactCommand>;
@@ -144,7 +141,7 @@ data: ICommandResult;
 }], [{
 event: "poll-spv";
 data: string;
-}], Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>>;
+}], Promise<ICommandResult> | Promise<undefined>>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/libs/client-utils/etc/client-utils-core.api.md
+++ b/packages/libs/client-utils/etc/client-utils-core.api.md
@@ -11,13 +11,10 @@ import { ICommandResult } from '@kadena/chainweb-node-client';
 import { ILocalCommandResult } from '@kadena/chainweb-node-client';
 import type { INetworkOptions } from '@kadena/client';
 import type { IPactCommand } from '@kadena/client';
-import { IPactDecimal } from '@kadena/types';
-import { IPactInt } from '@kadena/types';
 import { IPartialPactCommand } from '@kadena/client/lib/interfaces/IPactCommand';
 import type { IPartialPactCommand as IPartialPactCommand_2 } from '@kadena/client';
 import type { ISignFunction } from '@kadena/client';
 import { ITransactionDescriptor } from '@kadena/client';
-import { PactValue } from '@kadena/types';
 
 // Warning: (ae-forgotten-export) The symbol "IAsyncPipe" needs to be exported by the entry point index.d.ts
 //
@@ -62,13 +59,13 @@ data: ICommandResult;
 }], [{
 event: 'poll-spv';
 data: string;
-}], Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>>;
+}], Promise<ICommandResult> | Promise<undefined>>;
 
 // @alpha (undocumented)
 export const dirtyReadClient: (args_0: Omit<IClientConfig, "sign">, args_1?: IClient | undefined) => (cmd?: (Partial<IPartialPactCommand> | (() => Partial<IPartialPactCommand>)) | undefined) => IEmitterWrapper<[{
 event: "dirtyRead";
 data: ICommandResult;
-}], [], Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>>;
+}], [], Promise<ICommandResult> | Promise<undefined>>;
 
 // @alpha
 export const estimateGas: (command: IPartialPactCommand_2 | ((cmd?: IPartialPactCommand_2 | (() => IPartialPactCommand_2)) => IPartialPactCommand_2), host?: IClientConfig['host'], client?: IClient) => Promise<{
@@ -83,7 +80,7 @@ data: ICommand;
 }, {
 event: "preflight";
 data: ILocalCommandResult;
-}], [], Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>>;
+}], [], Promise<ICommandResult> | Promise<undefined>>;
 
 // @alpha (undocumented)
 export const submitClient: (args_0: IClientConfig, args_1?: IClient | undefined) => (cmd?: (Partial<IPartialPactCommand> | (() => Partial<IPartialPactCommand>)) | undefined) => IEmitterWrapper<[{
@@ -98,7 +95,7 @@ data: ITransactionDescriptor;
 }, {
 event: "listen";
 data: ICommandResult;
-}], [], Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>>;
+}], [], Promise<ICommandResult> | Promise<undefined>>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/libs/client-utils/src/core/cross-chain.ts
+++ b/packages/libs/client-utils/src/core/cross-chain.ts
@@ -18,7 +18,7 @@ import { asyncPipe } from './utils/asyncPipe';
 import type { IAccount, IClientConfig, IEmit } from './utils/helpers';
 import {
   checkSuccess,
-  extractResult,
+  returnResult,
   getClient,
   safeSign,
   throwIfFails,
@@ -108,6 +108,6 @@ export const crossChain = (
       client.listen,
       emit('listen-continuation'),
       throwIfFails,
-      extractResult,
+      returnResult,
     );
 };

--- a/packages/libs/client-utils/src/core/preflight.ts
+++ b/packages/libs/client-utils/src/core/preflight.ts
@@ -4,7 +4,7 @@ import { composePactCommand } from '@kadena/client/fp';
 import { asyncPipe } from './utils/asyncPipe';
 import type { IClientConfig, IEmit } from './utils/helpers';
 import {
-  extractResult,
+  returnResult,
   getClient,
   safeSign,
   throwIfFails,
@@ -21,5 +21,5 @@ export const preflight =
       client.preflight,
       emit('preflight'),
       throwIfFails,
-      extractResult,
+      returnResult,
     );

--- a/packages/libs/client-utils/src/core/read-dirty.ts
+++ b/packages/libs/client-utils/src/core/read-dirty.ts
@@ -3,7 +3,7 @@ import { composePactCommand } from '@kadena/client/fp';
 
 import { asyncPipe } from './utils/asyncPipe';
 import type { IClientConfig, IEmit } from './utils/helpers';
-import { extractResult, getClient, throwIfFails } from './utils/helpers';
+import { returnResult, getClient, throwIfFails } from './utils/helpers';
 
 export const dirtyRead =
   ({ host, defaults }: Omit<IClientConfig, 'sign'>, client = getClient(host)) =>
@@ -14,5 +14,5 @@ export const dirtyRead =
       client.dirtyRead,
       emit('dirtyRead'),
       throwIfFails,
-      extractResult,
+      returnResult,
     );

--- a/packages/libs/client-utils/src/core/submit-and-listen.ts
+++ b/packages/libs/client-utils/src/core/submit-and-listen.ts
@@ -5,7 +5,7 @@ import { asyncPipe } from './utils/asyncPipe';
 import type { IClientConfig, IEmit } from './utils/helpers';
 import {
   checkSuccess,
-  extractResult,
+  returnResult,
   getClient,
   safeSign,
   throwIfFails,
@@ -27,5 +27,5 @@ export const submitAndListen =
       client.listen,
       emit('listen'),
       throwIfFails,
-      extractResult,
+      returnResult,
     );

--- a/packages/libs/client-utils/src/core/test/cross-chain-client.test.ts
+++ b/packages/libs/client-utils/src/core/test/cross-chain-client.test.ts
@@ -153,7 +153,9 @@ describe('crossChainClient', () => {
         });
       });
 
-    await expect(result.execute()).resolves.toEqual('test-data');
+    await expect(result.execute()).resolves.toEqual({
+      result: { status: 'success', data: 'test-data' },
+    });
   });
 
   it('runs a cross chain flow including exec and cont and call the sign if gas payer is not a gas station ', async () => {
@@ -290,6 +292,8 @@ describe('crossChainClient', () => {
         });
       });
 
-    await expect(result.execute()).resolves.toEqual('test-data');
+    await expect(result.execute()).resolves.toEqual({
+      result: { status: 'success', data: 'test-data' },
+    });
   });
 });

--- a/packages/libs/client-utils/src/core/test/preflight-client.test.ts
+++ b/packages/libs/client-utils/src/core/test/preflight-client.test.ts
@@ -55,6 +55,8 @@ describe('preflightClient', () => {
         });
       });
 
-    await expect(result.execute()).resolves.toEqual('preflight-test');
+    await expect(result.execute()).resolves.toEqual({
+      result: { status: 'success', data: 'preflight-test' },
+    });
   });
 });

--- a/packages/libs/client-utils/src/core/test/read-dirty.test.ts
+++ b/packages/libs/client-utils/src/core/test/read-dirty.test.ts
@@ -33,6 +33,8 @@ describe('dirtyReadClient', () => {
       });
     });
 
-    await expect(result.execute()).resolves.toEqual('test-data');
+    await expect(result.execute()).resolves.toEqual({
+      result: { status: 'success', data: 'test-data' },
+    });
   });
 });

--- a/packages/libs/client-utils/src/core/test/submit-client.test.ts
+++ b/packages/libs/client-utils/src/core/test/submit-client.test.ts
@@ -75,6 +75,8 @@ describe('submitClient', () => {
         });
       });
 
-    await expect(result.execute()).resolves.toEqual('test-data');
+    await expect(result.execute()).resolves.toEqual({
+      result: { status: 'success', data: 'test-data' },
+    });
   });
 });

--- a/packages/libs/client-utils/src/core/utils/helpers.ts
+++ b/packages/libs/client-utils/src/core/utils/helpers.ts
@@ -102,9 +102,9 @@ export const throwIfFails = (response: ICommandResult): ICommandResult => {
 
 export const pickFirst = <T extends Any[]>([tx]: T) => tx;
 
-export const extractResult = (response: ICommandResult) => {
+export const returnResult = (response: ICommandResult) => {
   if (response.result.status === 'success') {
-    return response.result.data;
+    return response;
   }
   return undefined;
 };

--- a/packages/libs/client-utils/src/core/utils/test/helpers.test.ts
+++ b/packages/libs/client-utils/src/core/utils/test/helpers.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ICommandResult } from '@kadena/chainweb-node-client';
 import {
   checkSuccess,
-  extractResult,
+  returnResult,
   inspect,
   pickFirst,
   safeSign,
@@ -167,17 +167,19 @@ describe('throwIfFails', () => {
 });
 
 describe('extractResult', () => {
-  it('returns data if it is success', () => {
+  it('returns complete response if it is success', () => {
     expect(
-      extractResult({
+      returnResult({
         result: { status: 'success', data: 'test-data' },
       } as unknown as ICommandResult),
-    ).toBe('test-data');
+    ).toEqual({
+      result: { status: 'success', data: 'test-data' },
+    });
   });
 
   it('returns undefined if it is not success', () => {
     expect(
-      extractResult({
+      returnResult({
         result: {
           status: 'failure',
           data: 'failure-data',


### PR DESCRIPTION
This PR changes client utils to always return the complete response instead of just the result status. This is especially helpful for tests as it provides more context about the executed action instead of just "Write succeeded"