### PR TITLE
feat(pactjs-generator): add emit-event to the parse tree

### DIFF
--- a/.changeset/pink-lobsters-retire.md
+++ b/.changeset/pink-lobsters-retire.md
@@ -1,0 +1,5 @@
+---
+'@kadena/pactjs-generator': minor
+---
+
+Add events to the parse tree

--- a/packages/libs/pactjs-generator/src/contract/parsing/pactParser.ts
+++ b/packages/libs/pactjs-generator/src/contract/parsing/pactParser.ts
@@ -36,6 +36,7 @@ export interface IFunction extends IMethod {
   bodyPointer?: number;
   requiredCapabilities?: string[];
   withCapabilities?: string[];
+  events?: string[];
   functionCalls?: {
     internal: string[];
     external: Array<{ namespace?: string; module: string; func: string }>;

--- a/packages/libs/pactjs-generator/src/contract/parsing/utils/pactGrammar.ts
+++ b/packages/libs/pactjs-generator/src/contract/parsing/utils/pactGrammar.ts
@@ -86,6 +86,7 @@ const functionBody = seq(
   repeat(
     $('requiredCapabilities', seq(id('require-capability'), id('('), $(atom))),
     $('withCapabilities', seq(id('with-capability'), id('('), $(atom))),
+    $('events', seq(id('emit-event'), id('('), $(atom))),
     $(
       'externalFnCalls',
       seq(

--- a/packages/libs/pactjs-generator/src/contract/parsing/utils/tests/pactGrammar.test.ts
+++ b/packages/libs/pactjs-generator/src/contract/parsing/utils/tests/pactGrammar.test.ts
@@ -108,6 +108,19 @@ describe('pactGrammar', () => {
       expect(data.withCapabilities).toEqual(['CAP1', 'CAP2']);
     });
 
+    it("should extract emit-event from the function's body", () => {
+      const pointer = getPointer(
+        '(defun test (a:integer b:boolean) @doc "test doc" (require-capability (CAP1)) (emit-event (EVENT_CAP)))',
+      );
+      const result = defun(pointer);
+      const data = unwrapData(result);
+      if (data === FAILED) {
+        expect(data).not.toEqual(FAILED);
+        return;
+      }
+      expect(data.events).toEqual(['EVENT_CAP']);
+    });
+
     it("should extract external module function calls from the function's body", () => {
       const pointer = getPointer(
         '(defun test (a:integer b:boolean) @doc "test doc" (namespace1.mod1.func1 1) (mod2.func2 "test"))',


### PR DESCRIPTION
Add events to the parse tree. 
this could happen for defun and defpact
![image](https://github.com/kadena-community/kadena.js/assets/18360508/0b573e53-b2d0-4fc8-b715-91e2173fd300)
