### PR TITLE
[chore] Albert pushes updates to the release branch, instead of githu…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
+          token: ${{ secrets.RELEASE_ACTION_GITHUB_TOKEN }}
 
       - uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           publish: pnpm run publish
           commit: 'Update changelogs and bump versions'
           title: '[ci] Release'
+          setupGitUser: false
         env:
           # Needs "Contents" r+w and "Pull requests" r+w access to open/update PRs and push to main
           GITHUB_TOKEN: ${{ secrets.RELEASE_ACTION_GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, Github Actions do not execute the `[CI] Release` pull requests. This is due to restrictions imposed upon us by Github to  prevent recursive workflow triggers: A PR or commit that was created/pushed by GitHub Actions won't have workflows triggered.

We already use a personal access token to create the initial PR. While this solves the PR Creator, any subsequent commits wil still be done by the Github actions bot, disabling any subsequent runs of any workfows. 

This PR aims use the same access token to create the PR as well as commit to the changeset branch.

