### PR TITLE
fix(create-kadena-app): remove pnpm only installation step

### DIFF
--- a/.changeset/funny-moles-deliver.md
+++ b/.changeset/funny-moles-deliver.md
@@ -1,0 +1,5 @@
+---
+'@kadena/create-kadena-app': patch
+---
+
+Fix remove only allow pnpm

--- a/packages/tools/create-kadena-app/package.json
+++ b/packages/tools/create-kadena-app/package.json
@@ -28,7 +28,6 @@
   ],
   "scripts": {
     "cleanup": "rimraf dist lib",
-    "preinstall": "npx only-allow pnpm",
     "copy": "node ./src/scripts/copy.mjs",
     "build": "pnpm run cleanup && tsc && pnpm run copy",
     "format": "prettier config src templates --write",
@@ -38,6 +37,7 @@
     "test:integration": "rimraf test-* && cross-env NG_CLI_ANALYTICS=false ./scripts/generate-test.sh"
   },
   "dependencies": {
+    "chalk": "^5.2.0",
     "commander": "^11.0.0",
     "cross-fetch": "~3.1.5",
     "cross-spawn": "~7.0.3",
@@ -53,7 +53,6 @@
     "@types/mkdirp": "~1.0.2",
     "@types/node": "^18.17.14",
     "@types/rimraf": "~3.0.2",
-    "chalk": "^5.2.0",
     "cross-env": "~7.0.3",
     "eslint": "^8.45.0",
     "prettier": "~3.0.3",
@@ -61,9 +60,5 @@
     "rimraf": "~5.0.1",
     "ts-node": "~10.8.2",
     "typescript": "5.2.2"
-  },
-  "engines": {
-    "node": ">=18",
-    "pnpm": ">=8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1891,6 +1891,9 @@ importers:
 
   packages/tools/create-kadena-app:
     dependencies:
+      chalk:
+        specifier: ^5.2.0
+        version: 5.3.0
       commander:
         specifier: ^11.0.0
         version: 11.0.0
@@ -1931,9 +1934,6 @@ importers:
       '@types/rimraf':
         specifier: ~3.0.2
         version: 3.0.2
-      chalk:
-        specifier: ^5.2.0
-        version: 5.3.0
       cross-env:
         specifier: ~7.0.3
         version: 7.0.3


### PR DESCRIPTION
`"preinstall": "npx only-allow pnpm"` shouldn't be available. This makes it only to allow from `pnpm`