### PR TITLE
[@kadena/graph] Performance improvements for Prisma queries

### DIFF
--- a/.changeset/strange-birds-buy.md
+++ b/.changeset/strange-birds-buy.md
@@ -1,0 +1,5 @@
+---
+'@kadena/graph': patch
+---
+
+Performance improvements for prisma queries

--- a/packages/apps/graph/src/graph/objects/event.ts
+++ b/packages/apps/graph/src/graph/objects/event.ts
@@ -7,6 +7,7 @@ export default builder.prismaNode('Event', {
   description:
     'An event emitted by the execution of a smart-contract function.',
   id: { field: 'blockHash_orderIndex_requestKey' },
+  select: {},
   fields: (t) => ({
     // database fields
     incrementedId: t.exposeInt('id'),
@@ -34,6 +35,10 @@ export default builder.prismaNode('Event', {
       type: 'Transaction',
       nullable: true,
       complexity: COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS,
+      select: {
+        blockHash: true,
+        requestKey: true,
+      },
       async resolve(query, parent) {
         try {
           return await prismaClient.transaction.findUnique({
@@ -55,6 +60,9 @@ export default builder.prismaNode('Event', {
       type: 'Block',
       nullable: false,
       complexity: COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS,
+      select: {
+        blockHash: true,
+      },
       async resolve(query, parent) {
         try {
           return await prismaClient.block.findUniqueOrThrow({

--- a/packages/apps/graph/src/graph/objects/miner-key.ts
+++ b/packages/apps/graph/src/graph/objects/miner-key.ts
@@ -6,16 +6,17 @@ import { builder } from '../builder';
 export default builder.prismaNode('MinerKey', {
   description: 'The account of the miner that solved a block.',
   id: { field: 'blockHash_key' },
+  select: {},
   fields: (t) => ({
-    // database fields
     blockHash: t.exposeString('blockHash'),
     key: t.exposeString('key'),
-
-    //relations
     block: t.prismaField({
       type: 'Block',
       nullable: false,
       complexity: COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS,
+      select: {
+        blockHash: true,
+      },
       async resolve(query, parent) {
         try {
           return await prismaClient.block.findUniqueOrThrow({

--- a/packages/apps/graph/src/graph/objects/signer.ts
+++ b/packages/apps/graph/src/graph/objects/signer.ts
@@ -4,6 +4,7 @@ import { builder } from '../builder';
 export default builder.prismaNode('Signer', {
   description: 'A signer for a specific transaction.',
   id: { field: 'requestKey_orderIndex' },
+  select: {},
   fields: (t) => ({
     //database fields
     address: t.exposeString('address', {
@@ -12,6 +13,9 @@ export default builder.prismaNode('Signer', {
     }),
     capabilities: t.string({
       nullable: true,
+      select: {
+        capabilities: true,
+      },
       resolve({ capabilities }) {
         return nullishOrEmpty(capabilities)
           ? undefined

--- a/packages/apps/graph/src/graph/objects/transaction.ts
+++ b/packages/apps/graph/src/graph/objects/transaction.ts
@@ -7,12 +7,16 @@ import { PRISMA, builder } from '../builder';
 export default builder.prismaNode('Transaction', {
   description: 'A confirmed transaction.',
   id: { field: 'blockHash_requestKey' },
+  select: {},
   fields: (t) => ({
     // database fields
     badResult: t.string({
       description:
         'The JSON stringified error message if the transaction failed.',
       nullable: true,
+      select: {
+        badResult: true,
+      },
       resolve({ badResult }) {
         return nullishOrEmpty(badResult)
           ? undefined
@@ -20,10 +24,12 @@ export default builder.prismaNode('Transaction', {
       },
     }),
     chainId: t.expose('chainId', { type: 'BigInt' }),
-    // code: t.exposeString('code', { nullable: true }),
     code: t.string({
       description:
         'The Pact expressions executed in this transaction when it is an `exec` transaction. For a continuation, this field is `cont`.',
+      select: {
+        code: true,
+      },
       resolve({ code }) {
         return code === null ? JSON.stringify('cont') : JSON.stringify(code);
       },
@@ -32,6 +38,9 @@ export default builder.prismaNode('Transaction', {
       description:
         'The JSON stringified continuation in the case that it is a continuation.',
       nullable: true,
+      select: {
+        continuation: true,
+      },
       resolve({ continuation }) {
         return nullishOrEmpty(continuation)
           ? undefined
@@ -43,6 +52,9 @@ export default builder.prismaNode('Transaction', {
       description:
         'The environment data made available to the transaction. Formatted as raw JSON.',
       nullable: true,
+      select: {
+        data: true,
+      },
       resolve({ data }) {
         return nullishOrEmpty(data) ? undefined : JSON.stringify(data);
       },
@@ -54,6 +66,9 @@ export default builder.prismaNode('Transaction', {
       description:
         'The transaction result when it was successful. Formatted as raw JSON.',
       nullable: true,
+      select: {
+        goodResult: true,
+      },
       resolve({ goodResult }) {
         return nullishOrEmpty(goodResult)
           ? undefined
@@ -71,6 +86,9 @@ export default builder.prismaNode('Transaction', {
     }),
     metadata: t.string({
       nullable: true,
+      select: {
+        metadata: true,
+      },
       resolve({ metadata }) {
         return nullishOrEmpty(metadata) ? undefined : JSON.stringify(metadata);
       },
@@ -112,6 +130,9 @@ export default builder.prismaNode('Transaction', {
       type: 'Block',
       nullable: true,
       complexity: COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS,
+      select: {
+        blockHash: true,
+      },
       async resolve(query, parent) {
         try {
           return await prismaClient.block.findUnique({
@@ -131,6 +152,10 @@ export default builder.prismaNode('Transaction', {
       nullable: true,
       complexity:
         COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS * PRISMA.DEFAULT_SIZE,
+      select: {
+        blockHash: true,
+        requestKey: true,
+      },
       async resolve(query, parent) {
         try {
           return await prismaClient.event.findMany({
@@ -152,6 +177,10 @@ export default builder.prismaNode('Transaction', {
       nullable: true,
       complexity:
         COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS * PRISMA.DEFAULT_SIZE,
+      select: {
+        blockHash: true,
+        requestKey: true,
+      },
       async resolve(query, parent) {
         try {
           return await prismaClient.transfer.findMany({
@@ -173,6 +202,9 @@ export default builder.prismaNode('Transaction', {
       nullable: true,
       complexity:
         COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS * PRISMA.DEFAULT_SIZE,
+      select: {
+        requestKey: true,
+      },
       async resolve(query, parent) {
         try {
           return await prismaClient.signer.findMany({

--- a/packages/apps/graph/src/graph/objects/transfer.ts
+++ b/packages/apps/graph/src/graph/objects/transfer.ts
@@ -8,6 +8,7 @@ import { PRISMA, builder } from '../builder';
 export default builder.prismaNode('Transfer', {
   description: 'A transfer of funds from a fungible between two accounts.',
   id: { field: 'blockHash_chainId_orderIndex_moduleHash_requestKey' },
+  select: {},
   fields: (t) => ({
     // database fields
     amount: t.expose('amount' as never, { type: 'Decimal' }),
@@ -32,6 +33,11 @@ export default builder.prismaNode('Transfer', {
       type: 'Transfer',
       nullable: true,
       complexity: COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS * 2, // In the worst case resolve scenario, it executes 2 queries.
+      select: {
+        amount: true,
+        blockHash: true,
+        requestKey: true,
+      },
       async resolve(__query, parent) {
         try {
           // Find all transactions that match either of the two conditions
@@ -92,6 +98,9 @@ export default builder.prismaNode('Transfer', {
     blocks: t.prismaField({
       type: ['Block'],
       complexity: COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS,
+      select: {
+        blockHash: true,
+      },
       async resolve(query, parent) {
         try {
           return await prismaClient.block.findMany({
@@ -112,6 +121,10 @@ export default builder.prismaNode('Transfer', {
       nullable: true,
       complexity:
         COMPLEXITY.FIELD.PRISMA_WITHOUT_RELATIONS * PRISMA.DEFAULT_SIZE,
+      select: {
+        blockHash: true,
+        requestKey: true,
+      },
       async resolve(query, parent) {
         try {
           return await prismaClient.transaction.findUnique({

--- a/packages/apps/graph/src/graph/subscription/events.ts
+++ b/packages/apps/graph/src/graph/subscription/events.ts
@@ -1,5 +1,4 @@
 import { prismaClient } from '@db/prisma-client';
-import type { Event } from '@prisma/client';
 import { createID } from '@utils/global-id';
 import { nullishOrEmpty } from '@utils/nullish-or-empty';
 import type { IContext } from '../builder';
@@ -56,7 +55,12 @@ async function* iteratorFn(
   }
 }
 
-async function getLastEvents(eventName: string, id?: number): Promise<Event[]> {
+async function getLastEvents(
+  eventName: string,
+  id?: number,
+): Promise<
+  { blockHash: string; orderIndex: bigint; requestKey: string; id: number }[]
+> {
   const defaultFilter: Parameters<typeof prismaClient.event.findMany>[0] = {
     orderBy: {
       id: 'desc',
@@ -79,6 +83,12 @@ async function getLastEvents(eventName: string, id?: number): Promise<Event[]> {
       transaction: {
         NOT: [],
       },
+    },
+    select: {
+      id: true,
+      blockHash: true,
+      orderIndex: true,
+      requestKey: true,
     },
   });
 

--- a/packages/apps/graph/src/graph/subscription/transaction.ts
+++ b/packages/apps/graph/src/graph/subscription/transaction.ts
@@ -27,6 +27,10 @@ async function* iteratorFn(
       where: {
         requestKey: requestKey,
       },
+      select: {
+        blockHash: true,
+        requestKey: true,
+      },
     });
 
     if (transaction) {

--- a/packages/apps/graph/src/services/tracing/trace-analyser.ts
+++ b/packages/apps/graph/src/services/tracing/trace-analyser.ts
@@ -1,8 +1,6 @@
-import 'module-alias/register';
-
-import { dotenv } from '@utils/dotenv';
 import { Command, Option } from 'commander';
 import { readFileSync } from 'fs';
+import { dotenv } from '../../utils/dotenv';
 
 new Command()
   .command('trace-analyser')

--- a/packages/apps/graph/src/services/tracing/trace-service.ts
+++ b/packages/apps/graph/src/services/tracing/trace-service.ts
@@ -1,5 +1,3 @@
-import 'module-alias/register';
-
 import { dotenv } from '@utils/dotenv';
 import fs from 'fs';
 


### PR DESCRIPTION
With this change, Prisma only queries the fields that were requested from the GraphQL query.

With the help of @hayes: https://github.com/hayes/pothos/issues/1131
