### PR TITLE
[@kadena/graph] Made graph a releasable package

### DIFF
--- a/.changeset/lovely-lies-battle.md
+++ b/.changeset/lovely-lies-battle.md
@@ -1,0 +1,5 @@
+---
+'@kadena/graph': patch
+---
+
+Made graph a releasable package

--- a/packages/apps/graph/.npmrc
+++ b/packages/apps/graph/.npmrc
@@ -1,0 +1,1 @@
+enable-pre-post-scripts=true

--- a/packages/apps/graph/package.json
+++ b/packages/apps/graph/package.json
@@ -1,14 +1,24 @@
 {
   "name": "@kadena/graph",
   "version": "1.0.6",
-  "private": true,
-  "description": "",
-  "keywords": [],
-  "license": "ISC",
-  "author": "",
-  "main": "index.js",
+  "description": "GraphQL server, available for running your own GraphQL endpoint. This project uses chainweb-data as the datasource.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kadena-community/kadena.js.git",
+    "directory": "packages/apps/graph"
+  },
+  "license": "BSD-3",
+  "contributors": [
+    "Albert Groothedde <albert@kadena.io>",
+    "Maarten van den Hoven <maarten.vandenhoven@deptagency.com>",
+    "Nil Amrutlal <nil.amrutlal@deptagency.com>"
+  ],
+  "bin": {
+    "kadena-graph": "./dist/index.js"
+  },
   "scripts": {
-    "build": "pnpm run pactjs:generate:contract:coin && pnpm prisma:generate",
+    "prebuild": "pnpm run pactjs:generate:contract:coin && pnpm prisma:generate",
+    "build": "tsc",
     "devnet": "docker volume create kadena_devnet; docker run --rm -it -p 8080:8080 -p 5432:5432 -p 9999:9999 -v kadena_devnet:/data -v ./cwd-extra-migrations:/cwd-extra-migrations:ro --name devnet kadena/devnet",
     "devnet:update": "docker pull kadena/devnet",
     "format": "pnpm run --sequential /^format:.*/",

--- a/packages/apps/graph/src/devnet/crosschain-transfer.ts
+++ b/packages/apps/graph/src/devnet/crosschain-transfer.ts
@@ -130,7 +130,7 @@ export async function crossChainTransfer({
   );
 
   const continuation = {
-    pactId: status.continuation?.pactId,
+    pactId: status.continuation?.pactId || '',
     proof,
     rollback: false,
     step: 1,

--- a/packages/apps/graph/src/index.ts
+++ b/packages/apps/graph/src/index.ts
@@ -1,5 +1,14 @@
-// Cjs style import of module-alias/register to avoid sorting of imports.
-require('module-alias/register');
+#!/usr/bin/env node
+// commonjs import of module-alias/register to avoid sorting of imports.
+const moduleAlias = require('module-alias');
+
+moduleAlias.addAliases({
+  '@db': `${__dirname}/db`,
+  '@services': `${__dirname}/services`,
+  '@utils': `${__dirname}/utils`,
+  '@devnet': `${__dirname}/devnet`,
+});
+
 import { dotenv } from '@utils/dotenv';
 import { createYoga } from 'graphql-yoga';
 import 'json-bigint-patch';

--- a/packages/apps/graph/tsconfig.json
+++ b/packages/apps/graph/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "types": [".kadena/pactjs-generated", "node"],
     "target": "ES2020",
+    "outDir": "dist",
     "paths": {
       "@db/*": ["./src/db/*"],
       "@services/*": ["./src/services/*"],


### PR DESCRIPTION
- Added a bin reference to dist, making it possible to for example run `npx kadena-graph` to start the graphql server.
- Changed the package.json to a releasable format.
- Fixed module aliases for the built version.