### PR TITLE
New aria complete button without new tokens

### DIFF
--- a/.changeset/itchy-spoons-reflect.md
+++ b/.changeset/itchy-spoons-reflect.md
@@ -1,0 +1,13 @@
+---
+'@kadena/react-ui': minor
+---
+
+New aria complete button without new tokens
+  1. Use react aria which come with one major change is `onPress` instead of `onClick` read more about why https://react-spectrum.adobe.com/blog/building-a-button-part-1.html. we added `onClick` to allow easy migration but it is deprecated and we should not use it for new code.
+  2. Unify the `IconButton` and `Button` components using `<Button icon={<SomeIcon/>} />` instead of `IconButton`.
+  3. Change some props names to be consistent with react-aria naming `compact` -> `isCompact`.
+  4. `Button` is not a polymorphic component anymore we will have a separate link component.
+  5. `iconAlign` is replaced by specific icon renders props `startIcon` and `endIcon`, and `icon` is repurposed for icon-only buttons aka `IconButton`.
+  6. Use `recipe` instead of individual `styleVariants`. 
+  7. `color` and `variant` are now one prop `variant` and all `alternative` variants are added as a standalone variant eg `<Button color="primary" variant="alternative" />` is now `<Button variant="primaryInverted" />` we use `inverted` postfix is used instead of  `alternative` to match the intended color inversion behavior.
+  8. The `isCompact` variant now works for all button variations before it only worked for some color variants.

--- a/packages/libs/react-ui/src/components/Button/NewButton.css.ts
+++ b/packages/libs/react-ui/src/components/Button/NewButton.css.ts
@@ -1,0 +1,240 @@
+import { createVar, keyframes, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import { colorPalette } from '../../styles/colors';
+import { tokens } from '../../styles/tokens/contract.css';
+import { bodyBaseBold } from '../../styles/tokens/styles.css';
+import { vars } from '../../styles/vars.css';
+
+const hoverBackgroundColor = createVar();
+const activeBackgroundColor = createVar();
+const hoverColor = createVar();
+const outlineColor = createVar();
+const backgroundColor = createVar();
+const color = createVar();
+
+// TODO: use the new tokens once they are ready in the design system and figma is updated
+
+// eslint-disable-next-line @kadena-dev/typedef-var
+const colorVariants = {
+  primary: {
+    vars: {
+      [color]: vars.colors.$primaryContrast,
+      [backgroundColor]: vars.colors.$primarySurface,
+      [hoverBackgroundColor]: vars.colors.$primaryHighContrast,
+      [activeBackgroundColor]: vars.colors.$primaryHighContrast,
+      [hoverColor]: vars.colors.$primaryContrast,
+      [outlineColor]: vars.colors.$primaryAccent,
+    },
+  },
+  secondary: {
+    vars: {
+      [color]: vars.colors.$secondaryContrast,
+      [backgroundColor]: vars.colors.$secondarySurface,
+      [hoverBackgroundColor]: vars.colors.$secondaryHighContrast,
+      [activeBackgroundColor]: vars.colors.$secondaryHighContrast,
+      [hoverColor]: vars.colors.$secondaryContrast,
+      [outlineColor]: vars.colors.$secondaryAccent,
+    },
+  },
+  tertiary: {
+    vars: {
+      [color]: vars.colors.$tertiaryContrast,
+      [backgroundColor]: vars.colors.$tertiarySurface,
+      [hoverBackgroundColor]: vars.colors.$tertiaryHighContrast,
+      [activeBackgroundColor]: vars.colors.$tertiaryHighContrast,
+      [hoverColor]: vars.colors.$tertiaryContrast,
+      [outlineColor]: vars.colors.$tertiaryAccent,
+    },
+  },
+  warning: {
+    vars: {
+      [color]: vars.colors.$warningContrast,
+      [backgroundColor]: vars.colors.$warningSurface,
+      [hoverBackgroundColor]: vars.colors.$warningHighContrast,
+      [activeBackgroundColor]: vars.colors.$warningHighContrast,
+      [hoverColor]: vars.colors.$warningContrast,
+      [outlineColor]: vars.colors.$warningAccent,
+    },
+  },
+  negative: {
+    vars: {
+      [color]: vars.colors.$negativeContrast,
+      [backgroundColor]: vars.colors.$negativeSurface,
+      [hoverBackgroundColor]: vars.colors.$negativeHighContrast,
+      [activeBackgroundColor]: vars.colors.$negativeHighContrast,
+      [hoverColor]: vars.colors.$negativeContrast,
+      [outlineColor]: vars.colors.$negativeAccent,
+    },
+  },
+  positive: {
+    vars: {
+      [color]: vars.colors.$positiveContrast,
+      [backgroundColor]: vars.colors.$positiveSurface,
+      [hoverBackgroundColor]: vars.colors.$positiveHighContrast,
+      [activeBackgroundColor]: vars.colors.$positiveHighContrast,
+      [hoverColor]: vars.colors.$positiveContrast,
+      [outlineColor]: vars.colors.$positiveAccent,
+    },
+  },
+  primaryInverted: {
+    vars: {
+      [color]: vars.colors.$primaryContrastInverted,
+      [backgroundColor]: vars.colors.$primaryLowContrast,
+      [hoverBackgroundColor]: vars.colors.$primarySurfaceInverted,
+      [activeBackgroundColor]: vars.colors.$primaryHighContrast,
+      [hoverColor]: vars.colors.$primaryContrastInverted,
+      [outlineColor]: vars.colors.$primaryAccent,
+    },
+  },
+  secondaryInverted: {
+    vars: {
+      [color]: vars.colors.$secondaryContrastInverted,
+      [backgroundColor]: vars.colors.$secondaryLowContrast,
+      [hoverBackgroundColor]: vars.colors.$secondarySurfaceInverted,
+      [activeBackgroundColor]: vars.colors.$secondaryHighContrast,
+      [hoverColor]: vars.colors.$secondaryContrastInverted,
+      [outlineColor]: vars.colors.$secondaryAccent,
+    },
+  },
+  tertiaryInverted: {
+    vars: {
+      [color]: vars.colors.$tertiaryContrastInverted,
+      [backgroundColor]: vars.colors.$tertiaryLowContrast,
+      [hoverBackgroundColor]: vars.colors.$tertiarySurfaceInverted,
+      [activeBackgroundColor]: vars.colors.$tertiaryHighContrast,
+      [hoverColor]: vars.colors.$tertiaryContrastInverted,
+      [outlineColor]: vars.colors.$tertiaryAccent,
+    },
+  },
+  warningInverted: {
+    vars: {
+      [color]: vars.colors.$warningContrastInverted,
+      [backgroundColor]: vars.colors.$warningLowContrast,
+      [hoverBackgroundColor]: vars.colors.$warningSurfaceInverted,
+      [activeBackgroundColor]: vars.colors.$warningHighContrast,
+      [hoverColor]: vars.colors.$warningContrastInverted,
+      [outlineColor]: vars.colors.$warningAccent,
+    },
+  },
+  positiveInverted: {
+    vars: {
+      [color]: vars.colors.$positiveContrastInverted,
+      [backgroundColor]: vars.colors.$positiveLowContrast,
+      [hoverBackgroundColor]: vars.colors.$positiveSurfaceInverted,
+      [activeBackgroundColor]: vars.colors.$positiveHighContrast,
+      [hoverColor]: vars.colors.$positiveContrastInverted,
+      [outlineColor]: vars.colors.$positiveAccent,
+    },
+  },
+  negativeInverted: {
+    vars: {
+      [color]: vars.colors.$negativeContrastInverted,
+      [backgroundColor]: vars.colors.$negativeLowContrast,
+      [hoverBackgroundColor]: vars.colors.$negativeSurfaceInverted,
+      [activeBackgroundColor]: vars.colors.$negativeHighContrast,
+      [hoverColor]: vars.colors.$negativeContrastInverted,
+      [outlineColor]: vars.colors.$negativeAccent,
+    },
+  },
+} as const;
+
+export const button = recipe({
+  base: [
+    bodyBaseBold,
+    {
+      color,
+      backgroundColor,
+      position: 'relative',
+      display: 'flex',
+      placeItems: 'center',
+      cursor: 'pointer',
+      border: 'none',
+      textDecoration: 'none',
+      borderRadius: tokens.kda.foundation.radius.sm,
+      gap: tokens.kda.foundation.size.n2,
+      paddingInline: tokens.kda.foundation.size.n4,
+      paddingBlock: tokens.kda.foundation.size.n2,
+      outlineOffset: tokens.kda.foundation.border.width.normal,
+
+      ':hover': {
+        color: hoverColor,
+        backgroundColor: hoverBackgroundColor,
+      },
+      ':active': {
+        outlineStyle: 'solid',
+        outlineWidth: tokens.kda.foundation.border.width.normal,
+        outlineColor,
+      },
+      ':focus-visible': {
+        outlineStyle: 'solid',
+        outlineWidth: tokens.kda.foundation.border.width.normal,
+        outlineColor,
+      },
+      ':disabled': {
+        opacity: 0.7,
+        backgroundColor: colorPalette.$gray60,
+        color: colorPalette.$gray10,
+        cursor: 'not-allowed',
+        pointerEvents: 'none',
+      },
+      transition:
+        'background-color 0.2s ease-in-out, color 0.2s ease-in-out, border-color 0.2s ease-in-out',
+    },
+  ],
+  variants: {
+    variant: colorVariants,
+    isCompact: {
+      true: {
+        paddingInline: vars.sizes.$1,
+        paddingBlock: vars.sizes.$1,
+      },
+    },
+    isOutlined: {
+      true: {
+        backgroundColor: 'transparent',
+        outlineOffset: 0,
+        vars: {
+          [backgroundColor]: 'none',
+          [hoverBackgroundColor]: 'none',
+        },
+      },
+    },
+    isLoading: {
+      true: {
+        pointerEvents: 'none',
+      },
+    },
+    onlyIcon: {
+      true: {
+        paddingInline: vars.sizes.$2,
+        paddingBlock: vars.sizes.$2,
+      },
+    },
+  },
+  defaultVariants: {
+    variant: 'primary',
+    isCompact: false,
+    isOutlined: false,
+  },
+});
+
+const rotate = keyframes({
+  '0%': { transform: 'rotate(0deg)' },
+  '100%': { transform: 'rotate(360deg)' },
+});
+
+export const spinner = style({
+  animationName: rotate,
+  animationDuration: '1.5s',
+  animationIterationCount: 'infinite',
+  animationTimingFunction: 'linear',
+});
+
+export const cloak = style({
+  visibility: 'hidden',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  position: 'absolute',
+  inset: 0,
+});

--- a/packages/libs/react-ui/src/components/Button/NewButton.css.ts
+++ b/packages/libs/react-ui/src/components/Button/NewButton.css.ts
@@ -1,3 +1,4 @@
+import { atoms } from '@theme/atoms.css';
 import { createVar, keyframes, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 import { colorPalette } from '../../styles/colors';
@@ -141,21 +142,23 @@ const colorVariants = {
 export const button = recipe({
   base: [
     bodyBaseBold,
+    atoms({
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderRadius: 'sm',
+      gap: 'sm',
+      paddingInline: 'md',
+      paddingBlock: 'sm',
+      border: 'none',
+      textDecoration: 'none',
+      cursor: 'pointer',
+      position: 'relative',
+    }),
     {
       color,
       backgroundColor,
-      position: 'relative',
-      display: 'flex',
-      placeItems: 'center',
-      cursor: 'pointer',
-      border: 'none',
-      textDecoration: 'none',
-      borderRadius: tokens.kda.foundation.radius.sm,
-      gap: tokens.kda.foundation.size.n2,
-      paddingInline: tokens.kda.foundation.size.n4,
-      paddingBlock: tokens.kda.foundation.size.n2,
       outlineOffset: tokens.kda.foundation.border.width.normal,
-
       ':hover': {
         color: hoverColor,
         backgroundColor: hoverBackgroundColor,

--- a/packages/libs/react-ui/src/components/Button/NewButton.css.ts
+++ b/packages/libs/react-ui/src/components/Button/NewButton.css.ts
@@ -1,6 +1,6 @@
-import { atoms } from '@theme/atoms.css';
 import { createVar, keyframes, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
+import { atoms } from '../../styles/atoms.css';
 import { colorPalette } from '../../styles/colors';
 import { tokens } from '../../styles/tokens/contract.css';
 import { bodyBaseBold } from '../../styles/tokens/styles.css';
@@ -139,49 +139,85 @@ const colorVariants = {
   },
 } as const;
 
+// eslint-disable-next-line @kadena-dev/typedef-var
+const focusRing = {
+  outlineColor,
+  outlineStyle: 'solid',
+  outlineWidth: tokens.kda.foundation.border.width.normal,
+  outlineOffset: tokens.kda.foundation.border.width.normal,
+};
+
+const buttonReset = style({
+  position: 'relative',
+  appearance: 'button',
+  WebkitAppearance: 'button',
+  /* Remove the inheritance of text transform on button in Edge, Firefox, and IE. */
+  textTransform: 'none',
+  WebkitFontSmoothing: 'antialiased',
+  /* Font smoothing for Firefox */
+  MozOsxFontSmoothing: 'grayscale',
+  verticalAlign: 'top',
+  /* prevent touch scrolling on buttons */
+  touchAction: 'none',
+  userSelect: 'none',
+  cursor: 'default',
+  textDecoration: 'none',
+  isolation: 'isolate',
+  border: 'none',
+  margin: 0,
+  ':focus': {
+    outline: 'none',
+  },
+  ':focus-visible': {
+    zIndex: 3,
+  },
+  selectors: {
+    /* Fix Firefox */
+    '&::-moz-focus-inner': {
+      border: 0,
+      /* Remove the inner border and padding for button in Firefox. */
+      borderStyle: 'none',
+      padding: 0,
+      /* Use uppercase PX so values don't get converted to rem */
+      marginBlockStart: '-2PX',
+      marginBlockEnd: '-2PX',
+    },
+  },
+});
 export const button = recipe({
   base: [
+    buttonReset,
     bodyBaseBold,
     atoms({
-      display: 'flex',
+      display: 'inline-flex',
       justifyContent: 'center',
       alignItems: 'center',
       borderRadius: 'sm',
       gap: 'sm',
       paddingInline: 'md',
       paddingBlock: 'sm',
-      border: 'none',
-      textDecoration: 'none',
-      cursor: 'pointer',
-      position: 'relative',
     }),
     {
       color,
       backgroundColor,
-      outlineOffset: tokens.kda.foundation.border.width.normal,
-      ':hover': {
-        color: hoverColor,
-        backgroundColor: hoverBackgroundColor,
-      },
-      ':active': {
-        outlineStyle: 'solid',
-        outlineWidth: tokens.kda.foundation.border.width.normal,
-        outlineColor,
-      },
-      ':focus-visible': {
-        outlineStyle: 'solid',
-        outlineWidth: tokens.kda.foundation.border.width.normal,
-        outlineColor,
-      },
-      ':disabled': {
-        opacity: 0.7,
-        backgroundColor: colorPalette.$gray60,
-        color: colorPalette.$gray10,
-        cursor: 'not-allowed',
-        pointerEvents: 'none',
-      },
       transition:
         'background-color 0.2s ease-in-out, color 0.2s ease-in-out, border-color 0.2s ease-in-out',
+
+      selectors: {
+        '&[data-hovered]': {
+          color: hoverColor,
+          backgroundColor: hoverBackgroundColor,
+        },
+        '&[data-pressed]': focusRing,
+        '&[data-focus-visible]': focusRing,
+        '&[data-disabled]': {
+          opacity: 0.7,
+          backgroundColor: colorPalette.$gray60,
+          color: colorPalette.$gray10,
+          cursor: 'not-allowed',
+          pointerEvents: 'none',
+        },
+      },
     },
   ],
   variants: {

--- a/packages/libs/react-ui/src/components/Button/NewButton.css.ts
+++ b/packages/libs/react-ui/src/components/Button/NewButton.css.ts
@@ -1,4 +1,4 @@
-import { createVar, keyframes, style } from '@vanilla-extract/css';
+import { createVar, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 import { atoms } from '../../styles/atoms.css';
 import { colorPalette } from '../../styles/colors';
@@ -255,25 +255,4 @@ export const button = recipe({
     isCompact: false,
     isOutlined: false,
   },
-});
-
-const rotate = keyframes({
-  '0%': { transform: 'rotate(0deg)' },
-  '100%': { transform: 'rotate(360deg)' },
-});
-
-export const spinner = style({
-  animationName: rotate,
-  animationDuration: '1.5s',
-  animationIterationCount: 'infinite',
-  animationTimingFunction: 'linear',
-});
-
-export const cloak = style({
-  visibility: 'hidden',
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  position: 'absolute',
-  inset: 0,
 });

--- a/packages/libs/react-ui/src/components/Button/NewButton.spec.tsx
+++ b/packages/libs/react-ui/src/components/Button/NewButton.spec.tsx
@@ -1,0 +1,173 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { useState } from 'react';
+import { Button } from './NewButton';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('Button', () => {
+  const onPressSpy = vi.fn();
+  const onPressStartSpy = vi.fn();
+  const onPressEndSpy = vi.fn();
+  const onPressUpSpy = vi.fn();
+  const onPressChangeSpy = vi.fn();
+
+  afterEach(() => {
+    onPressSpy.mockClear();
+  });
+
+  it('should handle defaults', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const { getByRole, getByText } = render(
+      <Button onPress={onPressSpy}>Click Me</Button>,
+    );
+
+    const button = getByRole('button');
+    await user.click(button);
+    expect(onPressSpy).toHaveBeenCalledTimes(1);
+
+    const text = getByText('Click Me');
+    expect(text).not.toBeNull();
+  });
+
+  it('Should support press events', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const { getByRole, getByText } = render(
+      <Button
+        onPress={onPressSpy}
+        onPressStart={onPressStartSpy}
+        onPressEnd={onPressEndSpy}
+        onPressUp={onPressUpSpy}
+        onPressChange={onPressChangeSpy}
+      >
+        Click Me
+      </Button>,
+    );
+
+    const button = getByRole('button');
+    await user.click(button);
+    expect(onPressStartSpy).toHaveBeenCalledTimes(1);
+    expect(onPressSpy).toHaveBeenCalledTimes(1);
+    expect(onPressEndSpy).toHaveBeenCalledTimes(1);
+    expect(onPressUpSpy).toHaveBeenCalledTimes(1);
+    expect(onPressChangeSpy).toHaveBeenCalledTimes(2);
+
+    const text = getByText('Click Me');
+    expect(text).not.toBeNull();
+  });
+
+  it('Should allow custom props to be passed through to the button', () => {
+    const { getByRole } = render(<Button data-foo="bar">Click Me</Button>);
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('data-foo', 'bar');
+  });
+
+  it('Should support aria-label', () => {
+    const { getByRole } = render(<Button aria-label="Test" />);
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('aria-label', 'Test');
+  });
+
+  it('Should support aria-labelledby', () => {
+    const { getByRole } = render(
+      <>
+        <span id="test">Test</span>
+        <Button aria-labelledby="test" />
+      </>,
+    );
+
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('aria-labelledby', 'test');
+  });
+
+  it('Should support aria-describedby', () => {
+    const { getByRole } = render(
+      <>
+        <span id="test">Test</span>
+        <Button aria-describedby="test">Hi</Button>
+      </>,
+    );
+
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('aria-describedby', 'test');
+  });
+
+  it('Should allow a custom className on the button', () => {
+    const { getByRole } = render(
+      <Button className="x-men-first-class">Click Me</Button>,
+    );
+
+    const button = getByRole('button');
+    expect(button.getAttribute('class')).toEqual(
+      expect.stringContaining('x-men-first-class'),
+    );
+  });
+
+  it('Should handle deprecated onClick', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { getByRole } = render(
+      <Button onClick={onPressSpy}>Click Me</Button>,
+    );
+
+    const button = getByRole('button');
+    await user.click(button);
+    expect(onPressSpy).toHaveBeenCalledTimes(1);
+    expect(spyWarn).toHaveBeenCalledWith(
+      'onClick is deprecated, please use onPress',
+    );
+  });
+
+  it('Should not respond when disabled', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const { getByRole } = render(
+      <Button onPress={onPressSpy} isDisabled>
+        Click Me
+      </Button>,
+    );
+
+    const button = getByRole('button');
+    await user.click(button);
+    expect(button).toBeDisabled();
+    expect(onPressSpy).not.toHaveBeenCalled();
+  });
+
+  it('Should support autoFocus', () => {
+    const { getByRole } = render(<Button autoFocus>Click Me</Button>);
+    const button = getByRole('button');
+    expect(document.activeElement).toBe(button);
+  });
+
+  it('Should display a spinner when isLoading prop is true', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const onPressSpy = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    const TestComponent = () => {
+      const [pending, setPending] = useState(false);
+      return (
+        <Button
+          onPress={(e) => {
+            setPending(true);
+            onPressSpy();
+          }}
+          isLoading={pending}
+        >
+          Click me
+        </Button>
+      );
+    };
+    const { getByRole, queryByRole } = render(<TestComponent />);
+    const button = getByRole('button');
+    expect(button).not.toHaveAttribute('aria-disabled');
+    await user.click(button);
+
+    // Button is disabled immediately and spinner is visible
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    const spinner = queryByRole('progressbar');
+    expect(spinner).toBeVisible();
+
+    // Multiple clicks shouldn't call onPressSpy
+    await user.click(button);
+    expect(onPressSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/libs/react-ui/src/components/Button/NewButton.stories.tsx
+++ b/packages/libs/react-ui/src/components/Button/NewButton.stories.tsx
@@ -1,0 +1,160 @@
+import type { Meta, StoryFn, StoryObj } from '@storybook/react';
+import React from 'react';
+import { Plus } from '../Icon/System/SystemIcon';
+import type { IButtonProps } from './NewButton';
+import { NewButton } from './NewButton';
+import { button } from './NewButton.css';
+
+// eslint-disable-next-line @kadena-dev/typedef-var
+const buttonVariants = Object.keys(
+  (button as any).classNames?.variants?.variant,
+) as IButtonProps['variant'][];
+
+const meta: Meta<IButtonProps> = {
+  title: 'Components/NewButton',
+  component: NewButton,
+  parameters: {
+    status: { type: 'inDevelopment' },
+    controls: {
+      hideNoControlsWarning: true,
+      sort: 'requiredFirst',
+    },
+    docs: {
+      description: {
+        component:
+          'The Button component renders a button which will be styled according to the variant prop (`primary` being the default)',
+      },
+    },
+  },
+  argTypes: {
+    onClick: {
+      action: 'clicked',
+      table: {
+        disable: true,
+      },
+    },
+    variant: {
+      options: buttonVariants,
+      control: {
+        type: 'select',
+      },
+      description: 'button style variant',
+      table: {
+        type: { summary: buttonVariants.join(' | ') },
+        defaultValue: { summary: 'default' },
+      },
+    },
+    title: {
+      control: {
+        type: 'text',
+      },
+      description: 'native tooltip',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: '' },
+      },
+    },
+    type: {
+      description: 'type of button',
+      options: ['button', 'submit', 'reset'] as IButtonProps['type'][],
+      control: {
+        type: 'select',
+      },
+      table: {
+        type: { summary: 'button | submit | reset' },
+        defaultValue: { summary: 'button' },
+      },
+    },
+
+    isDisabled: {
+      description: 'only used when rendered as button',
+      control: {
+        type: 'boolean',
+      },
+    },
+    isLoading: {
+      description: 'loading state',
+      control: {
+        type: 'boolean',
+      },
+    },
+    isCompact: {
+      description: 'compact button style',
+      control: {
+        type: 'boolean',
+      },
+    },
+    isOutlined: {
+      description: 'outlined button style',
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+};
+
+type Story = StoryObj<
+  {
+    text: string;
+  } & IButtonProps
+>;
+
+export const Default: Story = {
+  name: 'Button',
+  args: {
+    isDisabled: false,
+    isCompact: false,
+    isOutlined: false,
+    icon: undefined,
+    startIcon: undefined,
+    endIcon: undefined,
+    isLoading: false,
+    text: 'Click me',
+    title: 'test title',
+    variant: 'primary',
+  },
+  render: ({
+    startIcon,
+    endIcon,
+    icon,
+    isCompact,
+    isDisabled,
+    isOutlined,
+    isLoading,
+    onClick,
+    text,
+    title,
+    variant = 'primary',
+  }) => {
+    return (
+      <NewButton
+        startIcon={startIcon}
+        endIcon={endIcon}
+        icon={icon}
+        isCompact={isCompact}
+        isDisabled={isDisabled}
+        isOutlined={isOutlined}
+        isLoading={isLoading}
+        onClick={onClick}
+        title={title}
+        variant={variant}
+      >
+        {text}
+      </NewButton>
+    );
+  },
+};
+
+export const StartIcon: StoryFn<IButtonProps> = () => (
+  <NewButton startIcon={<Plus />}>Click me</NewButton>
+);
+
+export const EndIcon: StoryFn<IButtonProps> = () => (
+  <NewButton endIcon={<Plus />}>Click me</NewButton>
+);
+
+export const OnlyIcon: StoryFn<IButtonProps> = () => (
+  <NewButton icon={<Plus />} />
+);
+
+export default meta;

--- a/packages/libs/react-ui/src/components/Button/NewButton.stories.tsx
+++ b/packages/libs/react-ui/src/components/Button/NewButton.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import React from 'react';
 import { Plus } from '../Icon/System/SystemIcon';
 import type { IButtonProps } from './NewButton';
-import { NewButton } from './NewButton';
+import { Button } from './NewButton';
 import { button } from './NewButton.css';
 
 // eslint-disable-next-line @kadena-dev/typedef-var
@@ -12,7 +12,7 @@ const buttonVariants = Object.keys(
 
 const meta: Meta<IButtonProps> = {
   title: 'Components/NewButton',
-  component: NewButton,
+  component: Button,
   parameters: {
     status: { type: 'inDevelopment' },
     controls: {
@@ -29,6 +29,7 @@ const meta: Meta<IButtonProps> = {
   argTypes: {
     onClick: {
       action: 'clicked',
+      description: '(deprecated) callback when button is clicked',
       table: {
         disable: true,
       },
@@ -42,16 +43,6 @@ const meta: Meta<IButtonProps> = {
       table: {
         type: { summary: buttonVariants.join(' | ') },
         defaultValue: { summary: 'default' },
-      },
-    },
-    title: {
-      control: {
-        type: 'text',
-      },
-      description: 'native tooltip',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: '' },
       },
     },
     type: {
@@ -110,7 +101,6 @@ export const Default: Story = {
     endIcon: undefined,
     isLoading: false,
     text: 'Click me',
-    title: 'test title',
     variant: 'primary',
   },
   render: ({
@@ -123,11 +113,10 @@ export const Default: Story = {
     isLoading,
     onClick,
     text,
-    title,
     variant = 'primary',
   }) => {
     return (
-      <NewButton
+      <Button
         startIcon={startIcon}
         endIcon={endIcon}
         icon={icon}
@@ -136,25 +125,22 @@ export const Default: Story = {
         isOutlined={isOutlined}
         isLoading={isLoading}
         onClick={onClick}
-        title={title}
         variant={variant}
       >
         {text}
-      </NewButton>
+      </Button>
     );
   },
 };
 
 export const StartIcon: StoryFn<IButtonProps> = () => (
-  <NewButton startIcon={<Plus />}>Click me</NewButton>
+  <Button startIcon={<Plus />}>Click me</Button>
 );
 
 export const EndIcon: StoryFn<IButtonProps> = () => (
-  <NewButton endIcon={<Plus />}>Click me</NewButton>
+  <Button endIcon={<Plus />}>Click me</Button>
 );
 
-export const OnlyIcon: StoryFn<IButtonProps> = () => (
-  <NewButton icon={<Plus />} />
-);
+export const OnlyIcon: StoryFn<IButtonProps> = () => <Button icon={<Plus />} />;
 
 export default meta;

--- a/packages/libs/react-ui/src/components/Button/NewButton.tsx
+++ b/packages/libs/react-ui/src/components/Button/NewButton.tsx
@@ -2,17 +2,13 @@
 
 import { mergeProps, useObjectRef } from '@react-aria/utils';
 import type { RecipeVariants } from '@vanilla-extract/recipes';
-import type {
-  ComponentProps,
-  ForwardedRef,
-  MouseEvent,
-  ReactNode,
-} from 'react';
-import React, { forwardRef, useCallback } from 'react';
+import classNames from 'classnames';
+import type { ComponentProps, ForwardedRef, ReactNode } from 'react';
+import React, { forwardRef } from 'react';
 import type { AriaButtonProps, HoverEvents } from 'react-aria';
 import { useButton, useFocusRing, useHover } from 'react-aria';
-import { Loading } from '../Icon/System/SystemIcon';
-import { button, spinner } from './NewButton.css';
+import { ProgressCircle } from '../ProgressCircle/ProgressCircle';
+import { button } from './NewButton.css';
 
 type Variants = Omit<NonNullable<RecipeVariants<typeof button>>, 'onlyIcon'>;
 // omit link related props from `AriaButtonProps`
@@ -20,10 +16,12 @@ type PickedAriaButtonProps = Omit<
   AriaButtonProps,
   'href' | 'target' | 'rel' | 'elementType'
 >;
+
 export interface IButtonProps
   extends PickedAriaButtonProps,
     HoverEvents,
     Variants {
+  className?: string;
   startIcon?: ReactNode;
   endIcon?: ReactNode;
   icon?: ReactNode;
@@ -33,26 +31,35 @@ export interface IButtonProps
    */
   onClick?: ComponentProps<'button'>['onClick'];
 }
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function disableLoadingProps(props: IButtonProps) {
+  const newProps = { ...props };
+  // Don't allow interaction while isPending is true
+  if (newProps.isLoading) {
+    newProps.onPress = undefined;
+    newProps.onPressStart = undefined;
+    newProps.onPressEnd = undefined;
+    newProps.onPressChange = undefined;
+    newProps.onPressUp = undefined;
+    newProps.onKeyDown = undefined;
+    newProps.onKeyUp = undefined;
+    newProps.onClick = undefined;
+  }
+  return newProps;
+}
+
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /* eslint-disable react/function-component-definition */
-
 function BaseButton(
   props: IButtonProps,
   forwardedRef: ForwardedRef<HTMLButtonElement>,
 ) {
+  props = disableLoadingProps(props);
   const ref = useObjectRef(forwardedRef);
   const { buttonProps, isPressed } = useButton(props, ref);
   const { hoverProps, isHovered } = useHover(props);
   const { focusProps, isFocused, isFocusVisible } = useFocusRing(props);
-
-  // support for deprecated `onClick` prop
-  const handleClick = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      props.onClick?.(event);
-      buttonProps.onClick?.(event);
-    },
-    [props.onClick, buttonProps.onClick],
-  );
 
   const onlyIcon = props.icon !== undefined;
   const content = onlyIcon ? (
@@ -65,18 +72,28 @@ function BaseButton(
     </>
   );
 
+  const isLoadingAriaLiveLabel = `${
+    typeof props.children === 'string'
+      ? props.children
+      : buttonProps['aria-label'] ?? 'is'
+  } loading`.trim();
+
   return (
     <button
       {...mergeProps(buttonProps, hoverProps, focusProps)}
       ref={ref}
-      className={button({
-        onlyIcon,
-        variant: props.variant,
-        isCompact: props.isCompact,
-        isOutlined: props.isOutlined,
-      })}
-      onClick={handleClick}
-      data-disabled={props.isDisabled || undefined}
+      className={classNames(
+        button({
+          onlyIcon,
+          variant: props.variant,
+          isCompact: props.isCompact,
+          isOutlined: props.isOutlined,
+          isLoading: props.isLoading,
+        }),
+        props.className,
+      )}
+      aria-disabled={props.isLoading || undefined}
+      data-disabled={props.isDisabled || props.isLoading || undefined}
       data-pressed={isPressed || undefined}
       data-hovered={isHovered || undefined}
       data-focused={isFocused || undefined}
@@ -84,8 +101,12 @@ function BaseButton(
     >
       {props.isLoading ? (
         <>
-          <Loading className={spinner} />
           {onlyIcon ? null : 'Loading'}
+          <ProgressCircle
+            aria-hidden="true"
+            aria-label={isLoadingAriaLiveLabel}
+            isIndeterminate
+          />
         </>
       ) : (
         content
@@ -94,4 +115,4 @@ function BaseButton(
   );
 }
 
-export const NewButton = forwardRef(BaseButton);
+export const Button = forwardRef(BaseButton);

--- a/packages/libs/react-ui/src/components/Button/NewButton.tsx
+++ b/packages/libs/react-ui/src/components/Button/NewButton.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable @kadena-dev/no-eslint-disable */
+
+import { useObjectRef } from '@react-aria/utils';
+import type { RecipeVariants } from '@vanilla-extract/recipes';
+import type {
+  ComponentProps,
+  ForwardedRef,
+  MouseEvent,
+  ReactNode,
+} from 'react';
+import React, { forwardRef, useCallback } from 'react';
+import type { AriaButtonProps } from 'react-aria';
+import { useButton } from 'react-aria';
+import { Loading } from '../Icon/System/SystemIcon';
+import { button, spinner } from './NewButton.css';
+
+type Variants = Omit<NonNullable<RecipeVariants<typeof button>>, 'onlyIcon'>;
+export interface IButtonProps extends AriaButtonProps, Variants {
+  startIcon?: ReactNode;
+  endIcon?: ReactNode;
+  icon?: ReactNode;
+  title?: string;
+  /**
+   * @deprecated use `onPress` instead to be consistent with React Aria, also keep in mind that `onPress` is not a native event it is a synthetic event created by React Aria
+   * @see https://react-spectrum.adobe.com/react-aria/useButton.html#props
+   */
+  onClick?: ComponentProps<'button'>['onClick'];
+}
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable react/function-component-definition */
+
+function BaseButton(
+  props: IButtonProps,
+  forwardedRef: ForwardedRef<HTMLButtonElement>,
+) {
+  const ref = useObjectRef(forwardedRef);
+  const { buttonProps } = useButton(props, ref);
+
+  // support for deprecated `onClick` prop
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      props.onClick?.(event);
+      buttonProps.onClick?.(event);
+    },
+    [props.onClick, buttonProps.onClick],
+  );
+
+  const onlyIcon = props.icon !== undefined;
+  const content = onlyIcon ? (
+    props.icon
+  ) : (
+    <>
+      {props.startIcon}
+      {props.children}
+      {props.endIcon}
+    </>
+  );
+
+  return (
+    <button
+      {...buttonProps}
+      ref={ref}
+      className={button({
+        onlyIcon,
+        variant: props.variant,
+        isCompact: props.isCompact,
+        isOutlined: props.isOutlined,
+      })}
+      onClick={handleClick}
+    >
+      {props.isLoading ? (
+        <>
+          <Loading className={spinner} />
+          {onlyIcon ? null : 'Loading'}
+        </>
+      ) : (
+        content
+      )}
+    </button>
+  );
+}
+
+export const NewButton = forwardRef(BaseButton);

--- a/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.spec.tsx
+++ b/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.spec.tsx
@@ -81,7 +81,7 @@ describe('ProgressCircle', () => {
     );
   });
 
-  it('supports custom DOM props', function () {
+  it('supports custom DOM props', () => {
     const { getByTestId } = render(
       <ProgressCircle value={25} aria-label="Progress" data-testid="test" />,
     );

--- a/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.spec.tsx
+++ b/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.spec.tsx
@@ -1,0 +1,91 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ProgressCircle } from './ProgressCircle';
+
+describe('ProgressCircle', () => {
+  it('Should handle defaults', () => {
+    const { getByRole } = render(<ProgressCircle aria-label="Progress" />);
+    const progressCircle = getByRole('progressbar');
+    expect(progressCircle).toHaveAttribute('aria-valuemin', '0');
+    expect(progressCircle).toHaveAttribute('aria-valuemax', '100');
+    expect(progressCircle).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('Should handle indeterminate', () => {
+    const { getByRole } = render(
+      <ProgressCircle aria-label="Progress" isIndeterminate />,
+    );
+    const progressCircle = getByRole('progressbar');
+    expect(progressCircle).toHaveAttribute('aria-valuemin', '0');
+    expect(progressCircle).toHaveAttribute('aria-valuemax', '100');
+    expect(progressCircle).not.toHaveAttribute('aria-valuenow');
+  });
+
+  it('Should handle controlled value', () => {
+    const { getByRole } = render(
+      <ProgressCircle aria-label="Progress" value={30} />,
+    );
+    const progressCircle = getByRole('progressbar');
+    expect(progressCircle).toHaveAttribute('aria-valuemin', '0');
+    expect(progressCircle).toHaveAttribute('aria-valuemax', '100');
+    expect(progressCircle).toHaveAttribute('aria-valuenow', '30');
+  });
+
+  it('Should clamp values to 0', () => {
+    const { getByRole } = render(
+      <ProgressCircle aria-label="Progress" value={-1} />,
+    );
+    const progressCircle = getByRole('progressbar');
+    expect(progressCircle).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('Should clamp values to 100', () => {
+    const { getByRole } = render(
+      <ProgressCircle aria-label="Progress" value={1000} />,
+    );
+    const progressCircle = getByRole('progressbar');
+    expect(progressCircle).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('Should support className', () => {
+    const { getByRole } = render(
+      <ProgressCircle aria-label="Progress" className="testClass" />,
+    );
+    const progressCircle = getByRole('progressbar');
+    expect(progressCircle).toHaveAttribute(
+      'class',
+      expect.stringContaining('testClass'),
+    );
+  });
+
+  it('can handle negative values with minValue and maxValue', () => {
+    const { getByRole } = render(
+      <ProgressCircle
+        aria-label="Progress"
+        value={0}
+        minValue={-5}
+        maxValue={5}
+      />,
+    );
+    const progressBar = getByRole('progressbar');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '0');
+    expect(progressBar).toHaveAttribute('aria-valuetext', '50%');
+  });
+
+  it('warns user if no aria-label is provided', () => {
+    const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(<ProgressCircle value={25} />);
+    expect(spyWarn).toHaveBeenCalledWith(
+      'If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility',
+    );
+  });
+
+  it('supports custom DOM props', function () {
+    const { getByTestId } = render(
+      <ProgressCircle value={25} aria-label="Progress" data-testid="test" />,
+    );
+    const progressBar = getByTestId('test');
+    expect(progressBar).toBeInTheDocument();
+  });
+});

--- a/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.stories.tsx
+++ b/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.stories.tsx
@@ -46,7 +46,7 @@ const meta: Meta<IProgressCircleProps> = {
       },
     },
     color: {
-      options: ['currentColor', ...Object.keys(colorAtoms)],
+      options: Object.keys(colorAtoms),
       control: {
         type: 'select',
       },

--- a/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.stories.tsx
+++ b/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { colorAtoms } from '../../styles/atoms.css';
+import type { IProgressCircleProps } from './ProgressCircle';
+import { ProgressCircle } from './ProgressCircle';
+
+console.log('colorAtoms', colorAtoms, Object.keys(colorAtoms));
+const meta: Meta<IProgressCircleProps> = {
+  title: 'Components/ProgressCircle',
+  parameters: {
+    status: {
+      type: ['inDevelopment'],
+    },
+    docs: {
+      description: {
+        component:
+          'A component that shows the completion status of a task or process.',
+      },
+    },
+  },
+  argTypes: {
+    isIndeterminate: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    value: {
+      control: {
+        type: 'number',
+      },
+    },
+    minValue: {
+      control: {
+        type: 'number',
+      },
+    },
+    maxValue: {
+      control: {
+        type: 'number',
+      },
+    },
+    size: {
+      options: ['sm', 'md', 'lg'],
+      control: {
+        type: 'select',
+      },
+    },
+    color: {
+      options: ['currentColor', ...Object.keys(colorAtoms)],
+      control: {
+        type: 'select',
+      },
+    },
+    label: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<IProgressCircleProps>;
+
+export const Primary: Story = {
+  name: 'ProgressCircle',
+  args: {
+    isIndeterminate: false,
+    value: 25,
+    minValue: 0,
+    maxValue: 100,
+    size: 'md',
+    color: 'icon.brand.primary.default',
+    label: 'Progress',
+  },
+  render: (args) => {
+    return <ProgressCircle {...args} />;
+  },
+};

--- a/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.tsx
@@ -47,7 +47,7 @@ export function ProgressCircle(props: IProgressCircleProps) {
       {...testProps(props)}
       className={classNames(
         atoms({
-          color: props.color !== 'currentColor' ? props.color : undefined,
+          color: props.color,
         }),
         props.className,
       )}

--- a/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.tsx
+++ b/packages/libs/react-ui/src/components/ProgressCircle/ProgressCircle.tsx
@@ -1,0 +1,87 @@
+import { clamp } from '@react-aria/utils';
+import classNames from 'classnames';
+import React from 'react';
+import type { AriaProgressBarProps } from 'react-aria';
+import { useProgressBar } from 'react-aria';
+import type { Atoms } from '../../styles/atoms.css';
+import { atoms } from '../../styles/atoms.css';
+import type { ITestProps } from '../../utils/testId';
+import { testProps } from '../../utils/testId';
+
+// eslint-disable-next-line @kadena-dev/typedef-var
+const SPINNER_SIZE = {
+  sm: 16,
+  md: 24,
+  lg: 32,
+} as const;
+
+type SpinnerSize = keyof typeof SPINNER_SIZE;
+export interface IProgressCircleProps extends AriaProgressBarProps, ITestProps {
+  isIndeterminate?: boolean;
+  size?: SpinnerSize;
+  color?: 'currentColor' | Atoms['color'];
+  className?: string;
+}
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type, react/function-component-definition
+export function ProgressCircle(props: IProgressCircleProps) {
+  const { isIndeterminate, value = 0, minValue = 0, maxValue = 100 } = props;
+  const v = clamp(value, minValue, maxValue);
+  const { progressBarProps } = useProgressBar({
+    ...props,
+    value: v,
+  });
+  const size = props.size ?? 'md';
+  const spinnerSize = SPINNER_SIZE[size];
+  const center = spinnerSize / 2;
+  const strokeWidth = spinnerSize / 8;
+  const r = center - strokeWidth;
+  const c = 2 * r * Math.PI;
+  const percentage = isIndeterminate
+    ? 0.25
+    : (v - minValue) / (maxValue - minValue);
+  const offset = c - percentage * c;
+
+  return (
+    <svg
+      {...progressBarProps}
+      {...testProps(props)}
+      className={classNames(
+        atoms({
+          color: props.color !== 'currentColor' ? props.color : undefined,
+        }),
+        props.className,
+      )}
+      width={spinnerSize}
+      height={spinnerSize}
+      viewBox={`0 0 ${spinnerSize} ${spinnerSize}`}
+      fill="none"
+      strokeWidth={strokeWidth}
+    >
+      <circle role="presentation" cx={center} cy={center} r={r} stroke="gray" />
+      <circle
+        {...testProps(props, 'progress')}
+        role="presentation"
+        cx={center}
+        cy={center}
+        r={r}
+        stroke="currentColor"
+        strokeDasharray={`${c} ${c}`}
+        strokeDashoffset={offset}
+        transform={`rotate(-90 ${center} ${center})`}
+      >
+        {props.isIndeterminate && (
+          <animateTransform
+            {...testProps(props, 'indeterminate-animation')}
+            attributeName="transform"
+            type="rotate"
+            begin="0s"
+            dur="1s"
+            from={`0 ${center} ${center}`}
+            to={`360 ${center} ${center}`}
+            repeatCount="indefinite"
+          />
+        )}
+      </circle>
+    </svg>
+  );
+}

--- a/packages/libs/react-ui/src/components/ProgressCircle/index.ts
+++ b/packages/libs/react-ui/src/components/ProgressCircle/index.ts
@@ -1,0 +1,1 @@
+export * from './ProgressCircle';

--- a/packages/libs/react-ui/src/styles/atoms.css.ts
+++ b/packages/libs/react-ui/src/styles/atoms.css.ts
@@ -61,6 +61,8 @@ const systemProperties = defineProperties({
   },
 });
 
+// eslint-disable-next-line @kadena-dev/typedef-var
+const spacingWithAuto = { ...tokens.kda.foundation.spacing, auto: 'auto' };
 const responsiveProperties = defineProperties({
   conditions: mapValues(breakpoints, (bp?: string) =>
     bp === '' ? {} : { '@media': bp },
@@ -80,7 +82,6 @@ const responsiveProperties = defineProperties({
     flexDirection: ['row', 'row-reverse', 'column', 'column-reverse'],
     fontSize: tokens.kda.foundation.typography.fontSize,
     gap: tokens.kda.foundation.spacing,
-    gridGap: tokens.kda.foundation.spacing,
     justifyContent: [
       'flex-start',
       'center',
@@ -89,22 +90,36 @@ const responsiveProperties = defineProperties({
       'space-between',
     ],
     lineHeight: tokens.kda.foundation.typography.lineHeight,
-    marginBottom: tokens.kda.foundation.spacing,
-    marginLeft: { ...tokens.kda.foundation.spacing, auto: 'auto' },
-    marginRight: { ...tokens.kda.foundation.spacing, auto: 'auto' },
-    marginTop: tokens.kda.foundation.spacing,
-    paddingBottom: tokens.kda.foundation.spacing,
-    paddingLeft: tokens.kda.foundation.spacing,
-    paddingRight: tokens.kda.foundation.spacing,
-    paddingTop: tokens.kda.foundation.spacing,
+    marginBlockEnd: spacingWithAuto,
+    marginInlineStart: spacingWithAuto,
+    marginInlineEnd: spacingWithAuto,
+    marginBlockStart: spacingWithAuto,
+    paddingBlockEnd: tokens.kda.foundation.spacing,
+    paddingInlineStart: tokens.kda.foundation.spacing,
+    paddingInlineEnd: tokens.kda.foundation.spacing,
+    paddingBlockStart: tokens.kda.foundation.spacing,
   },
   shorthands: {
-    margin: ['marginTop', 'marginBottom', 'marginLeft', 'marginRight'],
-    marginX: ['marginLeft', 'marginRight'],
-    marginY: ['marginTop', 'marginBottom'],
-    padding: ['paddingTop', 'paddingBottom', 'paddingLeft', 'paddingRight'],
-    paddingX: ['paddingLeft', 'paddingRight'],
-    paddingY: ['paddingTop', 'paddingBottom'],
+    margin: [
+      'marginBlockStart',
+      'marginBlockEnd',
+      'marginInlineStart',
+      'marginInlineEnd',
+    ],
+    marginX: ['marginInlineStart', 'marginInlineEnd'],
+    marginY: ['marginBlockStart', 'marginBlockEnd'],
+    marginInline: ['marginInlineStart', 'marginInlineEnd'],
+    marginBlock: ['marginBlockStart', 'marginBlockEnd'],
+    padding: [
+      'paddingBlockStart',
+      'paddingBlockEnd',
+      'paddingInlineStart',
+      'paddingInlineEnd',
+    ],
+    paddingX: ['paddingInlineStart', 'paddingInlineEnd'],
+    paddingY: ['paddingBlockStart', 'paddingBlockEnd'],
+    paddingInline: ['paddingInlineStart', 'paddingInlineEnd'],
+    paddingBlock: ['paddingBlockStart', 'paddingBlockEnd'],
   },
 });
 

--- a/packages/libs/react-ui/src/styles/atoms.css.ts
+++ b/packages/libs/react-ui/src/styles/atoms.css.ts
@@ -4,6 +4,7 @@ import { breakpoints, flattenTokens } from './themeUtils';
 import { tokens } from './tokens/contract.css';
 
 export const colorAtoms = flattenTokens({
+  currentColor: 'currentColor',
   icon: tokens.kda.foundation.color.icon,
   text: tokens.kda.foundation.color.text,
 });

--- a/packages/libs/react-ui/src/styles/atoms.css.ts
+++ b/packages/libs/react-ui/src/styles/atoms.css.ts
@@ -3,6 +3,11 @@ import mapValues from 'lodash.mapvalues';
 import { breakpoints, flattenTokens } from './themeUtils';
 import { tokens } from './tokens/contract.css';
 
+export const colorAtoms = flattenTokens({
+  icon: tokens.kda.foundation.color.icon,
+  text: tokens.kda.foundation.color.text,
+});
+
 const systemProperties = defineProperties({
   properties: {
     background: ['none'],
@@ -21,10 +26,7 @@ const systemProperties = defineProperties({
     borderWidth: tokens.kda.foundation.border.width,
     bottom: [0],
     boxShadow: tokens.kda.foundation.effect.shadow,
-    color: flattenTokens({
-      icon: tokens.kda.foundation.color.icon,
-      text: tokens.kda.foundation.color.text,
-    }),
+    color: colorAtoms,
     cursor: ['pointer', 'not-allowed'],
     flex: [1],
     flexGrow: [0, 1],

--- a/packages/libs/react-ui/src/styles/tokens/contract.css.ts
+++ b/packages/libs/react-ui/src/styles/tokens/contract.css.ts
@@ -85,45 +85,45 @@ export const tokens = createThemeContract({
       },
       radius: {
         /**
-         * @default 0
-         * @light 0
-         * @dark 0
+         * @default 0px
+         * @light 0px
+         * @dark 0px
          */
         no: '',
         /**
-         * @default 2
-         * @light 2
-         * @dark 2
+         * @default 2px
+         * @light 2px
+         * @dark 2px
          */
         xs: '',
         /**
-         * @default 4
-         * @light 4
-         * @dark 4
+         * @default 4px
+         * @light 4px
+         * @dark 4px
          */
         sm: '',
         /**
-         * @default 6
-         * @light 6
-         * @dark 6
+         * @default 6px
+         * @light 6px
+         * @dark 6px
          */
         md: '',
         /**
-         * @default 8
-         * @light 8
-         * @dark 8
+         * @default 8px
+         * @light 8px
+         * @dark 8px
          */
         lg: '',
         /**
-         * @default 16
-         * @light 16
-         * @dark 16
+         * @default 16px
+         * @light 16px
+         * @dark 16px
          */
         xl: '',
         /**
-         * @default 24
-         * @light 24
-         * @dark 24
+         * @default 24px
+         * @light 24px
+         * @dark 24px
          */
         xxl: '',
         /**
@@ -371,32 +371,91 @@ export const tokens = createThemeContract({
          */
         xxxl: '',
       },
-      effect: {
-        shadow: {
-          /**
-           * @description This is the shadow 1 description
-           * @default 4px 0.5rem kda.foundation.size.n2 4px #000000
-           * @light 4px 0.5rem kda.foundation.size.n2 4px #000000
-           * @dark 4px 0.5rem kda.foundation.size.n2 4px #000000
-           */
-          level1: '',
-          /**
-           * @description This is the shadow 2 description
-           * @default 4rem 4rem kda.foundation.size.n2 2rem #000000
-           * @light 4rem 4rem kda.foundation.size.n2 2rem #000000
-           * @dark 4rem 4rem kda.foundation.size.n2 2rem #000000
-           */
-          level2: '',
-          /**
-           * @description This is the shadow 3 description updated
-           * @default 0px 0px kda.foundation.size.n2 24px #000000
-           * @light 0px 0px kda.foundation.size.n2 24px #000000
-           * @dark 0px 0px kda.foundation.size.n2 24px #000000
-           */
-          level3: '',
-        },
-      },
       color: {
+        accent: {
+          /**
+           * @default kda.foundation.color.palette.blue.n70
+           * @light kda.foundation.color.palette.blue.n70
+           * @dark kda.foundation.color.palette.blue.n70
+           */
+          blue: '',
+          /**
+           * @default kda.foundation.color.palette.indigo.n70
+           * @light kda.foundation.color.palette.indigo.n70
+           * @dark kda.foundation.color.palette.indigo.n70
+           */
+          indigo: '',
+          /**
+           * @default kda.foundation.color.palette.lime.n70
+           * @light kda.foundation.color.palette.lime.n70
+           * @dark kda.foundation.color.palette.lime.n70
+           */
+          lime: '',
+          /**
+           * @default kda.foundation.color.palette.magenta.n70
+           * @light kda.foundation.color.palette.magenta.n70
+           * @dark kda.foundation.color.palette.magenta.n70
+           */
+          magenta: '',
+          /**
+           * @default kda.foundation.color.palette.purple.n70
+           * @light kda.foundation.color.palette.purple.n70
+           * @dark kda.foundation.color.palette.purple.n70
+           */
+          purple: '',
+          /**
+           * @default kda.foundation.color.palette.red.n70
+           * @light kda.foundation.color.palette.red.n70
+           * @dark kda.foundation.color.palette.red.n70
+           */
+          red: '',
+          /**
+           * @default kda.foundation.color.palette.yellow.n70
+           * @light kda.foundation.color.palette.yellow.n70
+           * @dark kda.foundation.color.palette.yellow.n70
+           */
+          yellow: '',
+          brand: {
+            /**
+             * @default kda.foundation.color.brand.primary.n70
+             * @light kda.foundation.color.brand.primary.n70
+             * @dark kda.foundation.color.brand.primary.n70
+             */
+            primary: '',
+            /**
+             * @default kda.foundation.color.brand.secondary.n70
+             * @light kda.foundation.color.brand.secondary.n70
+             * @dark kda.foundation.color.brand.secondary.n70
+             */
+            secondary: '',
+          },
+          semantic: {
+            /**
+             * @default kda.foundation.color.semantic.info.n70
+             * @light kda.foundation.color.semantic.info.n70
+             * @dark kda.foundation.color.semantic.info.n70
+             */
+            info: '',
+            /**
+             * @default kda.foundation.color.semantic.warning.n70
+             * @light kda.foundation.color.semantic.warning.n70
+             * @dark kda.foundation.color.semantic.warning.n70
+             */
+            warning: '',
+            /**
+             * @default kda.foundation.color.semantic.positive.n70
+             * @light kda.foundation.color.semantic.positive.n70
+             * @dark kda.foundation.color.semantic.positive.n70
+             */
+            positive: '',
+            /**
+             * @default kda.foundation.color.semantic.negative.n70
+             * @light kda.foundation.color.semantic.negative.n70
+             * @dark kda.foundation.color.semantic.negative.n70
+             */
+            negative: '',
+          },
+        },
         background: {
           base: {
             /**
@@ -2778,6 +2837,77 @@ export const tokens = createThemeContract({
              */
             '@hover': '',
           },
+        },
+      },
+      effect: {
+        shadow: {
+          /**
+           * @description This is the shadow 1 description
+           * @default 4px 0.5rem kda.foundation.size.n2 4px #000000
+           * @light 4px 0.5rem kda.foundation.size.n2 4px #000000
+           * @dark 4px 0.5rem kda.foundation.size.n2 4px #000000
+           */
+          level1: '',
+          /**
+           * @description This is the shadow 2 description
+           * @default 4rem 4rem kda.foundation.size.n2 2rem #000000
+           * @light 4rem 4rem kda.foundation.size.n2 2rem #000000
+           * @dark 4rem 4rem kda.foundation.size.n2 2rem #000000
+           */
+          level2: '',
+          /**
+           * @description This is the shadow 3 description updated
+           * @default 0px 0px kda.foundation.size.n2 24px #000000
+           * @light 0px 0px kda.foundation.size.n2 24px #000000
+           * @dark 0px 0px kda.foundation.size.n2 24px #000000
+           */
+          level3: '',
+        },
+      },
+      icon: {
+        size: {
+          /**
+           * @default kda.foundation.size.n3
+           * @light kda.foundation.size.n3
+           * @dark kda.foundation.size.n3
+           */
+          xxs: '',
+          /**
+           * @default kda.foundation.size.n4
+           * @light kda.foundation.size.n4
+           * @dark kda.foundation.size.n4
+           */
+          xs: '',
+          /**
+           * @default kda.foundation.size.n5
+           * @light kda.foundation.size.n5
+           * @dark kda.foundation.size.n5
+           */
+          sm: '',
+          /**
+           * @default kda.foundation.size.n6
+           * @light kda.foundation.size.n6
+           * @dark kda.foundation.size.n6
+           */
+          base: '',
+          /**
+           * @default kda.foundation.size.n8
+           * @light kda.foundation.size.n8
+           * @dark kda.foundation.size.n8
+           */
+          lg: '',
+          /**
+           * @default kda.foundation.size.n10
+           * @light kda.foundation.size.n10
+           * @dark kda.foundation.size.n10
+           */
+          xl: '',
+          /**
+           * @default kda.foundation.size.n16
+           * @light kda.foundation.size.n16
+           * @dark kda.foundation.size.n16
+           */
+          xxl: '',
         },
       },
       layout: {

--- a/packages/libs/react-ui/src/styles/tokens/dark.css.ts
+++ b/packages/libs/react-ui/src/styles/tokens/dark.css.ts
@@ -24,13 +24,13 @@ export const darkThemeValues = {
         xxl: '96rem',
       },
       radius: {
-        no: '0',
-        xs: '2',
-        sm: '4',
-        md: '6',
-        lg: '8',
-        xl: '16',
-        xxl: '24',
+        no: '0px',
+        xs: '2px',
+        sm: '4px',
+        md: '6px',
+        lg: '8px',
+        xl: '16px',
+        xxl: '24px',
         round: '999rem',
       },
       size: {
@@ -76,14 +76,26 @@ export const darkThemeValues = {
         xxl: tokens.kda.foundation.size.n9,
         xxxl: tokens.kda.foundation.size.n10,
       },
-      effect: {
-        shadow: {
-          level1: `4px 0.5rem ${tokens.kda.foundation.size.n2} 4px #000000`,
-          level2: `4rem 4rem ${tokens.kda.foundation.size.n2} 2rem #000000`,
-          level3: `0px 0px ${tokens.kda.foundation.size.n2} 24px #000000`,
-        },
-      },
       color: {
+        accent: {
+          blue: tokens.kda.foundation.color.palette.blue.n70,
+          indigo: tokens.kda.foundation.color.palette.indigo.n70,
+          lime: tokens.kda.foundation.color.palette.lime.n70,
+          magenta: tokens.kda.foundation.color.palette.magenta.n70,
+          purple: tokens.kda.foundation.color.palette.purple.n70,
+          red: tokens.kda.foundation.color.palette.red.n70,
+          yellow: tokens.kda.foundation.color.palette.yellow.n70,
+          brand: {
+            primary: tokens.kda.foundation.color.brand.primary.n70,
+            secondary: tokens.kda.foundation.color.brand.secondary.n70,
+          },
+          semantic: {
+            info: tokens.kda.foundation.color.semantic.info.n70,
+            warning: tokens.kda.foundation.color.semantic.warning.n70,
+            positive: tokens.kda.foundation.color.semantic.positive.n70,
+            negative: tokens.kda.foundation.color.semantic.negative.n70,
+          },
+        },
         background: {
           base: {
             default: tokens.kda.foundation.color.neutral.n20,
@@ -610,6 +622,24 @@ export const darkThemeValues = {
             default: '#fec195',
             '@hover': '#fedec8',
           },
+        },
+      },
+      effect: {
+        shadow: {
+          level1: `4px 0.5rem ${tokens.kda.foundation.size.n2} 4px #000000`,
+          level2: `4rem 4rem ${tokens.kda.foundation.size.n2} 2rem #000000`,
+          level3: `0px 0px ${tokens.kda.foundation.size.n2} 24px #000000`,
+        },
+      },
+      icon: {
+        size: {
+          xxs: tokens.kda.foundation.size.n3,
+          xs: tokens.kda.foundation.size.n4,
+          sm: tokens.kda.foundation.size.n5,
+          base: tokens.kda.foundation.size.n6,
+          lg: tokens.kda.foundation.size.n8,
+          xl: tokens.kda.foundation.size.n10,
+          xxl: tokens.kda.foundation.size.n16,
         },
       },
       layout: {

--- a/packages/libs/react-ui/src/styles/tokens/light.css.ts
+++ b/packages/libs/react-ui/src/styles/tokens/light.css.ts
@@ -24,13 +24,13 @@ export const lightThemeValues = {
         xxl: '96rem',
       },
       radius: {
-        no: '0',
-        xs: '2',
-        sm: '4',
-        md: '6',
-        lg: '8',
-        xl: '16',
-        xxl: '24',
+        no: '0px',
+        xs: '2px',
+        sm: '4px',
+        md: '6px',
+        lg: '8px',
+        xl: '16px',
+        xxl: '24px',
         round: '999rem',
       },
       size: {
@@ -76,14 +76,26 @@ export const lightThemeValues = {
         xxl: tokens.kda.foundation.size.n9,
         xxxl: tokens.kda.foundation.size.n10,
       },
-      effect: {
-        shadow: {
-          level1: `4px 0.5rem ${tokens.kda.foundation.size.n2} 4px #000000`,
-          level2: `4rem 4rem ${tokens.kda.foundation.size.n2} 2rem #000000`,
-          level3: `0px 0px ${tokens.kda.foundation.size.n2} 24px #000000`,
-        },
-      },
       color: {
+        accent: {
+          blue: tokens.kda.foundation.color.palette.blue.n70,
+          indigo: tokens.kda.foundation.color.palette.indigo.n70,
+          lime: tokens.kda.foundation.color.palette.lime.n70,
+          magenta: tokens.kda.foundation.color.palette.magenta.n70,
+          purple: tokens.kda.foundation.color.palette.purple.n70,
+          red: tokens.kda.foundation.color.palette.red.n70,
+          yellow: tokens.kda.foundation.color.palette.yellow.n70,
+          brand: {
+            primary: tokens.kda.foundation.color.brand.primary.n70,
+            secondary: tokens.kda.foundation.color.brand.secondary.n70,
+          },
+          semantic: {
+            info: tokens.kda.foundation.color.semantic.info.n70,
+            warning: tokens.kda.foundation.color.semantic.warning.n70,
+            positive: tokens.kda.foundation.color.semantic.positive.n70,
+            negative: tokens.kda.foundation.color.semantic.negative.n70,
+          },
+        },
         background: {
           base: {
             default: tokens.kda.foundation.color.neutral.n20,
@@ -610,6 +622,24 @@ export const lightThemeValues = {
             default: '#a54800',
             '@hover': '#702e00',
           },
+        },
+      },
+      effect: {
+        shadow: {
+          level1: `4px 0.5rem ${tokens.kda.foundation.size.n2} 4px #000000`,
+          level2: `4rem 4rem ${tokens.kda.foundation.size.n2} 2rem #000000`,
+          level3: `0px 0px ${tokens.kda.foundation.size.n2} 24px #000000`,
+        },
+      },
+      icon: {
+        size: {
+          xxs: tokens.kda.foundation.size.n3,
+          xs: tokens.kda.foundation.size.n4,
+          sm: tokens.kda.foundation.size.n5,
+          base: tokens.kda.foundation.size.n6,
+          lg: tokens.kda.foundation.size.n8,
+          xl: tokens.kda.foundation.size.n10,
+          xxl: tokens.kda.foundation.size.n16,
         },
       },
       layout: {

--- a/packages/libs/react-ui/src/utils/testId.ts
+++ b/packages/libs/react-ui/src/utils/testId.ts
@@ -1,0 +1,17 @@
+export interface ITestProps {
+  'data-testid'?: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const testProps = (props: ITestProps, postfix = '') =>
+  typeof props['data-testid'] === 'string'
+    ? {
+        'data-testid': `${props['data-testid']}${postfix ? `-${postfix}` : ''}`,
+      }
+    : {};
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const withTestProps = (props: ITestProps) => ({
+  ...props,
+  ...testProps(props),
+});


### PR DESCRIPTION
1. Use react aria which come with one major change is `onPress` instead of `onClick` read more about why https://react-spectrum.adobe.com/blog/building-a-button-part-1.html. we added `onClick` to allow easy migration but it is deprecated and we should not use it for new code.
2. Unify the `IconButton` and `Button` components using `<Button icon={<SomeIcon/>} />` instead of `IconButton`.
3. Change some props names to be consistent with react-aria naming `compact` -> `isCompact`.
4. `Button` is not a polymorphic component anymore we will have a separate link component.
5. `iconAlign` is replaced by specific icon renders props `startIcon` and `endIcon`, and `icon` is repurposed for icon-only buttons aka `IconButton`.
6. Use `recipe` instead of individual `styleVariants`. 
7. `color` and `variant` are now one prop `variant` and all `alternative` variants are added as a standalone variant eg `<Button color="primary" variant="alternative" />` is now `<Button variant="primaryInverted" />` we use `inverted` postfix is used instead of  `alternative` to match the intended color inversion behavior.
8. The `isCompact` variant now works for all button variations before it only worked for some color variants.