### PR TITLE
chore(@kadena/react-ui): Update select spacing and added "startIcon" to combobox

### DIFF
--- a/.changeset/serious-rocks-reply.md
+++ b/.changeset/serious-rocks-reply.md
@@ -1,0 +1,5 @@
+---
+'@kadena/react-ui': patch
+---
+
+Update Select and Combobox styles

--- a/packages/libs/react-ui/src/components/Form/Combobox/Combobox.stories.tsx
+++ b/packages/libs/react-ui/src/components/Form/Combobox/Combobox.stories.tsx
@@ -141,6 +141,28 @@ export const Default: Story = {
   },
 };
 
+export const WithIcon: Story = {
+  args: {
+    isDisabled: false,
+    isInvalid: false,
+    isRequired: false,
+    isPositive: false,
+    description: 'Some description',
+    label: 'Select something',
+    placeholder: 'Select an option',
+  },
+  render: (args) => {
+    return (
+      <Combobox {...args} startIcon={<Account />}>
+        <ComboboxItem key="option1">Option 1</ComboboxItem>
+        <ComboboxItem key="option2">Option 2</ComboboxItem>
+        <ComboboxItem key="option3">Option 3</ComboboxItem>
+        <ComboboxItem key="option4">Option 4</ComboboxItem>
+      </Combobox>
+    );
+  },
+};
+
 export const ComplexItems = () => (
   <Combobox label="Select an option">
     <ComboboxItem key="option1" textValue="Option 1">

--- a/packages/libs/react-ui/src/components/Form/Combobox/Combobox.tsx
+++ b/packages/libs/react-ui/src/components/Form/Combobox/Combobox.tsx
@@ -1,11 +1,12 @@
 import { mergeProps, useObjectRef } from '@react-aria/utils';
 import classNames from 'classnames';
-import type { ForwardedRef } from 'react';
+import type { ForwardedRef, ReactNode } from 'react';
 import React, { forwardRef, useRef } from 'react';
 import type { AriaComboBoxProps } from 'react-aria';
 import { useComboBox, useFilter, useHover } from 'react-aria';
 import { useComboBoxState } from 'react-stately';
 
+import { atoms } from '../../../styles';
 import { ListBox } from '../../ListBox';
 import { Popover } from '../../Popover';
 import { formField } from '../Form.css';
@@ -17,6 +18,7 @@ import { ComboboxButton } from './ComboboxButton';
 export interface IComboboxProps<T extends object = any>
   extends AriaComboBoxProps<T> {
   isPositive?: boolean;
+  startIcon?: ReactNode;
   className?: string;
   tag?: string;
   info?: string;
@@ -98,6 +100,11 @@ function ComboBoxBase<T extends object>(
         ref={triggerRef}
         className={comboBoxControlClass}
       >
+        {props.startIcon && (
+          <span className={atoms({ marginInlineEnd: 'sm' })}>
+            {props.startIcon}
+          </span>
+        )}
         <input {...inputProps} ref={inputRef} className={comboBoxInputClass} />
         <ComboboxButton
           {...buttonProps}

--- a/packages/libs/react-ui/src/components/Form/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Form/Select/Select.css.ts
@@ -13,6 +13,7 @@ export const selectButtonClass = style([
     outline: 'none',
     flex: 1,
     overflow: 'hidden',
+    position: 'relative',
   }),
   {
     paddingInlineStart: token('spacing.md'),

--- a/packages/libs/react-ui/src/components/Form/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Form/Select/Select.css.ts
@@ -13,7 +13,6 @@ export const selectButtonClass = style([
     outline: 'none',
     flex: 1,
     overflow: 'hidden',
-    position: 'relative',
   }),
   {
     paddingInlineStart: token('spacing.md'),

--- a/packages/libs/react-ui/src/components/Form/Select/Select.stories.tsx
+++ b/packages/libs/react-ui/src/components/Form/Select/Select.stories.tsx
@@ -141,6 +141,28 @@ export const Default: Story = {
   },
 };
 
+export const WithIcon: Story = {
+  args: {
+    isDisabled: false,
+    isInvalid: false,
+    isRequired: false,
+    isPositive: false,
+    description: 'Some description',
+    label: 'Select something',
+    placeholder: 'Select an option',
+  },
+  render: (args) => {
+    return (
+      <Select {...args} startIcon={<Account />}>
+        <SelectItem key="option1">Option 1</SelectItem>
+        <SelectItem key="option2">Option 2</SelectItem>
+        <SelectItem key="option3">Option 3</SelectItem>
+        <SelectItem key="option4">Option 4</SelectItem>
+      </Select>
+    );
+  },
+};
+
 export const ComplexItems = () => (
   <Select label="Select an option">
     <SelectItem key="option1" textValue="Option 1">

--- a/packages/libs/react-ui/src/components/Form/Select/SelectButton.tsx
+++ b/packages/libs/react-ui/src/components/Form/Select/SelectButton.tsx
@@ -5,8 +5,9 @@ import React, { forwardRef } from 'react';
 import type { AriaButtonProps } from 'react-aria';
 import { useButton, useHover } from 'react-aria';
 import type { SelectState } from 'react-stately';
-import { rotate180Transition } from '../../../styles';
+import { atoms, rotate180Transition } from '../../../styles';
 import { ChevronDown } from '../../Icon/System/SystemIcon';
+import { startAddon } from '../Form.css';
 import { selectButtonClass } from './Select.css';
 
 export interface ISelectButtonProps<T extends object> extends AriaButtonProps {
@@ -41,9 +42,13 @@ function SelectButtonBase<T extends object>(
       className={classNames(selectButtonClass, props.className)}
       ref={ref}
     >
-      {props.startIcon && <span>{props.startIcon}</span>}
+      {props.startIcon && (
+        <span className={atoms({ marginInlineEnd: 'sm' })}>
+          {props.startIcon}
+        </span>
+      )}
       {props.children}
-      <span>
+      <span className={atoms({ marginInlineStart: 'sm' })}>
         <ChevronDown
           data-open={props.state.isOpen}
           className={rotate180Transition}

--- a/packages/libs/react-ui/src/components/Form/Select/SelectButton.tsx
+++ b/packages/libs/react-ui/src/components/Form/Select/SelectButton.tsx
@@ -7,7 +7,6 @@ import { useButton, useHover } from 'react-aria';
 import type { SelectState } from 'react-stately';
 import { atoms, rotate180Transition } from '../../../styles';
 import { ChevronDown } from '../../Icon/System/SystemIcon';
-import { startAddon } from '../Form.css';
 import { selectButtonClass } from './Select.css';
 
 export interface ISelectButtonProps<T extends object> extends AriaButtonProps {


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->

- Added some padding between the icons in the select component
- Added `startIcon` to the combobox
