### PR TITLE
feat(client): Add signMethod to the signWithKeyPair for flexibility

### DIFF
--- a/.changeset/proud-snails-compare.md
+++ b/.changeset/proud-snails-compare.md
@@ -1,0 +1,5 @@
+---
+'@kadena/client': minor
+---
+
+Add signMethod to the signWithKeyPair for flexibility


### PR DESCRIPTION
accept the sign method for signWithKeyPair
this let us to reuse this function for scenarios that keypair is encrypted
