### PR TITLE
[@kadena/graph] Exposed tracing to extensions

### DIFF
--- a/.changeset/tidy-trains-fly.md
+++ b/.changeset/tidy-trains-fly.md
@@ -1,0 +1,5 @@
+---
+'@kadena/graph': patch
+---
+
+Expose tracing data in the extension

--- a/packages/apps/graph/.env.example
+++ b/packages/apps/graph/.env.example
@@ -20,4 +20,5 @@ PORT=4000
 
 # Tracing
 TRACING_ENABLED=false
+TRACING_EXPOSED=false
 TRACING_LOG_FILENAME="traces.log"

--- a/packages/apps/graph/src/index.ts
+++ b/packages/apps/graph/src/index.ts
@@ -7,13 +7,14 @@ import { createServer } from 'node:http';
 import './graph';
 import { builder } from './graph/builder';
 import { complexityPlugin } from './plugins/complexity';
+import { extensionsPlugin } from './plugins/extensions';
 import { writeSchema } from './utils/write-schema';
 
 writeSchema();
 
 const schema = builder.toSchema();
 
-const plugins = [];
+const plugins = [extensionsPlugin()];
 
 if (dotenv.COMPLEXITY_EXPOSED) {
   plugins.push(complexityPlugin(schema));
@@ -23,7 +24,12 @@ createServer(
   createYoga({
     schema,
     plugins,
+    context: () => {
+      return {
+        extensions: {},
+      };
+    },
   }),
 ).listen(dotenv.PORT, () => {
-  console.info('Server is running on http://localhost:4000/graphql');
+  console.info(`Server is running on http://localhost:${dotenv.PORT}/graphql`);
 });

--- a/packages/apps/graph/src/plugins/extensions.ts
+++ b/packages/apps/graph/src/plugins/extensions.ts
@@ -1,0 +1,20 @@
+import type { Plugin } from 'graphql-yoga';
+import { handleStreamOrSingleExecutionResult } from 'graphql-yoga';
+import type { IContext } from '../graph/builder';
+
+export const extensionsPlugin = () =>
+  ({
+    onExecute: () => ({
+      onExecuteDone(options: any) {
+        handleStreamOrSingleExecutionResult(
+          options,
+          ({ result, args: { contextValue } }) => {
+            result.extensions = {
+              ...result.extensions,
+              ...(contextValue as unknown as IContext).extensions,
+            };
+          },
+        );
+      },
+    }),
+  }) as Plugin;

--- a/packages/apps/graph/src/utils/dotenv.ts
+++ b/packages/apps/graph/src/utils/dotenv.ts
@@ -13,6 +13,7 @@ export const dotenv: {
   NETWORK_ID: string;
   PORT: number;
   TRACING_ENABLED: boolean;
+  TRACING_EXPOSED: boolean;
   TRACING_LOG_FILENAME: string;
 } = {
   CHAIN_COUNT: parseInt(or(process.env.CHAIN_COUNT, '20'), 10),
@@ -31,6 +32,7 @@ export const dotenv: {
   NETWORK_ID: or(process.env.NETWORK_ID, 'fast-development'),
   PORT: parseInt(or(process.env.PORT, '4000'), 10),
   TRACING_ENABLED: or(process.env.TRACING_ENABLED === 'true', false),
+  TRACING_EXPOSED: or(process.env.TRACING_EXPOSED === 'true', false),
   TRACING_LOG_FILENAME: or(process.env.TRACING_LOG_FILENAME, 'traces.log'),
 };
 


### PR DESCRIPTION
With the help of @hayes: https://github.com/hayes/pothos/issues/1094

Query:

```graphql
query ($hash: String!) {
  block(hash: $hash) {    
    id
    chainId
    creationTime
    epoch
    hash
    height
    payloadHash
    powHash
    predicate
    minerAccount {
      guard {
        keys
        predicate
      }
    }
  }
}
```

Result when `TRACING_EXPOSED` and `COMPLEXITY_EXPOSED` are set to `true`:

```
{
  "data": {
    "block": {
      "chainId": 5,
      "creationTime": "2023-11-09T14:13:29.176Z",
      "epoch": "2023-11-09T14:06:00.656Z",
      "hash": "WzpZ6ElQKcSpb_Xuhrm_6wSG5jT7zWLMWhmckKUQgH0",
      "height": 6444,
      "payloadHash": "U4FUAkmPk5J6TvGfZYycxrCrVd2YHtEVSaFqDg4qiAw",
      "powHash": "cfe99c5912299b5715c7e0c0a585b228b7297f4397cd132239fe51b89b84fe1e",
      "predicate": "keys-all",
      "id": "QmxvY2s6V3pwWjZFbFFLY1NwYl9YdWhybV82d1NHNWpUN3pXTE1XaG1ja0tVUWdIMA==",
      "minerAccount": {
        "guard": {
          "keys": [
            "f90ef46927f506c70b6a58fd322450a936311dc6ac91f4ec3d8ef949608dbf1f"
          ],
          "predicate": "keys-all"
        }
      }
    }
  },
  "extensions": {
    "tracing": {
      "Query.block": 3.419188000028953,
      "Block.chainId": 0.006286000134423375,
      "Block.creationTime": 0.00532800005748868,
      "Block.epoch": 0.001471000025048852,
      "Block.hash": 0.0011470001190900803,
      "Block.height": 0.0011700000613927841,
      "Block.payloadHash": 0.0011250001844018698,
      "Block.powHash": 0.0010319999419152737,
      "Block.predicate": 0.0009850000496953726,
      "Block.id": 0.48883899999782443,
      "Block.minerAccount": 3.1457730000838637,
      "ChainFungibleAccount.guard": 7.002318999962881,
      "Guard.keys": 0.005478000035509467,
      "Guard.predicate": 0.0012620000634342432
    },
    "complexity": {
      "depth": 4,
      "breadth": 14,
      "complexity": 33
    }
  }
}
```