### PR TITLE
added react aria text field hook

### DIFF
--- a/.changeset/fluffy-students-deny.md
+++ b/.changeset/fluffy-students-deny.md
@@ -1,0 +1,5 @@
+---
+'@kadena/react-ui': patch
+---
+
+Improved aria to Form Fields

--- a/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldHeader/FormFieldHeader.tsx
+++ b/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldHeader/FormFieldHeader.tsx
@@ -10,7 +10,7 @@ import {
 
 export interface IFormFieldHeaderProps {
   label: string;
-  htmlFor: string;
+  htmlFor?: string;
   tag?: string;
   info?: string;
   labelProps?:

--- a/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldHeader/FormFieldHeader.tsx
+++ b/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldHeader/FormFieldHeader.tsx
@@ -1,5 +1,5 @@
 import { SystemIcon } from '@components/Icon';
-import type { FC } from 'react';
+import type { DOMAttributes, FC, LabelHTMLAttributes } from 'react';
 import React from 'react';
 import {
   headerClass,
@@ -13,18 +13,22 @@ export interface IFormFieldHeaderProps {
   htmlFor: string;
   tag?: string;
   info?: string;
+  labelProps?:
+    | DOMAttributes<HTMLLabelElement>
+    | LabelHTMLAttributes<HTMLLabelElement>;
 }
 
 export const FormFieldHeader: FC<IFormFieldHeaderProps> = ({
   label,
   htmlFor,
+  labelProps,
   tag,
   info,
 }) => {
   return (
     <div className={headerClass}>
       {Boolean(label) && (
-        <label className={labelClass} htmlFor={htmlFor}>
+        <label className={labelClass} htmlFor={htmlFor} {...labelProps}>
           {label}
         </label>
       )}

--- a/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldHelper/FormFieldHelper.tsx
+++ b/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldHelper/FormFieldHelper.tsx
@@ -1,15 +1,20 @@
 import { SystemIcon } from '@components/Icon';
-import type { FC } from 'react';
+import { FocusableElement } from '@react-types/shared';
+import type { DOMAttributes, FC } from 'react';
 import React from 'react';
 import { helperClass, helperIconClass } from './FormFieldHelper.css';
 
 interface IFormFieldHelperProps {
   children: React.ReactNode;
+  descriptionProps?: DOMAttributes<FocusableElement>;
 }
 
-export const FormFieldHelper: FC<IFormFieldHelperProps> = ({ children }) => {
+export const FormFieldHelper: FC<IFormFieldHelperProps> = ({
+  children,
+  descriptionProps,
+}) => {
   return (
-    <span className={helperClass}>
+    <span {...descriptionProps} className={helperClass}>
       <span className={helperIconClass}>
         <SystemIcon.AlertBox size="sm" />
       </span>

--- a/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldHelper/FormFieldHelper.tsx
+++ b/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldHelper/FormFieldHelper.tsx
@@ -1,20 +1,20 @@
 import { SystemIcon } from '@components/Icon';
-import { FocusableElement } from '@react-types/shared';
+import type { FocusableElement } from '@react-types/shared';
 import type { DOMAttributes, FC } from 'react';
 import React from 'react';
 import { helperClass, helperIconClass } from './FormFieldHelper.css';
 
 interface IFormFieldHelperProps {
   children: React.ReactNode;
-  descriptionProps?: DOMAttributes<FocusableElement>;
+  helperTextProps?: DOMAttributes<FocusableElement>;
 }
 
 export const FormFieldHelper: FC<IFormFieldHelperProps> = ({
   children,
-  descriptionProps,
+  helperTextProps,
 }) => {
   return (
-    <span {...descriptionProps} className={helperClass}>
+    <span {...helperTextProps} className={helperClass}>
       <span className={helperIconClass}>
         <SystemIcon.AlertBox size="sm" />
       </span>

--- a/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldWrapper.tsx
+++ b/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldWrapper.tsx
@@ -3,12 +3,18 @@ import type {
   ISelectProps,
   ITextareaProps,
 } from '@components/Form';
-import type { FC, FunctionComponentElement } from 'react';
-import React from 'react';
+import type {
+  DOMAttributes,
+  FC,
+  FunctionComponentElement,
+  LabelHTMLAttributes,
+} from 'react';
+import React, { useRef } from 'react';
 import type { vars } from 'src/styles';
 import type { FormFieldStatus } from '../Form.css';
 
 import { Stack } from '@components/Layout';
+import { useTextField } from 'react-aria';
 import type { IFormFieldHeaderProps } from './FormFieldHeader/FormFieldHeader';
 import { FormFieldHeader } from './FormFieldHeader/FormFieldHeader';
 import { FormFieldHelper } from './FormFieldHelper/FormFieldHelper';
@@ -25,6 +31,9 @@ export interface IFormFieldWrapperProps
   helperText?: string;
   label?: string;
   leadingTextWidth?: keyof typeof vars.sizes;
+  labelProps?:
+    | DOMAttributes<HTMLLabelElement>
+    | LabelHTMLAttributes<HTMLLabelElement>;
 }
 
 export const FormFieldWrapper: FC<IFormFieldWrapperProps> = ({
@@ -37,6 +46,7 @@ export const FormFieldWrapper: FC<IFormFieldWrapperProps> = ({
   tag,
   info,
   helperText,
+  labelProps,
 }) => {
   const statusVal = disabled === true ? 'disabled' : status;
 
@@ -47,6 +57,7 @@ export const FormFieldWrapper: FC<IFormFieldWrapperProps> = ({
           <FormFieldHeader
             htmlFor={htmlFor}
             label={label}
+            labelProps={labelProps}
             tag={tag}
             info={info}
           />

--- a/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldWrapper.tsx
+++ b/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldWrapper.tsx
@@ -34,7 +34,7 @@ export interface IFormFieldWrapperProps
   labelProps?:
     | DOMAttributes<HTMLLabelElement>
     | LabelHTMLAttributes<HTMLLabelElement>;
-  descriptionProps?: DOMAttributes<FocusableElement>;
+  helperTextProps?: DOMAttributes<FocusableElement>;
 }
 
 export const FormFieldWrapper: FC<IFormFieldWrapperProps> = ({
@@ -43,11 +43,12 @@ export const FormFieldWrapper: FC<IFormFieldWrapperProps> = ({
   children,
   label,
   leadingTextWidth = undefined,
-  htmlFor,
+  // htmlFor,
   tag,
   info,
   helperText,
   labelProps,
+  helperTextProps,
 }) => {
   const statusVal = disabled === true ? 'disabled' : status;
 
@@ -56,7 +57,6 @@ export const FormFieldWrapper: FC<IFormFieldWrapperProps> = ({
       <div className={statusVal ? statusVariant[statusVal] : undefined}>
         {label !== undefined && (
           <FormFieldHeader
-            htmlFor={htmlFor}
             label={label}
             labelProps={labelProps}
             tag={tag}
@@ -66,7 +66,11 @@ export const FormFieldWrapper: FC<IFormFieldWrapperProps> = ({
         <Stack gap="$2" direction="column">
           {children}
         </Stack>
-        {Boolean(helperText) && <FormFieldHelper>{helperText}</FormFieldHelper>}
+        {Boolean(helperText) && (
+          <FormFieldHelper helperTextProps={helperTextProps}>
+            {helperText}
+          </FormFieldHelper>
+        )}
       </div>
     </FormFieldWrapperContext.Provider>
   );

--- a/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldWrapper.tsx
+++ b/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldWrapper.tsx
@@ -43,7 +43,6 @@ export const FormFieldWrapper: FC<IFormFieldWrapperProps> = ({
   children,
   label,
   leadingTextWidth = undefined,
-  // htmlFor,
   tag,
   info,
   helperText,

--- a/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldWrapper.tsx
+++ b/packages/libs/react-ui/src/components/Form/FormFieldWrapper/FormFieldWrapper.tsx
@@ -9,12 +9,12 @@ import type {
   FunctionComponentElement,
   LabelHTMLAttributes,
 } from 'react';
-import React, { useRef } from 'react';
+import React from 'react';
 import type { vars } from 'src/styles';
 import type { FormFieldStatus } from '../Form.css';
 
 import { Stack } from '@components/Layout';
-import { useTextField } from 'react-aria';
+import type { FocusableElement } from '@react-types/shared';
 import type { IFormFieldHeaderProps } from './FormFieldHeader/FormFieldHeader';
 import { FormFieldHeader } from './FormFieldHeader/FormFieldHeader';
 import { FormFieldHelper } from './FormFieldHelper/FormFieldHelper';
@@ -34,6 +34,7 @@ export interface IFormFieldWrapperProps
   labelProps?:
     | DOMAttributes<HTMLLabelElement>
     | LabelHTMLAttributes<HTMLLabelElement>;
+  descriptionProps?: DOMAttributes<FocusableElement>;
 }
 
 export const FormFieldWrapper: FC<IFormFieldWrapperProps> = ({

--- a/packages/libs/react-ui/src/components/Form/TextField/TextField.tsx
+++ b/packages/libs/react-ui/src/components/Form/TextField/TextField.tsx
@@ -2,6 +2,7 @@ import type { IFormFieldWrapperProps, IInputProps } from '@components/Form';
 import { FormFieldWrapper, Input } from '@components/Form';
 import type { FC } from 'react';
 import React, { useRef } from 'react';
+import type { AriaTextFieldProps } from 'react-aria';
 import { useTextField } from 'react-aria';
 
 export interface ITextFieldProps
@@ -22,9 +23,9 @@ export const TextField: FC<ITextFieldProps> = ({
     inputProps: ariaInputProps,
     descriptionProps,
     errorMessageProps,
-  } = useTextField(props, ref);
+  } = useTextField(inputProps as AriaTextFieldProps, ref);
 
-  const computedDescriptionProps =
+  const computedHelperTextProps =
     status === 'negative' ? errorMessageProps : descriptionProps;
 
   return (
@@ -33,7 +34,7 @@ export const TextField: FC<ITextFieldProps> = ({
       disabled={disabled}
       status={status}
       labelProps={labelProps}
-      descriptionProps={computedDescriptionProps}
+      helperTextProps={computedHelperTextProps}
       {...props}
     >
       <Input

--- a/packages/libs/react-ui/src/components/Form/TextField/TextField.tsx
+++ b/packages/libs/react-ui/src/components/Form/TextField/TextField.tsx
@@ -17,7 +17,15 @@ export const TextField: FC<ITextFieldProps> = ({
 }) => {
   const { id } = inputProps;
   const ref = useRef(null);
-  const { labelProps, inputProps: ariaInputProps } = useTextField(props, ref);
+  const {
+    labelProps,
+    inputProps: ariaInputProps,
+    descriptionProps,
+    errorMessageProps,
+  } = useTextField(props, ref);
+
+  const computedDescriptionProps =
+    status === 'negative' ? errorMessageProps : descriptionProps;
 
   return (
     <FormFieldWrapper
@@ -25,6 +33,7 @@ export const TextField: FC<ITextFieldProps> = ({
       disabled={disabled}
       status={status}
       labelProps={labelProps}
+      descriptionProps={computedDescriptionProps}
       {...props}
     >
       <Input

--- a/packages/libs/react-ui/src/components/Form/TextField/TextField.tsx
+++ b/packages/libs/react-ui/src/components/Form/TextField/TextField.tsx
@@ -23,7 +23,7 @@ export const TextField: FC<ITextFieldProps> = ({
     inputProps: ariaInputProps,
     descriptionProps,
     errorMessageProps,
-  } = useTextField(inputProps as AriaTextFieldProps, ref);
+  } = useTextField(props, ref);
 
   const computedHelperTextProps =
     status === 'negative' ? errorMessageProps : descriptionProps;

--- a/packages/libs/react-ui/src/components/Form/TextField/TextField.tsx
+++ b/packages/libs/react-ui/src/components/Form/TextField/TextField.tsx
@@ -1,7 +1,8 @@
 import type { IFormFieldWrapperProps, IInputProps } from '@components/Form';
 import { FormFieldWrapper, Input } from '@components/Form';
 import type { FC } from 'react';
-import React from 'react';
+import React, { useRef } from 'react';
+import { useTextField } from 'react-aria';
 
 export interface ITextFieldProps
   extends Omit<IFormFieldWrapperProps, 'children' | 'htmlFor'> {
@@ -12,18 +13,26 @@ export const TextField: FC<ITextFieldProps> = ({
   disabled = false,
   inputProps,
   status,
-  ...rest
+  ...props
 }) => {
   const { id } = inputProps;
+  const ref = useRef(null);
+  const { labelProps, inputProps: ariaInputProps } = useTextField(props, ref);
 
   return (
     <FormFieldWrapper
       htmlFor={id}
       disabled={disabled}
       status={status}
-      {...rest}
+      labelProps={labelProps}
+      {...props}
     >
-      <Input disabled={disabled} {...inputProps} />
+      <Input
+        disabled={disabled}
+        ref={ref}
+        {...inputProps}
+        {...ariaInputProps}
+      />
     </FormFieldWrapper>
   );
 };

--- a/packages/libs/react-ui/src/components/Form/TextField/TextField.tsx
+++ b/packages/libs/react-ui/src/components/Form/TextField/TextField.tsx
@@ -2,7 +2,6 @@ import type { IFormFieldWrapperProps, IInputProps } from '@components/Form';
 import { FormFieldWrapper, Input } from '@components/Form';
 import type { FC } from 'react';
 import React, { useRef } from 'react';
-import type { AriaTextFieldProps } from 'react-aria';
 import { useTextField } from 'react-aria';
 
 export interface ITextFieldProps

--- a/packages/libs/react-ui/src/components/Form/TextareaField/TextareaField.tsx
+++ b/packages/libs/react-ui/src/components/Form/TextareaField/TextareaField.tsx
@@ -2,8 +2,7 @@ import type { IFormFieldWrapperProps, ITextareaProps } from '@components/Form';
 import { FormFieldWrapper, Textarea } from '@components/Form';
 import type { FC } from 'react';
 import React, { useRef } from 'react';
-import type { AriaTextFieldProps } from 'react-aria';
-import { useTextField } from 'react-aria';
+import { AriaTextFieldProps, useTextField } from 'react-aria';
 
 export interface ITextareaFieldProps
   extends Omit<IFormFieldWrapperProps, 'htmlFor' | 'children'> {
@@ -21,7 +20,7 @@ export const TextareaField: FC<ITextareaFieldProps> = ({
   const { labelProps, inputProps, descriptionProps, errorMessageProps } =
     useTextField(
       {
-        ...(textAreaProps as AriaTextFieldProps),
+        ...rest,
         inputElementType: 'textarea',
       },
       ref,

--- a/packages/libs/react-ui/src/components/Form/TextareaField/TextareaField.tsx
+++ b/packages/libs/react-ui/src/components/Form/TextareaField/TextareaField.tsx
@@ -2,7 +2,7 @@ import type { IFormFieldWrapperProps, ITextareaProps } from '@components/Form';
 import { FormFieldWrapper, Textarea } from '@components/Form';
 import type { FC } from 'react';
 import React, { useRef } from 'react';
-import { AriaTextFieldProps, useTextField } from 'react-aria';
+import { useTextField } from 'react-aria';
 
 export interface ITextareaFieldProps
   extends Omit<IFormFieldWrapperProps, 'htmlFor' | 'children'> {

--- a/packages/libs/react-ui/src/components/Form/TextareaField/TextareaField.tsx
+++ b/packages/libs/react-ui/src/components/Form/TextareaField/TextareaField.tsx
@@ -2,6 +2,7 @@ import type { IFormFieldWrapperProps, ITextareaProps } from '@components/Form';
 import { FormFieldWrapper, Textarea } from '@components/Form';
 import type { FC } from 'react';
 import React, { useRef } from 'react';
+import type { AriaTextFieldProps } from 'react-aria';
 import { useTextField } from 'react-aria';
 
 export interface ITextareaFieldProps
@@ -18,7 +19,13 @@ export const TextareaField: FC<ITextareaFieldProps> = ({
   const { id } = textAreaProps;
   const ref = useRef(null);
   const { labelProps, inputProps, descriptionProps, errorMessageProps } =
-    useTextField({ ...rest, inputElementType: 'textarea' }, ref);
+    useTextField(
+      {
+        ...(textAreaProps as AriaTextFieldProps),
+        inputElementType: 'textarea',
+      },
+      ref,
+    );
 
   const computedDescriptionProps =
     status === 'negative' ? errorMessageProps : descriptionProps;
@@ -28,7 +35,7 @@ export const TextareaField: FC<ITextareaFieldProps> = ({
       htmlFor={id}
       disabled={disabled}
       labelProps={labelProps}
-      descriptionProps={computedDescriptionProps}
+      helperTextProps={computedDescriptionProps}
       {...rest}
     >
       <Textarea

--- a/packages/libs/react-ui/src/components/Form/TextareaField/TextareaField.tsx
+++ b/packages/libs/react-ui/src/components/Form/TextareaField/TextareaField.tsx
@@ -1,7 +1,8 @@
 import type { IFormFieldWrapperProps, ITextareaProps } from '@components/Form';
 import { FormFieldWrapper, Textarea } from '@components/Form';
 import type { FC } from 'react';
-import React from 'react';
+import React, { useRef } from 'react';
+import { useTextField } from 'react-aria';
 
 export interface ITextareaFieldProps
   extends Omit<IFormFieldWrapperProps, 'htmlFor' | 'children'> {
@@ -11,13 +12,31 @@ export interface ITextareaFieldProps
 export const TextareaField: FC<ITextareaFieldProps> = ({
   disabled = false,
   textAreaProps,
+  status,
   ...rest
 }) => {
   const { id } = textAreaProps;
+  const ref = useRef(null);
+  const { labelProps, inputProps, descriptionProps, errorMessageProps } =
+    useTextField({ ...rest, inputElementType: 'textarea' }, ref);
+
+  const computedDescriptionProps =
+    status === 'negative' ? errorMessageProps : descriptionProps;
 
   return (
-    <FormFieldWrapper htmlFor={id} disabled={disabled} {...rest}>
-      <Textarea disabled={disabled} {...textAreaProps} />
+    <FormFieldWrapper
+      htmlFor={id}
+      disabled={disabled}
+      labelProps={labelProps}
+      descriptionProps={computedDescriptionProps}
+      {...rest}
+    >
+      <Textarea
+        disabled={disabled}
+        ref={ref}
+        {...textAreaProps}
+        {...inputProps}
+      />
     </FormFieldWrapper>
   );
 };


### PR DESCRIPTION
This pull request can be solved in 2 ways: either applying it at each field level, as illustrated in this PR example, or incorporating it into the FormFieldWrapper.

Opting for the per-field application offers a straightforward API, requiring the simple passage of props. Additionally, it simplifies the process of integrating the useNumberField hook *dince it would be same component different hook), where its inclusion is as straightforward as adding it during the creation of the number field components for export.

On the other hand, selecting the FormFieldWrapper approach needs uding React.cloneElement. While this method offers a centralized approach, it introduces more instances where we decided that we wanted to stop using it.

Let me know!