### PR TITLE
fix(@kadena/react-ui): Fix layout component prop type checking

### DIFF
--- a/packages/libs/react-ui/src/components/Layout/Box/Box.stories.tsx
+++ b/packages/libs/react-ui/src/components/Layout/Box/Box.stories.tsx
@@ -7,10 +7,9 @@ import {
   defaultBoxArgs,
   sharedStoryArgTypes,
 } from '../storyComponents';
-import type { IBoxProps } from './Box';
 import { Box } from './Box';
 
-const meta: Meta<IBoxProps> = {
+const meta: Meta<typeof Box> = {
   title: 'Layout/Box',
   component: Box,
   decorators: [onLayer2],
@@ -30,7 +29,7 @@ const meta: Meta<IBoxProps> = {
 };
 
 export default meta;
-type Story = StoryObj<IBoxProps>;
+type Story = StoryObj<typeof Box>;
 
 export const Primary: Story = {
   name: 'Box - Margin',

--- a/packages/libs/react-ui/src/components/Layout/Box/Box.tsx
+++ b/packages/libs/react-ui/src/components/Layout/Box/Box.tsx
@@ -5,7 +5,7 @@ import type { Atoms } from '../../../styles/atoms.css';
 import { atoms } from '../../../styles/atoms.css';
 
 export interface IBoxProps
-  extends ComponentPropsWithRef<ElementType>,
+  extends ComponentPropsWithRef<'div'>,
     Partial<
       Pick<
         Atoms,


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->

The proptypes on the Layout components were too flexible which is why the types checking wasn't working. I've updated the layout components to apply `div` component props to fix this. In most cases we use these components as divs and the ref is still typed to accept any `HTMLElement` ref if necessary. 
