### PR TITLE
feat(client-utils): query all chains

### DIFF
--- a/.changeset/cyan-months-return.md
+++ b/.changeset/cyan-months-return.md
@@ -1,0 +1,5 @@
+---
+'@kadena/client-utils': minor
+---
+
+Introducing accountDiscovery and queryAllChainsClient

--- a/packages/libs/client-utils/etc/client-utils-coin.api.md
+++ b/packages/libs/client-utils/etc/client-utils-coin.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { ChainId } from '@kadena/client';
+import { ChainId as ChainId_2 } from '@kadena/types';
 import { ICommand } from '@kadena/types';
 import { ICommandResult } from '@kadena/chainweb-node-client';
 import { ILocalCommandResult } from '@kadena/chainweb-node-client';
@@ -46,6 +47,24 @@ export const createCrossChainCommand: ({ sender, receiver, amount, targetChainId
 
 // @alpha (undocumented)
 export const details: (account: string, networkId: string, chainId: ChainId, host?: IClientConfig['host'], contract?: string) => Promise<undefined> | Promise<object>;
+
+// @alpha (undocumented)
+export const discoverAccount: (account: string, networkId: string, host?: IClientConfig['host'], contract?: string) => IEmitterWrapper<[{
+event: "query-result";
+data: {
+result: object | undefined;
+chainId: ChainId_2 | undefined;
+}[];
+}], [{
+event: "chain-result";
+data: {
+result: object;
+chainId: ChainId_2;
+};
+}], Promise<{
+result: object | undefined;
+chainId: ChainId_2 | undefined;
+}[]>>;
 
 // @alpha (undocumented)
 export const getBalance: (account: string, networkId: string, chainId: ChainId, host?: IClientConfig['host'], contract?: string) => Promise<string | undefined>;

--- a/packages/libs/client-utils/etc/client-utils-core.api.md
+++ b/packages/libs/client-utils/etc/client-utils-core.api.md
@@ -386,6 +386,26 @@ export const estimateGas: (command: IPartialPactCommand_2 | ((cmd?: IPartialPact
 }>;
 
 // @alpha (undocumented)
+export interface IEmitterWrapper<T extends Array<{
+    event: string;
+    data: Any;
+}>, Extra extends Array<{
+    event: string;
+    data: Any;
+}>, ExecReturnType> {
+    // (undocumented)
+    execute: () => ExecReturnType;
+    // Warning: (ae-forgotten-export) The symbol "ExecuteTo" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    executeTo: (() => ExecReturnType) & ExecuteTo<[...T]>;
+    // Warning: (ae-forgotten-export) The symbol "OnType" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    on: OnType<[...T, ...Extra], this>;
+}
+
+// @alpha (undocumented)
 export const preflightClient: <T = PactValue>(args_0: IClientConfig, args_1?: IClient | undefined) => {
     (cmd?: (Partial<IPartialPactCommand> | (() => Partial<IPartialPactCommand>)) | undefined): IEmitterWrapper<[{
     event: "sign";
@@ -407,6 +427,63 @@ export const preflightClient: <T = PactValue>(args_0: IClientConfig, args_1?: IC
     event: "preflight";
     data: ILocalCommandResult;
     }], [], Promise<undefined> | (T extends Promise<any> ? T : Promise<T>)>);
+};
+
+// @alpha (undocumented)
+export const queryAllChainsClient: <T = PactValue>(args_0: Omit<IClientConfig, "sign">) => {
+    (cmd?: (Partial<IPartialPactCommand> | (() => Partial<IPartialPactCommand>)) | undefined): IEmitterWrapper<[{
+    event: "query-result";
+    data: {
+    result: Awaited<T> | undefined;
+    chainId: ChainId | undefined;
+    }[];
+    }], [{
+    event: 'chain-result';
+    data: {
+    result: T;
+    chainId: ChainId;
+    };
+    }], Promise<{
+    result: Awaited<T> | undefined;
+    chainId: ChainId | undefined;
+    }[]>>;
+    from: ((event: "query-result", data: {
+        result: Awaited<T> | undefined;
+        chainId: ChainId | undefined;
+    }[]) => IEmitterWrapper<[{
+    event: "query-result";
+    data: {
+    result: Awaited<T> | undefined;
+    chainId: ChainId | undefined;
+    }[];
+    }], [{
+    event: 'chain-result';
+    data: {
+    result: T;
+    chainId: ChainId;
+    };
+    }], Promise<{
+    result: Awaited<T> | undefined;
+    chainId: ChainId | undefined;
+    }[]>>) & ((event: "chain-result", data: {
+        result: T;
+        chainId: ChainId;
+    }) => IEmitterWrapper<[{
+    event: "query-result";
+    data: {
+    result: Awaited<T> | undefined;
+    chainId: ChainId | undefined;
+    }[];
+    }], [{
+    event: 'chain-result';
+    data: {
+    result: T;
+    chainId: ChainId;
+    };
+    }], Promise<{
+    result: Awaited<T> | undefined;
+    chainId: ChainId | undefined;
+    }[]>>);
 };
 
 // @alpha (undocumented)
@@ -475,9 +552,28 @@ export const submitClient: <T = PactValue>(args_0: IClientConfig, args_1?: IClie
     }], [], Promise<undefined> | (T extends Promise<any> ? T : Promise<T>)>);
 };
 
+// Warning: (ae-forgotten-export) The symbol "IEmit" needs to be exported by the entry point index.d.ts
+//
+// @alpha (undocumented)
+export type WithEmitter<Extra extends [...Array<{
+    event: string;
+    data: Any;
+}>] = []> = <T extends (emit: IEmit) => Any>(fn: T) => {
+    (...args: Parameters<ReturnType<T>>): IEmitterWrapper<ExtractEventType<ReturnType<T>>, Extra, ReturnType<ReturnType<T>>>;
+    from: StartFrom<[
+    ...ExtractEventType<ReturnType<T>>,
+    ...Extra
+    ], IEmitterWrapper<ExtractEventType<ReturnType<T>>, Extra, ReturnType<ReturnType<T>>>>;
+};
+
+// @alpha (undocumented)
+export const withEmitter: WithEmitter;
+
 // Warnings were encountered during analysis:
 //
-// src/core/client-helpers.ts:41:57 - (ae-forgotten-export) The symbol "IEmitterWrapper" needs to be exported by the entry point index.d.ts
+// src/core/utils/with-emitter.ts:38:36 - (ae-forgotten-export) The symbol "Any" needs to be exported by the entry point index.d.ts
+// src/core/utils/with-emitter.ts:57:3 - (ae-forgotten-export) The symbol "ExtractEventType" needs to be exported by the entry point index.d.ts
+// src/core/utils/with-emitter.ts:64:3 - (ae-forgotten-export) The symbol "StartFrom" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/libs/client-utils/package.json
+++ b/packages/libs/client-utils/package.json
@@ -14,30 +14,25 @@
     "Nil Amrutlal <nil.amrutlal@deptagency.com>"
   ],
   "exports": {
-    "./built-in": "./lib/built-in/index.js",
-    "./coin": "./lib/coin/index.js",
-    "./core": "./lib/core/index.js",
-    "./nodejs": "./lib/nodejs/index.js",
-    "./marmalade": "./lib/marmalade/index.js"
-  },
-  "main": "./lib/core/index.js",
-  "typesVersions": {
-    "*": {
-      "built-in": [
-        "./lib/built-in/index.d.ts"
-      ],
-      "core": [
-        "./lib/core/index.d.ts"
-      ],
-      "coin": [
-        "./lib/coin/index.d.ts"
-      ],
-      "nodejs": [
-        "./lib/nodejs/index.d.ts"
-      ],
-      "marmalade": [
-        "./lib/marmalade/index.d.ts"
-      ]
+    "./built-in": {
+      "default": "./lib/built-in/index.js",
+      "types": "./lib/built-in/index.d.ts"
+    },
+    "./coin": {
+      "default": "./lib/coin/index.js",
+      "types": "./lib/coin/index.d.ts"
+    },
+    "./core": {
+      "default": "./lib/core/index.js",
+      "types": "./lib/core/index.d.ts"
+    },
+    "./nodejs": {
+      "default": "./lib/nodejs/index.js",
+      "types": "./lib/nodejs/index.d.ts"
+    },
+    "./marmalade": {
+      "default": "./lib/marmalade/index.js",
+      "types": "./lib/marmalade/index.d.ts"
     }
   },
   "files": [
@@ -57,6 +52,7 @@
     "dev:ae:built-in": "api-extractor run --local --verbose -c ./config/api-extractor-built-in.json",
     "dev:ae:coin": "api-extractor run --local --verbose -c ./config/api-extractor-coin.json",
     "dev:ae:core": "api-extractor run --local --verbose -c ./config/api-extractor-core.json",
+    "dev:ae": "pnpm run dev:ae:core && pnpm run dev:ae:built-in && pnpm run dev:ae:coin",
     "dev:postinstall": "pnpm run pactjs:generate:contract",
     "format": "pnpm run /^format:.*/",
     "format:lint": "pnpm run lint:src --fix",

--- a/packages/libs/client-utils/src/coin/discover-account.ts
+++ b/packages/libs/client-utils/src/coin/discover-account.ts
@@ -1,0 +1,30 @@
+import type { IPactModules, PactReturnType } from '@kadena/client';
+import { Pact } from '@kadena/client';
+import { execution } from '@kadena/client/fp';
+
+import { queryAllChainsClient } from '../core/client-helpers';
+import type { IClientConfig } from '../core/utils/helpers';
+
+import { pipe } from 'ramda';
+
+/**
+ * @alpha
+ */
+export const discoverAccount = (
+  account: string,
+  networkId: string,
+  host?: IClientConfig['host'],
+  contract: string = 'coin',
+) => {
+  const queryDetails = pipe(
+    (name) => Pact.modules[contract as 'coin'].details(name),
+    execution,
+    queryAllChainsClient<PactReturnType<IPactModules['coin']['details']>>({
+      host,
+      defaults: {
+        networkId,
+      },
+    }),
+  );
+  return queryDetails(account);
+};

--- a/packages/libs/client-utils/src/coin/index.ts
+++ b/packages/libs/client-utils/src/coin/index.ts
@@ -1,5 +1,6 @@
 export * from './create-account';
 export * from './details';
+export * from './discover-account';
 export * from './get-balance';
 export * from './rotate';
 export * from './safe-transfer';

--- a/packages/libs/client-utils/src/core/client-helpers.ts
+++ b/packages/libs/client-utils/src/core/client-helpers.ts
@@ -11,6 +11,7 @@ import type { WithEmitter } from './utils/with-emitter';
 import { withEmitter } from './utils/with-emitter';
 
 import type { PactValue } from '@kadena/types';
+import { queryAllChains } from './query-all-chains';
 
 /**
  * @alpha
@@ -32,6 +33,18 @@ export const preflightClient = <T = PactValue>(
 export const dirtyReadClient = <T = PactValue>(
   ...args: Parameters<typeof dirtyRead<T>>
 ) => withEmitter(dirtyRead<T>(...args));
+
+/**
+ * @alpha
+ */
+export const queryAllChainsClient = <T = PactValue>(
+  ...args: Parameters<typeof queryAllChains<T>>
+) =>
+  (
+    withEmitter as unknown as WithEmitter<
+      [{ event: 'chain-result'; data: { result: T; chainId: ChainId } }]
+    >
+  )(queryAllChains<T>(...args));
 
 /**
  * @alpha

--- a/packages/libs/client-utils/src/core/index.ts
+++ b/packages/libs/client-utils/src/core/index.ts
@@ -1,3 +1,4 @@
 export * from './client-helpers';
 export * from './estimate-gas';
 export * from './utils/asyncPipe';
+export * from './utils/with-emitter';

--- a/packages/libs/client-utils/src/core/query-all-chains.ts
+++ b/packages/libs/client-utils/src/core/query-all-chains.ts
@@ -1,0 +1,44 @@
+import type { ChainId, IPartialPactCommand } from '@kadena/client';
+import { createTransaction } from '@kadena/client';
+import { composePactCommand, setMeta } from '@kadena/client/fp';
+
+import type { PactValue } from '@kadena/types';
+import { asyncPipe } from './utils/asyncPipe';
+import type { IClientConfig, IEmit } from './utils/helpers';
+import { extractResult, getClient } from './utils/helpers';
+
+const chainIds = [...Array(20).keys()].map((key) => `${key}` as ChainId);
+
+export const query =
+  <T = PactValue>(
+    { host, defaults }: Omit<IClientConfig, 'sign'>,
+    client = getClient(host),
+  ) =>
+  (emit: IEmit) =>
+    asyncPipe(
+      composePactCommand(defaults ?? {}),
+      createTransaction,
+      client.dirtyRead,
+      extractResult<T>,
+      (result) => ({ result, chainId: defaults?.meta?.chainId }),
+      emit('chain-result'),
+    );
+
+export const queryAllChains =
+  <T = PactValue>({ host, defaults }: Omit<IClientConfig, 'sign'>) =>
+  (emit: IEmit) =>
+    asyncPipe(
+      composePactCommand(defaults ?? {}),
+      (command) =>
+        composePactCommand(command, setMeta({ chainId: undefined }))({}),
+      (command: IPartialPactCommand) => {
+        return Promise.all(
+          chainIds.map((chainId) => {
+            return query<T>({ host, defaults: { meta: { chainId } } })(emit)(
+              command,
+            );
+          }),
+        );
+      },
+      emit('query-result'),
+    );

--- a/packages/libs/client-utils/src/core/utils/helpers.ts
+++ b/packages/libs/client-utils/src/core/utils/helpers.ts
@@ -1,11 +1,13 @@
 import type {
+  ICommand,
   ICommandResult,
   INetworkOptions,
   IPactCommand,
   ISignFunction,
+  IUnsignedCommand,
 } from '@kadena/client';
 import { createClient, getHostUrl, isSignedTransaction } from '@kadena/client';
-import type { ICommand, IUnsignedCommand, PactValue } from '@kadena/types';
+import type { PactValue } from '@kadena/types';
 
 import type { Any } from './types';
 

--- a/packages/libs/client-utils/src/core/utils/with-emitter.ts
+++ b/packages/libs/client-utils/src/core/utils/with-emitter.ts
@@ -31,6 +31,9 @@ type OnType<
   }[number]
 >;
 
+/**
+ * @alpha
+ */
 export interface IEmitterWrapper<
   T extends Array<{ event: string; data: Any }>,
   Extra extends Array<{ event: string; data: Any }>,
@@ -41,6 +44,11 @@ export interface IEmitterWrapper<
   executeTo: (() => ExecReturnType) & ExecuteTo<[...T]>;
 }
 
+type ExtractEventType<T> = T extends { _event_type: infer U } ? U : any;
+
+/**
+ * @alpha
+ */
 export type WithEmitter<
   Extra extends [...Array<{ event: string; data: Any }>] = [],
 > = <T extends (emit: IEmit) => Any>(
@@ -49,20 +57,23 @@ export type WithEmitter<
   (
     ...args: Parameters<ReturnType<T>>
   ): IEmitterWrapper<
-    ReturnType<T>['_event_type'],
+    ExtractEventType<ReturnType<T>>,
     Extra,
     ReturnType<ReturnType<T>>
   >;
   from: StartFrom<
-    [...ReturnType<T>['_event_type'], ...Extra],
+    [...ExtractEventType<ReturnType<T>>, ...Extra],
     IEmitterWrapper<
-      ReturnType<T>['_event_type'],
+      ExtractEventType<ReturnType<T>>,
       Extra,
       ReturnType<ReturnType<T>>
     >
   >;
 };
 
+/**
+ * @alpha
+ */
 export const withEmitter: WithEmitter = (fn) => {
   const createListener = (
     args: Any[],

--- a/packages/libs/client-utils/src/integration-tests/support/interfaces.ts
+++ b/packages/libs/client-utils/src/integration-tests/support/interfaces.ts
@@ -1,4 +1,4 @@
-import type { ChainId } from '@kadena/types';
+import type { ChainId } from '@kadena/client';
 
 export interface IAccount {
   account: string;


### PR DESCRIPTION
Introducing accountDiscovery and queryAllChainsClient

```
queryAllChainsClient: accepts a query and do a local call on all chains
accountDiscovery: it calls `details` on all chains