### PR TITLE
feat: Add CI gate to enforce all status checks pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - end-to-end-tests
     runs-on: Ubuntu-latest
     steps:
-      - name: Decide whether the needed jobs succeeded or failed
+      - name: Check Required Jobs.
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,14 +142,11 @@ jobs:
 
   ci-gate:
     if: always()
-
     needs:
       - build
       - integration-tests
       - end-to-end-tests
-
     runs-on: Ubuntu-latest
-
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - end-to-end-tests
     runs-on: Ubuntu-latest
     steps:
-      - name: Check Required Jobs.
+      - name: Check required jobs.
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,19 @@ jobs:
           name: playwright-report
           path: packages/tools/e2e-tests/playwright-report/
           retention-days: 30
+
+  ci-gate:
+    if: always()
+
+    needs:
+      - build
+      - integration-tests
+      - end-to-end-tests
+
+    runs-on: Ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
We have enabled branch protection to require certain checks to pass before being allowed to merge to main. Unfortunately these settings are hidden away behind administrative permissions for the repository making them tedious to maintain. Especlally now that we're adding various tests as matrix builds, having to add them individually to branch protection is cumbersome. 

After some research, it seems I am not the only one that is frustrated with how GitHub Actions implements these features. I made these checks for a reason, why the heck would they not be required?

The solution appears to be a GitHub action called [Alls-Green](https://github.com/re-actors/alls-green). With this Action we can add 1 additional check for CI (and make _that_ required) which iterates over all other jobs in the workflow they make sure they have the status **success**

This allows us to maintain required workflows in code, instead of the github UI making maintenance available to anyone that can create a pull request, instead of just a few admins.  

Rationale for this change is, currently only the **build** Job is mandatory, allowing developers to merge pull requests that contain broken tests, as these workflows are not required.

This adds a `ci-gate` job, that checks if all other jobs passed and if so,  mark `ci-gate` as passed. If one of the required jobs does not have the success state, it will fail ci-gate.

@alber70g After this PR has been merged

Could you:
-  go in to the settings for the repository
- Navigate to Branches (left sidebar)
- Update 'Required Status checks to pass before merging'
- Remove 'Build' and add ci-gate