### PR TITLE
[@kadena/client-utils] Temporary fix for the return type of getBalance

### DIFF
--- a/.changeset/hip-shirts-agree.md
+++ b/.changeset/hip-shirts-agree.md
@@ -1,0 +1,6 @@
+---
+'@kadena/client-utils': patch
+'@kadena/graph': patch
+---
+
+Changed the return type for getBalance to string.

--- a/packages/apps/graph/src/devnet/helper.ts
+++ b/packages/apps/graph/src/devnet/helper.ts
@@ -188,9 +188,5 @@ export const getAccountBalance = async ({
     dotenv.NETWORK_HOST,
   );
 
-  if (typeof result === 'object') {
-    return parseFloat(result.decimal);
-  }
-
   return result || 0;
 };

--- a/packages/libs/client-utils/etc/client-utils-coin.api.md
+++ b/packages/libs/client-utils/etc/client-utils-coin.api.md
@@ -10,7 +10,6 @@ import { ICommandResult } from '@kadena/chainweb-node-client';
 import { ILocalCommandResult } from '@kadena/chainweb-node-client';
 import type { INetworkOptions } from '@kadena/client';
 import type { IPactCommand } from '@kadena/client';
-import { IPactDecimal } from '@kadena/types';
 import { IPartialPactCommand } from '@kadena/client/lib/interfaces/IPactCommand';
 import type { ISignFunction } from '@kadena/client';
 import { ITransactionDescriptor } from '@kadena/client';
@@ -46,7 +45,7 @@ export const createCrossChainCommand: ({ sender, receiver, amount, targetChainId
 export const details: (account: string, networkId: string, chainId: ChainId, host?: IClientConfig['host'], contract?: string) => Promise<undefined> | Promise<object>;
 
 // @alpha (undocumented)
-export const getBalance: (account: string, networkId: string, chainId: ChainId, host?: IClientConfig['host'], contract?: string) => Promise<undefined> | Promise<IPactDecimal>;
+export const getBalance: (account: string, networkId: string, chainId: ChainId, host?: IClientConfig['host'], contract?: string) => Promise<string | undefined>;
 
 // Warning: (ae-forgotten-export) The symbol "IRotateCommandInput" needs to be exported by the entry point index.d.ts
 //

--- a/packages/libs/client-utils/src/coin/get-balance.ts
+++ b/packages/libs/client-utils/src/coin/get-balance.ts
@@ -10,14 +10,14 @@ import { pipe } from 'ramda';
 /**
  * @alpha
  */
-export const getBalance = (
+export const getBalance = async (
   account: string,
   networkId: string,
   chainId: ChainId,
   host?: IClientConfig['host'],
   contract: string = 'coin',
 ) => {
-  const balance = pipe(
+  const result = await pipe(
     (name) => Pact.modules[contract as 'coin']['get-balance'](name),
     execution,
     dirtyReadClient<PactReturnType<IPactModules['coin']['get-balance']>>({
@@ -27,6 +27,15 @@ export const getBalance = (
         meta: { chainId },
       },
     }),
-  );
-  return balance(account).execute();
+  )(account).execute();
+
+  if (typeof result === 'object') {
+    return result.decimal;
+  }
+
+  if (result !== undefined) {
+    return (result as unknown as number).toString();
+  }
+
+  return result;
 };


### PR DESCRIPTION
`get-balance` has return type `IPactDecimal | undefined` defined, which is incorrect. It should be `IPactDecimal | number | undefined`. This is a temporary fix so that it always returns a string for now. Later @javadkh2 will update the client to parse all decimals into a standard value.