### PR TITLE
[@kadena/graph] Event queries added

### DIFF
--- a/.changeset/mighty-colts-help.md
+++ b/.changeset/mighty-colts-help.md
@@ -1,0 +1,6 @@
+---
+'@kadena/graph-client': patch
+'@kadena/graph': patch
+---
+
+Added event queries and views.

--- a/packages/apps/graph-client/src/components/events-table/events-table.tsx
+++ b/packages/apps/graph-client/src/components/events-table/events-table.tsx
@@ -1,0 +1,82 @@
+import type { Event } from '@/__generated__/sdk';
+import routes from '@/constants/routes';
+import { formatCode } from '@/utils/formatter';
+import { Table } from '@kadena/react-ui';
+import React from 'react';
+
+interface IEventsTableProps {
+  events?: Event[];
+}
+
+export const EventsTable = (props: IEventsTableProps): JSX.Element => {
+  const { events = [] } = props;
+
+  return (
+    <>
+      <Table.Root striped wordBreak="break-word">
+        <Table.Head>
+          <Table.Tr>
+            <Table.Th>Block Height</Table.Th>
+            <Table.Th>Chain ID</Table.Th>
+            <Table.Th>Parameters</Table.Th>
+            <Table.Th>Request Key</Table.Th>
+            <Table.Th></Table.Th>
+          </Table.Tr>
+        </Table.Head>
+        <Table.Body>
+          {events.map((event, index) => (
+            <Table.Tr
+              key={index}
+              url={`${routes.TRANSACTIONS}/${event.requestKey}`}
+            >
+              <Table.Td>{event.height}</Table.Td>
+              <Table.Td>{event.chainId}</Table.Td>
+              <Table.Td>
+                <Table.Root>
+                  <Table.Body>
+                    {JSON.parse(event.parameterText).map(
+                      (parameter: any, index: number) => (
+                        <Table.Tr key={`arguments-${index}`}>
+                          <Table.Td>
+                            {typeof parameter === 'string' ? (
+                              parameter
+                            ) : Array.isArray(parameter) ? (
+                              <Table.Root>
+                                <Table.Body>
+                                  {parameter.map(
+                                    (subparameter: any, index: number) => (
+                                      <Table.Tr key={`arguments-${index}`}>
+                                        <Table.Td>
+                                          {typeof subparameter === 'string' ? (
+                                            subparameter
+                                          ) : (
+                                            <pre>
+                                              {formatCode(
+                                                JSON.stringify(subparameter),
+                                              )}
+                                            </pre>
+                                          )}
+                                        </Table.Td>
+                                      </Table.Tr>
+                                    ),
+                                  )}
+                                </Table.Body>
+                              </Table.Root>
+                            ) : (
+                              JSON.stringify(parameter)
+                            )}
+                          </Table.Td>
+                        </Table.Tr>
+                      ),
+                    )}
+                  </Table.Body>
+                </Table.Root>
+              </Table.Td>
+              <Table.Td>{event.requestKey}</Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </>
+  );
+};

--- a/packages/apps/graph-client/src/components/extended-transactions-table/extended-transactions-table.tsx
+++ b/packages/apps/graph-client/src/components/extended-transactions-table/extended-transactions-table.tsx
@@ -33,7 +33,6 @@ export const ExtendedTransactionsTable = (
 
   // Parse the query parameters from the URL using Next.js router
   const router = useRouter();
-  // const { page: urlPage, items: urlItemsPerPage } = router.query;
   const urlPage = router.query.page;
   const urlItemsPerPage = router.query.items;
 

--- a/packages/apps/graph-client/src/graphql/queries.graph.ts
+++ b/packages/apps/graph-client/src/graphql/queries.graph.ts
@@ -4,6 +4,7 @@ import {
   ALL_CHAIN_ACCOUNT_FIELDS,
   CORE_CHAIN_ACCOUNT_FIELDS,
 } from './fields/chain-account.graph';
+import { ALL_EVENT_FIELDS } from './fields/event.graph';
 import { CORE_MINER_KEY_FIELDS } from './fields/miner-key.graph';
 import { CORE_TRANSACTION_FIELDS } from './fields/transaction.graph';
 import { CORE_TRANSFER_FIELDS } from './fields/transfer.graph';
@@ -249,6 +250,41 @@ export const getTransfers: DocumentNode = gql`
     }
   }
 `;
+
+export const getEvents: DocumentNode = gql`
+  ${ALL_EVENT_FIELDS}
+
+  query getEvents(
+    $qualifiedEventName: String!
+    $after: String
+    $before: String
+    $first: Int
+    $last: Int
+  ) {
+    events(
+      qualifiedEventName: $qualifiedEventName
+      after: $after
+      before: $before
+      first: $first
+      last: $last
+    ) {
+      totalCount
+      pageInfo {
+        startCursor
+        endCursor
+        hasPreviousPage
+        hasNextPage
+      }
+      edges {
+        cursor
+        node {
+          ...AllEventFields
+        }
+      }
+    }
+  }
+`;
+
 export const estimateGasLimit: DocumentNode = gql`
   query estimateGasLimit($transaction: PactTransaction!) {
     gasLimitEstimate(transaction: $transaction)

--- a/packages/apps/graph-client/src/graphql/subscriptions.graph.ts
+++ b/packages/apps/graph-client/src/graphql/subscriptions.graph.ts
@@ -40,11 +40,11 @@ export const getTransactionByRequestKey: DocumentNode = gql`
   }
 `;
 
-export const getEventByName: DocumentNode = gql`
+export const getEventsByName: DocumentNode = gql`
   ${ALL_EVENT_FIELDS}
 
-  subscription getEventByName($eventName: String!) {
-    event(eventName: $eventName) {
+  subscription getEventsByName($qualifiedEventName: String!) {
+    events(qualifiedEventName: $qualifiedEventName) {
       ...AllEventFields
       block {
         id

--- a/packages/apps/graph-client/src/pages/account/transactions/[fungible]/[account].tsx
+++ b/packages/apps/graph-client/src/pages/account/transactions/[fungible]/[account].tsx
@@ -34,7 +34,7 @@ const AccountTransactions: React.FC = () => {
           >
             Account Overview
           </Breadcrumbs.Item>
-          <Breadcrumbs.Item>Chain</Breadcrumbs.Item>
+          <Breadcrumbs.Item>Transactions</Breadcrumbs.Item>
         </Breadcrumbs.Root>
         <GraphQLQueryDialog queries={[{ query: getTransactions, variables }]} />
       </Stack>

--- a/packages/apps/graph-client/src/pages/event/[key].tsx
+++ b/packages/apps/graph-client/src/pages/event/[key].tsx
@@ -1,19 +1,187 @@
-import { useGetEventByNameSubscription } from '@/__generated__/sdk';
+import {
+  Event,
+  useGetEventsByNameSubscription,
+  useGetEventsQuery,
+} from '@/__generated__/sdk';
+import Loader from '@/components/common/loader/loader';
 import { ErrorBox } from '@/components/error-box/error-box';
+import { EventsTable } from '@/components/events-table/events-table';
 import { GraphQLQueryDialog } from '@/components/graphql-query-dialog/graphql-query-dialog';
 import LoaderAndError from '@/components/loader-and-error/loader-and-error';
-import { getEventByName } from '@/graphql/subscriptions.graph';
-import { formatCode } from '@/utils/formatter';
+import { getEvents } from '@/graphql/queries.graph';
+import { getEventsByName } from '@/graphql/subscriptions.graph';
 import routes from '@constants/routes';
-import { Box, Breadcrumbs, Stack, Table } from '@kadena/react-ui';
+import {
+  Box,
+  Breadcrumbs,
+  Grid,
+  GridItem,
+  Heading,
+  Pagination,
+  Select,
+  Stack,
+} from '@kadena/react-ui';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 const Event: React.FC = () => {
   const router = useRouter();
 
-  const variables = { eventName: router.query.key as string };
-  const { loading, data, error } = useGetEventByNameSubscription({ variables });
+  // Paginated events
+  const getEventsQueryVariables = {
+    qualifiedEventName: router.query.key as string,
+    first: parseInt((router.query.items as string) || '10'),
+  };
+  const {
+    loading: eventsQueryLoading,
+    data: eventsQueryData,
+    error: eventsQueryError,
+    fetchMore,
+  } = useGetEventsQuery({
+    variables: getEventsQueryVariables,
+  });
+
+  // Polled events
+  const getEventsByNameSubscriptionVariables = {
+    qualifiedEventName: router.query.key as string,
+  };
+  const {
+    loading: eventsSubscriptionLoading,
+    data: eventsSubscriptionData,
+    error: eventsSubscriptionError,
+  } = useGetEventsByNameSubscription({
+    variables: getEventsByNameSubscriptionVariables,
+  });
+
+  const [subscriptionsEvents, setSubscriptionsEvents] = useState<Event[]>([]);
+
+  useEffect(() => {
+    if (eventsSubscriptionData?.events?.length) {
+      const updatedEvents = [
+        ...(eventsSubscriptionData.events as Event[]),
+        ...subscriptionsEvents,
+      ];
+
+      if (updatedEvents.length > 20) {
+        updatedEvents.length = 20;
+      }
+
+      setSubscriptionsEvents(updatedEvents);
+    }
+  }, [eventsSubscriptionData]);
+
+  // Pagination
+  const itemsPerPageOptions = [10, 50, 100, 200];
+  const urlPage = router.query.page;
+  const urlItemsPerPage = router.query.items;
+
+  const [itemsPerPage, setItemsPerPage] = useState<number>(
+    urlItemsPerPage &&
+      itemsPerPageOptions.includes(parseInt(urlItemsPerPage as string))
+      ? parseInt(urlItemsPerPage as string)
+      : 10,
+  );
+
+  const totalPages = Math.ceil(
+    (eventsQueryData?.events.totalCount || 0) / itemsPerPage,
+  );
+
+  const [currentPage, setCurrentPage] = useState<number>(1);
+
+  const refetchEvents = async () => {
+    await fetchMore({
+      variables: {
+        first: itemsPerPage,
+        last: null,
+        after: null,
+        before: null,
+      },
+      updateQuery: (prev, { fetchMoreResult }) => {
+        if (!fetchMoreResult) return prev;
+        return fetchMoreResult;
+      },
+    });
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      await refetchEvents();
+      setCurrentPage(1);
+    };
+    fetchData().catch((err) => {
+      console.error(err);
+    });
+  }, [itemsPerPage]);
+
+  // Set items per page and page in URL when they change
+  useEffect(() => {
+    const updateUrl = async () => {
+      if (
+        urlItemsPerPage !== itemsPerPage.toString() ||
+        urlPage !== currentPage.toString()
+      ) {
+        const query = {
+          ...router.query,
+          page: currentPage,
+          items: itemsPerPage,
+        };
+
+        await router.push({
+          pathname: router.pathname,
+          query,
+        });
+      }
+    };
+    updateUrl().catch((err) => {
+      console.error(err);
+    });
+  }, [currentPage, itemsPerPage, router, urlItemsPerPage, urlPage]);
+
+  const handlePaginationClick = async (newPageNumber: number) => {
+    if (newPageNumber > currentPage) {
+      await fetchMore({
+        variables: {
+          first: itemsPerPage,
+          last: null,
+          after: eventsQueryData?.events.pageInfo.endCursor,
+          before: null,
+        },
+        updateQuery: (prev, { fetchMoreResult }) => {
+          if (!fetchMoreResult) return prev;
+          return fetchMoreResult;
+        },
+      });
+    } else if (newPageNumber < currentPage) {
+      await fetchMore({
+        variables: {
+          first: null,
+          last: itemsPerPage,
+          after: null,
+          before: eventsQueryData?.events.pageInfo.startCursor,
+        },
+        updateQuery: (prev, { fetchMoreResult }) => {
+          if (!fetchMoreResult) return prev;
+
+          if (fetchMoreResult.events.edges.length < itemsPerPage) {
+            return {
+              ...prev,
+              transactions: {
+                ...fetchMoreResult.events,
+                edges: [
+                  ...fetchMoreResult.events.edges,
+                  ...prev.events.edges,
+                ].slice(0, itemsPerPage),
+              },
+            };
+          }
+
+          return fetchMoreResult;
+        },
+      });
+    }
+
+    setCurrentPage(newPageNumber);
+  };
 
   return (
     <>
@@ -22,88 +190,96 @@ const Event: React.FC = () => {
           <Breadcrumbs.Item href={`${routes.HOME}`}>Home</Breadcrumbs.Item>
           <Breadcrumbs.Item>Events</Breadcrumbs.Item>
         </Breadcrumbs.Root>
-        <GraphQLQueryDialog queries={[{ query: getEventByName, variables }]} />
+        <GraphQLQueryDialog
+          queries={[
+            {
+              query: getEvents,
+              variables: getEventsQueryVariables,
+            },
+            {
+              query: getEventsByName,
+              variables: getEventsByNameSubscriptionVariables,
+            },
+          ]}
+        />
       </Stack>
 
       <Box marginBottom="$8" />
 
-      <LoaderAndError
-        error={error}
-        loading={loading}
-        loaderText="Waiting for event..."
-      />
+      <Grid columns={2}>
+        <GridItem>
+          <Heading variant="h4">All events</Heading>
+        </GridItem>
+        <GridItem>
+          <Heading variant="h4">Recent events</Heading>
+        </GridItem>
+      </Grid>
 
-      {error && <ErrorBox error={error} />}
-
-      {data?.event && (
-        <>
-          <Table.Root striped wordBreak="break-word">
-            <Table.Head>
-              <Table.Tr>
-                <Table.Th>Event Name</Table.Th>
-                <Table.Th>Parameters</Table.Th>
-                <Table.Th>Request Key</Table.Th>
-                <Table.Th></Table.Th>
-              </Table.Tr>
-            </Table.Head>
-            <Table.Body>
-              {data.event.map((event, index) => (
-                <Table.Tr
-                  key={index}
-                  url={`${routes.TRANSACTIONS}/${event.transaction?.requestKey}`}
-                >
-                  <Table.Td>{event.qualifiedName}</Table.Td>
-                  <Table.Td>
-                    <Table.Root>
-                      <Table.Body>
-                        {JSON.parse(event.parameterText).map(
-                          (parameter: any, index: number) => (
-                            <Table.Tr key={`arguments-${index}`}>
-                              <Table.Td>
-                                {typeof parameter === 'string' ? (
-                                  parameter
-                                ) : typeof parameter === 'object' ? (
-                                  <Table.Root>
-                                    <Table.Body>
-                                      {parameter.map(
-                                        (subparameter: any, index: number) => (
-                                          <Table.Tr key={`arguments-${index}`}>
-                                            <Table.Td>
-                                              {typeof subparameter ===
-                                              'string' ? (
-                                                subparameter
-                                              ) : (
-                                                <pre>
-                                                  {formatCode(
-                                                    JSON.stringify(
-                                                      subparameter,
-                                                    ),
-                                                  )}
-                                                </pre>
-                                              )}
-                                            </Table.Td>
-                                          </Table.Tr>
-                                        ),
-                                      )}
-                                    </Table.Body>
-                                  </Table.Root>
-                                ) : (
-                                  JSON.stringify(parameter)
-                                )}
-                              </Table.Td>
-                            </Table.Tr>
-                          ),
-                        )}
-                      </Table.Body>
-                    </Table.Root>
-                  </Table.Td>
-                  <Table.Td>{event.transaction?.requestKey}</Table.Td>
-                </Table.Tr>
+      <Grid columns={2}>
+        <GridItem>
+          <Stack justifyContent="space-between">
+            <Select
+              ariaLabel="items-per-page"
+              id="items-per-page"
+              onChange={(event) =>
+                setItemsPerPage(parseInt(event.target.value))
+              }
+              style={{ display: 'inline-block' }}
+              defaultValue={itemsPerPage}
+            >
+              {itemsPerPageOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
               ))}
-            </Table.Body>
-          </Table.Root>
-        </>
-      )}
+            </Select>
+            <Pagination
+              totalPages={totalPages}
+              label="pagination"
+              currentPage={currentPage}
+              onPageChange={handlePaginationClick}
+            />
+          </Stack>
+        </GridItem>
+        <GridItem>
+          <Box marginTop="$1" />
+          <Stack alignItems="center" gap="$2">
+            <Loader />
+            <p>Polling for the latest events...</p>
+          </Stack>
+        </GridItem>
+      </Grid>
+
+      <Grid columns={2}>
+        <GridItem>
+          <LoaderAndError
+            error={eventsQueryError}
+            loading={eventsQueryLoading}
+            loaderText="Waiting for events..."
+          />
+
+          {eventsQueryError && <ErrorBox error={eventsQueryError} />}
+
+          <EventsTable
+            events={
+              eventsQueryData?.events?.edges?.map((x) => x.node) as Event[]
+            }
+          />
+        </GridItem>
+        <GridItem>
+          <LoaderAndError
+            error={eventsSubscriptionError}
+            loading={eventsSubscriptionLoading}
+            loaderText="Waiting for events..."
+          />
+
+          {eventsSubscriptionError && (
+            <ErrorBox error={eventsSubscriptionError} />
+          )}
+
+          <EventsTable events={subscriptionsEvents} />
+        </GridItem>
+      </Grid>
     </>
   );
 };

--- a/packages/apps/graph/generated-schema.graphql
+++ b/packages/apps/graph/generated-schema.graphql
@@ -90,6 +90,7 @@ type Event implements Node {
   """The height of the block where the event was emitted."""
   height: BigInt!
   id: ID!
+  incrementedId: Int!
   moduleName: String!
   name: String!
 
@@ -212,6 +213,12 @@ type Query {
   """Retrieve all completed blocks from a given height."""
   completedBlockHeights(chainIds: [String!] = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"], completedHeights: Boolean = false, heightCount: Int = 3): [Block!]!
 
+  """Retrieve a single event by its unique key."""
+  event(blockHash: String!, orderIndex: Int!, requestKey: String!): Event
+
+  """Retrieve events."""
+  events(after: String, before: String, first: Int, last: Int, qualifiedEventName: String!): QueryEventsConnection!
+
   """Estimate the gas limit for a transaction."""
   gasLimitEstimate(transaction: PactTransaction!): Int!
 
@@ -236,14 +243,31 @@ type Query {
   """
   pactQuery(pactQuery: PactQuery!): String!
 
+  """Retrieve one transaction by its unique key."""
+  transaction(blockHash: String!, requestKey: String!): Transaction
+
   """Retrieve transactions."""
   transactions(accountName: String, after: String, before: String, blockHash: String, chainId: String, first: Int, fungibleName: String, last: Int, requestKey: String): QueryTransactionsConnection!
 
   """Retrieve all transactions by a given public key."""
   transactionsByPublicKey(after: String, before: String, first: Int, last: Int, publicKey: String!): QueryTransactionsByPublicKeyConnection!
 
+  """Retrieve one transfer by its unique key."""
+  transfer(blockHash: String!, chainId: String!, moduleHash: String!, orderIndex: Int!, requestKey: String!): Transfer
+
   """Retrieve transfers."""
   transfers(accountName: String, after: String, before: String, chainId: String, first: Int, fungibleName: String, last: Int): QueryTransfersConnection!
+}
+
+type QueryEventsConnection {
+  edges: [QueryEventsConnectionEdge!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type QueryEventsConnectionEdge {
+  cursor: String!
+  node: Event!
 }
 
 type QueryTransactionsByPublicKeyConnection {
@@ -297,8 +321,8 @@ type Signer implements Node {
 }
 
 type Subscription {
-  """Listen for a specific event by qualifiedName (e.g. `coin.TRANSFER`)."""
-  event(eventName: String!): [Event!]
+  """Listen for events by qualifiedName (e.g. `coin.TRANSFER`)."""
+  events(qualifiedEventName: String!): [Event!]
 
   """Subscribe to new blocks."""
   newBlocks(chainIds: [Int!]): [Block!]

--- a/packages/apps/graph/src/graph/index.ts
+++ b/packages/apps/graph/src/graph/index.ts
@@ -15,6 +15,7 @@ import './query/block';
 import './query/blocks-from-height';
 import './query/chain-account';
 import './query/completed-block-heights';
+import './query/events';
 import './query/gas-limit-estimate';
 import './query/graph-configuration';
 import './query/last-block-height';

--- a/packages/apps/graph/src/graph/objects/event.ts
+++ b/packages/apps/graph/src/graph/objects/event.ts
@@ -9,6 +9,7 @@ export default builder.prismaNode('Event', {
   id: { field: 'blockHash_orderIndex_requestKey' },
   fields: (t) => ({
     // database fields
+    incrementedId: t.exposeInt('id'),
     chainId: t.expose('chainId', { type: 'BigInt' }),
     height: t.expose('height', {
       type: 'BigInt',

--- a/packages/apps/graph/src/graph/query/events.ts
+++ b/packages/apps/graph/src/graph/query/events.ts
@@ -1,0 +1,82 @@
+import { prismaClient } from '@db/prisma-client';
+import { getDefaultConnectionComplexity } from '@services/complexity';
+import { normalizeError } from '@utils/errors';
+import { builder } from '../builder';
+
+builder.queryField('event', (t) =>
+  t.prismaField({
+    description: 'Retrieve a single event by its unique key.',
+    nullable: true,
+    args: {
+      blockHash: t.arg.string({ required: true }),
+      orderIndex: t.arg.int({ required: true }),
+      requestKey: t.arg.string({ required: true }),
+    },
+    type: 'Event',
+    complexity: getDefaultConnectionComplexity(),
+    async resolve(query, __parent, args) {
+      try {
+        return await prismaClient.event.findUnique({
+          ...query,
+          where: {
+            blockHash_orderIndex_requestKey: {
+              blockHash: args.blockHash,
+              orderIndex: args.orderIndex,
+              requestKey: args.requestKey,
+            },
+          },
+        });
+      } catch (error) {
+        throw normalizeError(error);
+      }
+    },
+  }),
+);
+
+builder.queryField('events', (t) =>
+  t.prismaConnection({
+    description: 'Retrieve events.',
+    edgesNullable: false,
+    args: {
+      qualifiedEventName: t.arg.string({ required: true }),
+    },
+    type: 'Event',
+    cursor: 'blockHash_orderIndex_requestKey',
+    complexity: (args) => ({
+      field: getDefaultConnectionComplexity({
+        withRelations: true,
+        first: args.first,
+        last: args.last,
+      }),
+    }),
+    async totalCount(__parent, args) {
+      try {
+        return await prismaClient.event.count({
+          where: {
+            qualifiedName: args.qualifiedEventName,
+          },
+        });
+      } catch (error) {
+        throw normalizeError(error);
+      }
+    },
+    async resolve(query, __parent, args) {
+      try {
+        return await prismaClient.event.findMany({
+          ...query,
+          where: {
+            qualifiedName: args.qualifiedEventName,
+            transaction: {
+              NOT: [],
+            },
+          },
+          orderBy: {
+            id: 'desc',
+          },
+        });
+      } catch (error) {
+        throw normalizeError(error);
+      }
+    },
+  }),
+);

--- a/packages/apps/graph/src/graph/query/transactions.ts
+++ b/packages/apps/graph/src/graph/query/transactions.ts
@@ -4,6 +4,34 @@ import { getDefaultConnectionComplexity } from '@services/complexity';
 import { normalizeError } from '@utils/errors';
 import { builder } from '../builder';
 
+builder.queryField('transaction', (t) =>
+  t.prismaField({
+    description: 'Retrieve one transaction by its unique key.',
+    nullable: true,
+    args: {
+      blockHash: t.arg.string({ required: true }),
+      requestKey: t.arg.string({ required: true }),
+    },
+    type: 'Transaction',
+    complexity: getDefaultConnectionComplexity(),
+    async resolve(query, __parent, args) {
+      try {
+        return await prismaClient.transaction.findUnique({
+          ...query,
+          where: {
+            blockHash_requestKey: {
+              blockHash: args.blockHash,
+              requestKey: args.requestKey,
+            },
+          },
+        });
+      } catch (error) {
+        throw normalizeError(error);
+      }
+    },
+  }),
+);
+
 builder.queryField('transactions', (t) =>
   t.prismaConnection({
     description: 'Retrieve transactions.',

--- a/packages/apps/graph/src/graph/query/transfers.ts
+++ b/packages/apps/graph/src/graph/query/transfers.ts
@@ -4,6 +4,40 @@ import { getDefaultConnectionComplexity } from '@services/complexity';
 import { normalizeError } from '@utils/errors';
 import { builder } from '../builder';
 
+builder.queryField('transfer', (t) =>
+  t.prismaField({
+    description: 'Retrieve one transfer by its unique key.',
+    nullable: true,
+    args: {
+      blockHash: t.arg.string({ required: true }),
+      chainId: t.arg.string({ required: true }),
+      orderIndex: t.arg.int({ required: true }),
+      moduleHash: t.arg.string({ required: true }),
+      requestKey: t.arg.string({ required: true }),
+    },
+    type: 'Transfer',
+    complexity: getDefaultConnectionComplexity(),
+    async resolve(query, __parent, args) {
+      try {
+        return await prismaClient.transfer.findUnique({
+          ...query,
+          where: {
+            blockHash_chainId_orderIndex_moduleHash_requestKey: {
+              blockHash: args.blockHash,
+              chainId: parseInt(args.chainId),
+              orderIndex: args.orderIndex,
+              moduleHash: args.moduleHash,
+              requestKey: args.requestKey,
+            },
+          },
+        });
+      } catch (error) {
+        throw normalizeError(error);
+      }
+    },
+  }),
+);
+
 builder.queryField('transfers', (t) =>
   t.prismaConnection({
     description: 'Retrieve transfers.',

--- a/packages/apps/graph/src/services/complexity.ts
+++ b/packages/apps/graph/src/services/complexity.ts
@@ -12,12 +12,12 @@ export const COMPLEXITY = {
   },
 };
 
-export const getDefaultConnectionComplexity = (options: {
+export const getDefaultConnectionComplexity = (options?: {
   withRelations?: boolean;
   first?: number | null;
   last?: number | null;
 }) =>
-  (options.withRelations
+  (options?.withRelations
     ? COMPLEXITY.FIELD.PRISMA_WITH_RELATIONS
     : COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS) *
-  (options.first || options.last || PRISMA.DEFAULT_SIZE);
+  (options?.first || options?.last || PRISMA.DEFAULT_SIZE);


### PR DESCRIPTION
In this PR:

- `event` and `events` queries added.
- Page in the graph client added for the events.
- `transfer` and `transaction` queries added for single record retrieval.

![chrome_vzGyASRSP6](https://github.com/kadena-community/kadena.js/assets/6686385/b8b1dfa7-5d85-4c99-9390-a292031ee0b5)
