### PR TITLE
[@kadena/graph] Allow marmalade deployment on multiple chains (Feat)

### DIFF
--- a/.changeset/flat-carrots-prove.md
+++ b/.changeset/flat-carrots-prove.md
@@ -1,0 +1,5 @@
+---
+'@kadena/graph': patch
+---
+
+Added multi-chain support for marmalade deployment

--- a/packages/apps/graph/package.json
+++ b/packages/apps/graph/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "prebuild": "pnpm run pactjs:generate:contract:coin && pnpm run pactjs:generate:contract:marmalade && pnpm prisma:generate",
     "build": "tsc",
-    "deploy:marmalade": "ts-node -T src/devnet/simulation/index.ts deploy:marmalade",
+    "deploy:marmalade": "ts-node -T src/devnet/deployment/index.ts deploy:marmalade",
     "devnet": "docker volume create kadena_devnet; docker run --rm -it -p 8080:8080 -p 5432:5432 -p 9999:9999 -v kadena_devnet:/data -v ./cwd-extra-migrations:/cwd-extra-migrations:ro --name devnet kadena/devnet",
     "devnet:update": "docker pull kadena/devnet",
     "format": "pnpm run --sequential /^format:.*/",

--- a/packages/apps/graph/src/devnet/deployment/index.ts
+++ b/packages/apps/graph/src/devnet/deployment/index.ts
@@ -1,0 +1,28 @@
+import 'module-alias/register';
+
+import { sender00 } from '@devnet/utils';
+import { ChainId } from '@kadena/types';
+import { dotenv } from '@utils/dotenv';
+import { logger } from '@utils/logger';
+import { Option, program } from 'commander';
+import { deployMarmaladeContracts } from './marmalade/deploy';
+
+program
+  .command('deploy:marmalade')
+  .description('Deploy marmalade contracts on the devnet')
+  .addOption(
+    new Option('-c --chainId <string>', 'Chain Id to deploy to').default(
+      dotenv.SIMULATE_DEFAULT_CHAIN_ID,
+    ),
+  )
+  .action(async (args) => {
+    try {
+      const chainId = args.chainId.split(',') as ChainId[];
+      logger.info('Deploying marmalade contracts on chains:', chainId);
+      await deployMarmaladeContracts(sender00, chainId);
+    } catch (error) {
+      console.error(error);
+    }
+  });
+
+program.parse();

--- a/packages/apps/graph/src/devnet/deployment/index.ts
+++ b/packages/apps/graph/src/devnet/deployment/index.ts
@@ -1,7 +1,7 @@
 import 'module-alias/register';
 
 import { sender00 } from '@devnet/utils';
-import { ChainId } from '@kadena/types';
+import type { ChainId } from '@kadena/types';
 import { dotenv } from '@utils/dotenv';
 import { logger } from '@utils/logger';
 import { Option, program } from 'commander';

--- a/packages/apps/graph/src/devnet/deployment/marmalade/README.md
+++ b/packages/apps/graph/src/devnet/deployment/marmalade/README.md
@@ -16,7 +16,14 @@ contracts in the devnet. The goal of this folder is to deploy the Marmalade
 scripts into the devnet. It contains all the necessary scripts and configuration
 files to facilitate this process.
 
-To deploy marmalade in devnet, please run the `pnpm deploy:marmalade`
+To deploy marmalade in devnet, please run the
+
+```sh
+pnpm deploy:marmalade -c <chains>
+```
+
+The chains format is comma-separated list, so if you want it do be deployed in
+chain 1 and 2, the command would look like `pnpm deploy:marmalade -c 1,2`
 
 ## Concepts
 

--- a/packages/apps/graph/src/devnet/deployment/marmalade/README.md
+++ b/packages/apps/graph/src/devnet/deployment/marmalade/README.md
@@ -16,7 +16,7 @@ contracts in the devnet. The goal of this folder is to deploy the Marmalade
 scripts into the devnet. It contains all the necessary scripts and configuration
 files to facilitate this process.
 
-To deploy marmalade in devnet, please run the
+To deploy marmalade in devnet, please run
 
 ```sh
 pnpm deploy:marmalade -c <chains>

--- a/packages/apps/graph/src/devnet/deployment/marmalade/deploy.ts
+++ b/packages/apps/graph/src/devnet/deployment/marmalade/deploy.ts
@@ -1,10 +1,10 @@
-import { ChainId, createTransaction } from '@kadena/client';
+import type { ChainId } from '@kadena/client';
+import { createTransaction } from '@kadena/client';
 import { createPactCommandFromTemplate } from '@kadena/client-utils/nodejs';
 import { readFileSync, readdirSync, writeFileSync } from 'fs';
 import yaml from 'js-yaml';
 import { join, relative } from 'path';
 
-import { dotenv } from '@utils/dotenv';
 import { downloadGitFiles } from '@utils/download-git-files';
 import { logger } from '@utils/logger';
 import { flattenFolder } from '@utils/path';

--- a/packages/apps/graph/src/devnet/deployment/marmalade/namespace.ts
+++ b/packages/apps/graph/src/devnet/deployment/marmalade/namespace.ts
@@ -15,11 +15,13 @@ export async function deployMarmamaladeNamespaces({
   namespacesConfig,
   sender = sender00,
   fileExtension,
+  chainId,
 }: {
   localConfigData: IMarmaladeLocalConfig;
   namespacesConfig: IMarmaladeNamespaceConfig[];
   sender?: IAccount;
   fileExtension: string;
+  chainId: ChainId;
 }): Promise<void> {
   const publickeys = sender.keys.map((key) => key.publicKey);
 
@@ -80,6 +82,7 @@ export async function deployMarmamaladeNamespaces({
             data: namespace,
           },
           keysets,
+          chainId,
         });
 
         logger.info(`Deploying namespace file ${config.file} for ${namespace}`);
@@ -102,7 +105,7 @@ export async function deployMarmamaladeNamespaces({
 export async function createPactCommandFromFile(
   filepath: string,
   {
-    chainId = dotenv.SIMULATE_DEFAULT_CHAIN_ID,
+    chainId,
     networkId = dotenv.NETWORK_ID,
     signers = sender00.keys,
     meta = {
@@ -114,7 +117,7 @@ export async function createPactCommandFromFile(
     keysets,
     namespace,
   }: {
-    chainId?: ChainId;
+    chainId: ChainId;
     networkId?: string;
     signers?: IKeyPair[];
     meta?: {

--- a/packages/apps/graph/src/devnet/simulation/index.ts
+++ b/packages/apps/graph/src/devnet/simulation/index.ts
@@ -1,10 +1,8 @@
 import 'module-alias/register';
 
 import type { IAccount } from '@devnet/utils';
-import { sender00 } from '@devnet/utils';
 import { logger } from '@utils/logger';
 import { Command, Option } from 'commander';
-import { deployMarmaladeContracts } from '../deployment/marmalade/deploy';
 import { simulateCoin } from './coin/simulate';
 import { transfer } from './coin/transfer';
 import { generateAccount } from './helper';
@@ -77,17 +75,6 @@ program
     try {
       logger.info('Simulation config parameters:', args);
       await simulateCoin(args);
-    } catch (error) {
-      console.error(error);
-    }
-  });
-
-program
-  .command('deploy:marmalade')
-  .description('Deploy marmalade contracts on the devnet')
-  .action(async (args) => {
-    try {
-      await deployMarmaladeContracts(sender00);
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
We can pass a chain argument in the cli now, when calling `pnpm deploy:marmalade`

<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->
