### PR TITLE
[client-utils]feat: add template parsing from string to yaml converter

### DIFF
--- a/.changeset/khaki-wolves-teach.md
+++ b/.changeset/khaki-wolves-teach.md
@@ -1,0 +1,5 @@
+---
+'@kadena/client-utils': minor
+---
+
+added createPactCommandFromStringTemplate method

--- a/packages/libs/client-utils/src/nodejs/index.ts
+++ b/packages/libs/client-utils/src/nodejs/index.ts
@@ -1,1 +1,5 @@
-export { createPactCommandFromTemplate } from './yaml-converter';
+export {
+  createPactCommandFromStringTemplate,
+  createPactCommandFromTemplate,
+  getPartsAndHoles,
+} from './yaml-converter';

--- a/packages/libs/client-utils/src/nodejs/test/yaml-converter.test.ts
+++ b/packages/libs/client-utils/src/nodejs/test/yaml-converter.test.ts
@@ -71,25 +71,23 @@ describe('yaml-converter', () => {
 
   describe('replaceHoles', () => {
     it('replaces holes for simple string', () => {
-      const result = replaceHoles(
+      const result = replaceHoles({
+        name: 'Albert',
+      })(
         getPartsAndHolesInCtx('./aux-files/simple-test.yaml', __dirname)
           .tplString,
-        {
-          name: 'Albert',
-        },
       );
       expect(result).eq(`Hello Albert!
 `);
     });
 
     it('replaces holes for simple string', () => {
-      const result = replaceHoles(
+      const result = replaceHoles({
+        name: 'Albert',
+        literalName: 'literalAlbert',
+      })(
         getPartsAndHolesInCtx('./aux-files/complex-test.yaml', __dirname)
           .tplString,
-        {
-          name: 'Albert',
-          literalName: 'literalAlbert',
-        },
       );
       expect(result).eq(`Hello Albert! Where is AlbertliteralAlbert!
 `);
@@ -97,12 +95,11 @@ describe('yaml-converter', () => {
 
     it('throws an error when a hole is not provided', () => {
       expect(() =>
-        replaceHoles(
+        replaceHoles({
+          notName: 'Albert',
+        })(
           getPartsAndHolesInCtx('./aux-files/complex-test.yaml', __dirname)
             .tplString,
-          {
-            notName: 'Albert',
-          },
         ),
       ).to.throw(
         'argument to fill hole for name is missing in Hello {{name}}!',
@@ -118,13 +115,13 @@ describe('yaml-converter', () => {
         literalName: 'My Literal Name',
       };
 
-      const res = parseYamlToKdaTx(args)(
+      const tplTx = parseYamlToKdaTx(args)(
         replaceHolesInCtx(args)(
           getPartsAndHolesInCtx('./aux-files/tx-with-codefile.yaml', __dirname),
         ),
       );
 
-      expect(res.tplTx).deep.eq({
+      expect(tplTx).deep.eq({
         code: `(module 12 My Literal Name)
 `,
         data: 12,
@@ -138,7 +135,7 @@ describe('yaml-converter', () => {
         aNumber: 12,
       };
 
-      const res = parseYamlToKdaTx(args)(
+      const tplTx = parseYamlToKdaTx(args)(
         replaceHolesInCtx(args)(
           getPartsAndHolesInCtx(
             './aux-files/tx-without-codefile.yaml',
@@ -147,7 +144,7 @@ describe('yaml-converter', () => {
         ),
       );
 
-      expect(res.tplTx).deep.eq({
+      expect(tplTx).deep.eq({
         code: `(module 123 Nil)`,
         data: 12,
         something: false,

--- a/packages/libs/client-utils/src/nodejs/test/yaml-converter.test.ts
+++ b/packages/libs/client-utils/src/nodejs/test/yaml-converter.test.ts
@@ -1,6 +1,9 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   convertTemplateTxToPactCommand,
+  createPactCommandFromStringTemplate,
   createPactCommandFromTemplate,
   getPartsAndHolesInCtx,
   parseYamlToKdaTx,
@@ -298,6 +301,24 @@ describe('yaml-converter', () => {
             code: '(let\n    ((mk-guard (lambda (max-gas-price:decimal)\n                (util.guards.guard-or\n                  (keyset-ref-guard "ns-admin-keyset")\n                  (util.guards1.guard-all\n                    [ (create-user-guard (coin.gas-only))\n                      (util.guards1.max-gas-price max-gas-price)\n                      (util.guards1.max-gas-limit 500)\n                    ]))\n               )\n     )\n    )\n\n    (coin.transfer-create\n      "k:554754f48b16df24b552f6832dda090642ed9658559fef9f3ee1bb4637ea7c94"\n      "my-gas-station"\n      (mk-guard 0.0000000001)\n      123000)\n    (coin.rotate\n      "my-gas-station"\n      (mk-guard 0.00000001))\n  )\n',
           },
         },
+      });
+    });
+
+    it('converts a yaml from string', async () => {
+      const result = await createPactCommandFromStringTemplate(
+        readFileSync(
+          join(__dirname, './aux-files/tx-without-codefile.yaml'),
+          'utf8',
+        ),
+        { aNumber: 1, thisIsFalse: '1' },
+      );
+      expect(result).toStrictEqual({
+        something: 1,
+        payload: { exec: { data: 1, code: '(module 123 Nil)' } },
+        meta: { chainId: undefined, creationTime: 1698278400 },
+        nonce: '',
+        signers: [],
+        networkId: undefined,
       });
     });
 

--- a/packages/libs/client-utils/src/nodejs/yaml-converter.ts
+++ b/packages/libs/client-utils/src/nodejs/yaml-converter.ts
@@ -165,7 +165,8 @@ export const convertTemplateTxToPactCommand = (
     },
   };
 
-  const { publicMeta, meta, ...kdaToolTxWithoutMeta } = kdaToolTx;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { publicMeta, meta, code, ...kdaToolTxWithoutMeta } = kdaToolTx;
   const metadata = meta || publicMeta || ({} as IPublicMeta);
 
   return {

--- a/packages/libs/client-utils/src/nodejs/yaml-converter.ts
+++ b/packages/libs/client-utils/src/nodejs/yaml-converter.ts
@@ -178,7 +178,7 @@ export const convertTemplateTxToPactCommand = (
       creationTime: Math.floor(Date.now() / 1000),
     },
     nonce: kdaToolTx.nonce ? kdaToolTx.nonce : '',
-    signers: kdaToolTx.signers.map(publicToPubkey),
+    signers: (kdaToolTx.signers ?? []).map(publicToPubkey),
     networkId: kdaToolTx.networkId,
   };
 };

--- a/packages/libs/client-utils/src/nodejs/yaml-converter.ts
+++ b/packages/libs/client-utils/src/nodejs/yaml-converter.ts
@@ -29,16 +29,18 @@ interface ITemplateContextReplacedHoles extends ITemplateContext {
   filledYamlString: FilledYamlString;
 }
 
+interface IPublicMeta {
+  chainId: string;
+  sender: string;
+  gasLimit: number;
+  gasPrice: number;
+  ttl: number;
+}
 interface ITemplateTransaction {
   codeFile?: string;
   command: string;
-  publicMeta: {
-    chainId: string;
-    sender: string;
-    gasLimit: number;
-    gasPrice: number;
-    ttl: number;
-  };
+  meta?: IPublicMeta;
+  publicMeta?: IPublicMeta;
   networkId: string;
   data: Record<string, any>;
   signers: Array<{ public: string }>;
@@ -85,91 +87,93 @@ export const getPartsAndHolesInCtx = (
 };
 
 // Responsible for replacing holes with values
-export const replaceHoles = (
-  partsAndHoles: PartsAndHoles,
-  args: Record<string, string | number>,
-) => {
-  const [parts, holes] = partsAndHoles;
-  const allParts = zip(parts, holes);
-  return allParts
-    .map((partOrHole, index) => {
-      if (typeof partOrHole === 'string') {
-        // it's a part
-        return partOrHole;
-      } else {
-        // Currently we are unaware of the difference between {{}} and {{{}}} so we treat them the same: as a literal hole
-        if ('literal' in partOrHole) {
-          // it's a literal hole
-          if (!(partOrHole.literal in args)) {
-            throw new Error(
-              `argument to fill hole for ${partOrHole.literal} is missing in ${
-                allParts[index - 1]
-              }{{${partOrHole.literal}}}${allParts[index + 1]}}`,
-            );
-          }
+export const replaceHoles =
+  (args: Record<string, string | number>) => (partsAndHoles: PartsAndHoles) => {
+    const [parts, holes] = partsAndHoles;
+    const allParts = zip(parts, holes);
+    return allParts
+      .map((partOrHole, index) => {
+        if (typeof partOrHole === 'string') {
+          // it's a part
+          return partOrHole;
+        } else {
+          // Currently we are unaware of the difference between {{}} and {{{}}} so we treat them the same: as a literal hole
+          if ('literal' in partOrHole) {
+            // it's a literal hole
+            if (!(partOrHole.literal in args)) {
+              throw new Error(
+                `argument to fill hole for ${
+                  partOrHole.literal
+                } is missing in ${allParts[index - 1]}{{${
+                  partOrHole.literal
+                }}}${allParts[index + 1]}}`,
+              );
+            }
 
-          return args[partOrHole.literal];
+            return args[partOrHole.literal];
+          }
         }
-      }
-    })
-    .join('');
+      })
+      .join('');
+  };
+
+const loadYaml = (filledYamlString: string) => {
+  return yaml.load(filledYamlString) as ITemplateTransaction;
 };
 
 // Responsible for replacing holes in a context with values
 export const replaceHolesInCtx = (args: Record<string, string | number>) => {
   return (ctx: ITemplateContext): ITemplateContextReplacedHoles => {
     const { tplString } = ctx;
-    return { ...ctx, filledYamlString: replaceHoles(tplString, args) };
+    return { ...ctx, filledYamlString: replaceHoles(args)(tplString) };
   };
 };
+
 export const parseYamlToKdaTx =
   (args: Record<string, string | number>) =>
-  (ctx: ITemplateContextReplacedHoles): ITemplateContextPactCommand => {
+  (
+    ctx: ITemplateContextReplacedHoles,
+  ): ITemplateContextPactCommand['tplTx'] => {
     const { filledYamlString } = ctx;
-    const kdaToolTx = yaml.load(filledYamlString) as ITemplateTransaction;
+    const kdaToolTx = loadYaml(filledYamlString);
 
     if (!('codeFile' in kdaToolTx && kdaToolTx.codeFile)) {
-      return {
-        ...ctx,
-        tplTx: kdaToolTx,
-      };
+      return kdaToolTx;
     }
 
     const { codeFile, ...kdaToolTxWithoutCodeFile } = kdaToolTx;
     const codeWithHoles = readFileSync(join(ctx.cwd, codeFile), 'utf-8');
 
-    const code = replaceHoles(getPartsAndHoles(codeWithHoles), args);
+    const code = replaceHoles(args)(getPartsAndHoles(codeWithHoles));
 
     return {
-      ...ctx,
-      tplTx: {
-        ...kdaToolTxWithoutCodeFile,
-        code,
-      },
+      ...kdaToolTxWithoutCodeFile,
+      code,
     };
   };
 
 // Responsible for converting a kda tool transaction into a kadena client transaction
 export const convertTemplateTxToPactCommand = (
-  ctx: ITemplateContextPactCommand,
+  tplTx: ITemplateContextPactCommand['tplTx'],
 ): IPactCommand => {
-  const { code, data, ...kdaToolTx } = ctx.tplTx;
+  const { data, ...kdaToolTx } = tplTx;
 
   const execPayload: IExecutionPayloadObject = {
     exec: {
       data: data ? data : {},
-      code: code!,
+      code: kdaToolTx.code!,
     },
   };
 
-  const { publicMeta, ...kdaToolTxWithoutMeta } = kdaToolTx;
+  const { publicMeta, meta, ...kdaToolTxWithoutMeta } = kdaToolTx;
+  const metadata = meta || publicMeta || ({} as IPublicMeta);
 
   return {
     ...kdaToolTxWithoutMeta,
     payload: execPayload,
     meta: {
-      ...publicMeta,
-      chainId: publicMeta.chainId as ChainId,
+      ...metadata,
+      chainId: metadata.chainId as ChainId,
       creationTime: Math.floor(Date.now() / 1000),
     },
     nonce: kdaToolTx.nonce ? kdaToolTx.nonce : '',
@@ -189,6 +193,18 @@ export const createPactCommandFromTemplate = async (
     parseYamlToKdaTx(args),
     convertTemplateTxToPactCommand,
   )(path, cwd);
+};
+
+export const createPactCommandFromStringTemplate = async (
+  template: string,
+  args: Record<string, string | number>,
+): Promise<IPactCommand> => {
+  return asyncPipe(
+    getPartsAndHoles,
+    replaceHoles(args),
+    loadYaml,
+    convertTemplateTxToPactCommand,
+  )(template);
 };
 
 // Responsible for zipping together parts and holes


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->
Add the `createPactCommandFromStringTemplate` and `getPartsAndHoles` method to `@kadena/client-utils/nodejs`

This allows finding holes in templates to data can be collected, and subsequently parsing the template with data into a transaction directly from strings, removing the need for filesystem usage.