### PR TITLE
[@kadena/graph] Reduce complexity of cross-chain counterpart lookup in Transfers (Feat)

### DIFF
--- a/.changeset/funny-ants-sort.md
+++ b/.changeset/funny-ants-sort.md
@@ -1,0 +1,6 @@
+---
+'@kadena/graph': patch
+---
+
+Increased effienciency and reduced complecity on the transfer cross-chain field
+search

--- a/packages/apps/graph/src/devnet/simulation/coin/crosschain-transfer.ts
+++ b/packages/apps/graph/src/devnet/simulation/coin/crosschain-transfer.ts
@@ -39,8 +39,8 @@ export async function crossChainTransfer({
   const crossChainTransferRequest = transferCrossChain(
     {
       sender: {
-        account: sender00.account,
-        publicKeys: sender00.keys.map((key) => key.publicKey),
+        account: sender.account,
+        publicKeys: sender.keys.map((key) => key.publicKey),
       },
       receiver: {
         account: receiver.account,
@@ -48,6 +48,10 @@ export async function crossChainTransfer({
           keys: receiver.keys.map((key) => key.publicKey),
           pred: 'keys-all',
         },
+      },
+      targetChainGasPayer: {
+        account: gasPayer.account,
+        publicKeys: gasPayer.keys.map((key) => key.publicKey),
       },
       chainId: sender.chainId as ChainId,
       targetChainId: receiver.chainId as ChainId,
@@ -58,7 +62,7 @@ export async function crossChainTransfer({
       defaults: {
         networkId: dotenv.NETWORK_ID,
       },
-      sign: createSignWithKeypair(sender00.keys),
+      sign: createSignWithKeypair([...sender.keys, ...gasPayer.keys]),
     },
   );
 

--- a/packages/apps/graph/src/graph/objects/transfer.ts
+++ b/packages/apps/graph/src/graph/objects/transfer.ts
@@ -1,4 +1,5 @@
 import { prismaClient } from '@db/prisma-client';
+import { prismaModelName } from '@pothos/plugin-prisma';
 import { COMPLEXITY } from '@services/complexity';
 import { normalizeError } from '@utils/errors';
 import { PRISMA, builder } from '../builder';
@@ -29,44 +30,43 @@ export default builder.prismaNode('Transfer', {
         'The counterpart of the crosschain-transfer. `null` when it is not a cross-chain-transfer.',
       type: 'Transfer',
       nullable: true,
-      complexity: COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS * 4, // In the worst case resolve scenario, it executes 4 queries.
+      complexity: COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS * 3, // In the worst case resolve scenario, it executes 3 queries.
       async resolve(__query, parent) {
         try {
-          let counterTransaction;
-
-          // Try to find finisher transfer
-          const finisherTransfer = await prismaClient.transaction.findFirst({
+          // Find all transactions that match either of the two conditions
+          const transactions = await prismaClient.transaction.findMany({
             where: {
-              pactId: parent.requestKey,
+              OR: [
+                { pactId: parent.requestKey },
+                { blockHash: parent.blockHash, requestKey: parent.requestKey },
+              ],
             },
           });
 
-          if (finisherTransfer) {
-            counterTransaction = finisherTransfer;
-          } else {
-            // If not found, try to find the initiating transfer
-            // First find the corresponding transaction
-            const finisherTransaction =
-              await prismaClient.transaction.findFirst({
-                where: {
-                  blockHash: parent.blockHash,
-                  requestKey: parent.requestKey,
-                },
-              });
+          // Filter the transactions to find the counterTransaction
+          let counterTransaction = transactions.find(
+            (transaction) =>
+              transaction.pactId === parent.requestKey ||
+              (transaction.blockHash === parent.blockHash &&
+                transaction.requestKey === parent.requestKey &&
+                transaction.pactId !== null &&
+                transaction.pactId !== undefined),
+          );
 
-            if (
-              !finisherTransaction ||
-              finisherTransaction.pactId === undefined ||
-              finisherTransaction.pactId === null
-            ) {
-              return null;
-            }
+          if (!counterTransaction) {
+            return null;
+          }
 
-            // Then find the initiating transaction with the pactId
+          // If the counterTransaction was found using the second condition, find the initiating transaction
+          if (
+            counterTransaction.blockHash === parent.blockHash &&
+            counterTransaction.requestKey === parent.requestKey &&
+            counterTransaction.pactId
+          ) {
             const initiatingTransaction =
               await prismaClient.transaction.findFirstOrThrow({
                 where: {
-                  requestKey: finisherTransaction.pactId,
+                  requestKey: counterTransaction.pactId,
                   pactId: undefined,
                 },
               });

--- a/packages/apps/graph/src/graph/objects/transfer.ts
+++ b/packages/apps/graph/src/graph/objects/transfer.ts
@@ -31,7 +31,7 @@ export default builder.prismaNode('Transfer', {
         'The counterpart of the crosschain-transfer. `null` when it is not a cross-chain-transfer.',
       type: 'Transfer',
       nullable: true,
-      complexity: COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS * 2, // In the worst case resolve scenario, it executes 3 queries.
+      complexity: COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS * 2, // In the worst case resolve scenario, it executes 2 queries.
       async resolve(__query, parent) {
         try {
           // Find all transactions that match either of the two conditions

--- a/packages/apps/graph/src/graph/objects/transfer.ts
+++ b/packages/apps/graph/src/graph/objects/transfer.ts
@@ -1,5 +1,5 @@
 import { prismaClient } from '@db/prisma-client';
-import { Transfer } from '@prisma/client';
+import type { Transfer } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
 import { COMPLEXITY } from '@services/complexity';
 import { normalizeError } from '@utils/errors';


### PR DESCRIPTION
For this, I tested a couple of scenarios:

- One using Prisma's query methods and ensuring type safety; this is the one included in the PR
- The other way was by using a single query, which although it removed complexity, added some other downsides because it made use of `$queryRaw`. These downsides had to do with the manual mapping of fields, which are not automatically mapped to our defined Prisma models, and no type safety. 

I ended up doing some tracing tests as well and saw that although the current complexity is 2 (higher than the single query way), it does take less time.


**TLDR: Reduced complexity from 4 -> 2. It was possible to bring it down to 1 but it had no real improvement**


Note: also fixed a small encountered issue in cross-chain transfers (simulation)

<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->
