### PR TITLE
chore(@kadena/react-ui): Use react-aria in Breadcrumbs component

### DIFF
--- a/.changeset/dirty-bats-learn.md
+++ b/.changeset/dirty-bats-learn.md
@@ -1,0 +1,5 @@
+---
+'@kadena/react-ui': minor
+---
+
+Updated the Breadcrumbs component to use `useBreadcrumbs` from react-aria

--- a/packages/libs/react-ui/src/components/Breadcrumbs/Breadcrumbs.css.ts
+++ b/packages/libs/react-ui/src/components/Breadcrumbs/Breadcrumbs.css.ts
@@ -1,11 +1,11 @@
-import { sprinkles } from '@theme/sprinkles.css';
-import { vars } from '@theme/vars.css';
+import { atoms } from '@theme/atoms.css';
+import { tokens } from '@theme/tokens/contract.css';
 import { style } from '@vanilla-extract/css';
 
 export const containerClass = style([
-  sprinkles({
+  atoms({
     display: 'flex',
-    padding: 0,
+    padding: 'no',
   }),
   {
     flexFlow: 'wrap',
@@ -14,67 +14,60 @@ export const containerClass = style([
 ]);
 
 export const itemClass = style([
-  sprinkles({
+  atoms({
     display: 'flex',
-    padding: 0,
-    color: '$neutral4',
+    padding: 'no',
+    whiteSpace: 'nowrap',
   }),
   {
-    whiteSpace: 'nowrap',
     selectors: {
-      '&::before': {
-        margin: `0 ${vars.sizes.$2}`,
-      },
       '&:not(:first-child):not(:last-child)::before': {
         content: '/',
+        marginInline: tokens.kda.foundation.spacing.sm,
       },
       '&:last-child::before': {
         content: '∙',
+        marginInline: tokens.kda.foundation.spacing.sm,
       },
       '&:first-child': {
         fontWeight: 'bold',
-      },
-      '&:first-child::before': {
-        content: '',
-        margin: '0',
       },
     },
   },
 ]);
 
 export const linkClass = style([
-  sprinkles({
+  atoms({
     display: 'flex',
-    color: '$neutral4',
+    color: 'text.base.default',
   }),
   {
     textDecoration: 'none',
     selectors: {
       '&:hover': {
         textDecoration: 'underline',
+        color: tokens.kda.foundation.color.text.base.default,
+      },
+      '&[data-current="true"]': {
+        textDecoration: 'none',
+        cursor: 'default',
+      },
+      "&[data-disabled='true']": {
+        textDecoration: 'none',
+        cursor: 'default',
+        color: tokens.kda.foundation.color.text.base['@disabled'],
       },
     },
   },
 ]);
 
-export const spanClass = style([
-  sprinkles({
-    marginRight: '$1',
-  }),
-]);
-
-export const iconContainer = style([
-  sprinkles({
-    display: 'flex',
-    marginX: '$2',
-  }),
-]);
-
 export const navClass = style([
-  sprinkles({
+  atoms({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    width: 'max-content',
   }),
+  {
+    width: 'max-content',
+  },
 ]);

--- a/packages/libs/react-ui/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/libs/react-ui/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -2,7 +2,7 @@ import type { IBreadcrumbsProps } from '@components/Breadcrumbs';
 import { ProductIcon } from '@components/Icon';
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import { BreadcrumbsContainer } from './Breadcrumbs';
+import { Breadcrumbs } from './Breadcrumbs';
 import { BreadcrumbsItem } from './BreadcrumbsItem';
 
 const ItemArray: string[] = [
@@ -26,7 +26,7 @@ const meta: Meta<
     docs: {
       description: {
         component:
-          'The Breadcrumb component displays the position of the current page within the site hierarchy, allowing page visitors to navigate the page hierarchy from their current location. It is composed by BreadcrumbsContainer and BreadcrumbsItem.<br><br><i>Note: In times when you need to use an external `Link` component (like next/link in Next.js), you can wrap the external component in BreadcrumbsItem and set the `asChild` prop to pass on styles and props to the child component.</i>',
+          'The Breadcrumb component displays the position of the current page within the site hierarchy, allowing page visitors to navigate the page hierarchy from their current location. It is composed by Breadcrumbs and BreadcrumbsItem.<br><br><i>Note: In times when you need to use an external `Link` component (like next/link in Next.js), you can wrap the external component in BreadcrumbsItem and set the `asChild` prop to pass on styles and props to the child component.</i>',
       },
     },
   },
@@ -63,18 +63,19 @@ export const Primary: Story = {
   render: ({ itemsCount, icon }) => {
     const items = ItemArray.slice(0, itemsCount);
     return (
-      <BreadcrumbsContainer icon={icon}>
+      <Breadcrumbs icon={icon}>
         {items.map((item, idx) => {
           return (
             <BreadcrumbsItem
               key={item}
               href={idx < items.length - 1 ? item : undefined}
+              isDisabled={idx % 2 === 1}
             >
               {item}
             </BreadcrumbsItem>
           );
         })}
-      </BreadcrumbsContainer>
+      </Breadcrumbs>
     );
   },
 };

--- a/packages/libs/react-ui/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/libs/react-ui/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,13 +1,39 @@
+import { Breadcrumbs, BreadcrumbsItem } from '@components/Breadcrumbs';
+import { SystemIcon } from '@components/Icon';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, test } from 'vitest';
-import { BreadcrumbsContainer } from './Breadcrumbs';
 
-describe('Breadcrumps', () => {
-  test('renders correctly', () => {
-    const { getByTestId } = render(<BreadcrumbsContainer />);
+describe('Breadcrumbs', () => {
+  test('has the correct aria label and breadcrumbs', () => {
+    const { getByLabelText, getByText } = render(
+      <Breadcrumbs icon={<SystemIcon.Account />}>
+        <BreadcrumbsItem>Item 1</BreadcrumbsItem>
+        <BreadcrumbsItem>Item 2</BreadcrumbsItem>
+      </Breadcrumbs>,
+    );
 
-    const boxContainer = getByTestId('kda-breadcrumbs');
-    expect(boxContainer).toBeInTheDocument();
+    const nav = getByLabelText('Breadcrumbs');
+    expect(nav).toBeInTheDocument();
+
+    const item1 = getByText('Item 1');
+    expect(item1).toBeInTheDocument();
+  });
+
+  test('disabled and current links are disabled', () => {
+    const { getByText } = render(
+      <Breadcrumbs>
+        <BreadcrumbsItem isDisabled>Item 1</BreadcrumbsItem>
+        <BreadcrumbsItem>Item 2</BreadcrumbsItem>
+      </Breadcrumbs>,
+    );
+
+    const item1 = getByText('Item 1');
+    expect(item1).toHaveAttribute('aria-disabled', 'true');
+    expect(item1).toHaveAttribute('data-disabled', 'true');
+
+    const item2 = getByText('Item 2');
+    expect(item2).toHaveAttribute('aria-disabled', 'true');
+    expect(item2).toHaveAttribute('data-current', 'true');
   });
 });

--- a/packages/libs/react-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/libs/react-ui/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,21 +1,33 @@
 import type { FC, FunctionComponentElement } from 'react';
 import React from 'react';
-import { containerClass, iconContainer, navClass } from './Breadcrumbs.css';
+import type { AriaBreadcrumbsProps } from 'react-aria';
+import { useBreadcrumbs } from 'react-aria';
+import { Box } from '..';
+import { containerClass, navClass } from './Breadcrumbs.css';
 import type { IBreadcrumbItemProps } from './BreadcrumbsItem';
 
-export interface IBreadcrumbsProps {
-  children?: FunctionComponentElement<IBreadcrumbItemProps>[];
+export interface IBreadcrumbsProps extends AriaBreadcrumbsProps {
+  children:
+    | FunctionComponentElement<IBreadcrumbItemProps>
+    | FunctionComponentElement<IBreadcrumbItemProps>[];
   icon?: React.ReactElement;
 }
 
-export const BreadcrumbsContainer: FC<IBreadcrumbsProps> = ({
-  children,
+export const Breadcrumbs: FC<IBreadcrumbsProps> = ({
   icon,
+  ...breadcrumbProps
 }) => {
+  const { navProps } = useBreadcrumbs(breadcrumbProps);
+  const childCount = React.Children.count(breadcrumbProps.children);
+
   return (
-    <nav className={navClass} data-testid="kda-breadcrumbs">
-      {icon && <span className={iconContainer}>{icon}</span>}
-      <ul className={containerClass}>{children}</ul>
+    <nav className={navClass} {...navProps}>
+      {icon && <Box marginInline="sm">{icon}</Box>}
+      <ol className={containerClass}>
+        {React.Children.map(breadcrumbProps.children, (child, i) =>
+          React.cloneElement(child as any, { isCurrent: i === childCount - 1 }),
+        )}
+      </ol>
     </nav>
   );
 };

--- a/packages/libs/react-ui/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/libs/react-ui/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -1,24 +1,32 @@
-import type { FC, ReactNode } from 'react';
+import { mergeRefs } from '@react-aria/utils';
+import cn from 'classnames';
+import type { FC } from 'react';
 import React from 'react';
-import { itemClass, linkClass, spanClass } from './Breadcrumbs.css';
+import type { AriaBreadcrumbItemProps } from 'react-aria';
+import { useBreadcrumbItem } from 'react-aria';
+import { itemClass, linkClass } from './Breadcrumbs.css';
 
-export interface IBreadcrumbItemProps {
-  children?: ReactNode;
+export interface IBreadcrumbItemProps extends AriaBreadcrumbItemProps {
   href?: string;
   asChild?: boolean;
 }
 
-export const BreadcrumbsItem: FC<IBreadcrumbItemProps> = ({
-  children,
-  href,
-  asChild = false,
-}) => {
+export const BreadcrumbsItem: FC<IBreadcrumbItemProps> = (props) => {
+  const { href, isCurrent, isDisabled, asChild, children } = props;
+  const ref = React.useRef(null);
+  const { itemProps } = useBreadcrumbItem(props, ref);
+
   if (asChild && React.isValidElement(children)) {
     return (
       <li className={itemClass}>
         {React.cloneElement(children, {
+          className: cn(linkClass, children.props.className),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ref: mergeRefs(ref, (children as any).ref),
           href,
-          className: linkClass,
+          'data-current': isCurrent,
+          'data-disabled': isDisabled,
+          ...itemProps,
           ...children.props,
         })}
       </li>
@@ -27,13 +35,16 @@ export const BreadcrumbsItem: FC<IBreadcrumbItemProps> = ({
 
   return (
     <li className={itemClass}>
-      {href !== undefined ? (
-        <a className={linkClass} href={href}>
-          {children}
-        </a>
-      ) : (
-        <span className={spanClass}>{children}</span>
-      )}
+      <a
+        {...itemProps}
+        className={linkClass}
+        ref={ref}
+        href={href}
+        data-current={isCurrent}
+        data-disabled={isDisabled}
+      >
+        {children}
+      </a>
     </li>
   );
 };

--- a/packages/libs/react-ui/src/components/Breadcrumbs/BreadcrumbsItem.tsx
+++ b/packages/libs/react-ui/src/components/Breadcrumbs/BreadcrumbsItem.tsx
@@ -20,14 +20,14 @@ export const BreadcrumbsItem: FC<IBreadcrumbItemProps> = (props) => {
     return (
       <li className={itemClass}>
         {React.cloneElement(children, {
+          href,
+          ...itemProps,
+          ...children.props,
           className: cn(linkClass, children.props.className),
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           ref: mergeRefs(ref, (children as any).ref),
-          href,
           'data-current': isCurrent,
           'data-disabled': isDisabled,
-          ...itemProps,
-          ...children.props,
         })}
       </li>
     );

--- a/packages/libs/react-ui/src/components/Breadcrumbs/index.tsx
+++ b/packages/libs/react-ui/src/components/Breadcrumbs/index.tsx
@@ -1,4 +1,4 @@
-export { BreadcrumbsContainer as Breadcrumbs } from './Breadcrumbs';
+export { Breadcrumbs } from './Breadcrumbs';
 export type { IBreadcrumbsProps } from './Breadcrumbs';
 export { BreadcrumbsItem } from './BreadcrumbsItem';
 export type { IBreadcrumbItemProps } from './BreadcrumbsItem';


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->

Updated the Breadcrumbs component to use `useBreadcrumbs` from react-aria. 

