### PR TITLE
Feat: rename fast-development to development

### DIFF
--- a/.github/actions/devnet/action.sh
+++ b/.github/actions/devnet/action.sh
@@ -10,14 +10,14 @@ echo "docker run --name=devnet -d --health-cmd='curl --verbose --fail http://loc
   -v /home/runner/work/_temp:/home/runner/work/_temp \
   $INPUT_MIGRATIONS \
   -e GITHUB_ENV -e GITHUB_OUTPUT -e GITHUB_PATH -e GITHUB_STATE -e GITHUB_STEP_SUMMARY 	\
-  -p 8080:8080 -p 5432:5432 \"kadena/devnet\""
+  -p 8080:8080 -p 5432:5432 \"kadena/devnet:experimental-network-id-development\""
 
 exec docker run --name=devnet -d --health-cmd='curl --verbose --fail http://localhost:8080/info || exit 1' \
   -v "/var/run/docker.sock":"/var/run/docker.sock" \
   -v /home/runner/work/_temp:/home/runner/work/_temp \
   $INPUT_MIGRATIONS \
   -e GITHUB_ENV -e GITHUB_OUTPUT -e GITHUB_PATH -e GITHUB_STATE -e GITHUB_STEP_SUMMARY 	\
-  -p 8080:8080 -p 5432:5432 "kadena/devnet"
+  -p 8080:8080 -p 5432:5432 "kadena/devnet:experimental-network-id-development"
 
 echo "Waiting for devnet to be healthy..."
 until [ "`docker inspect -f {{.State.Health.Status}} devnet`"=="healthy" ]; do

--- a/packages/apps/dev-wallet/src/config.ts
+++ b/packages/apps/dev-wallet/src/config.ts
@@ -1,4 +1,4 @@
 export const config = {
   flags: ["registry"],
-  networkId: "fast-development",
+  networkId: "development",
 };

--- a/packages/apps/docs/src/docs/blogchain/2023/kadena-tech-bulletin-5-2023-08-31.md
+++ b/packages/apps/docs/src/docs/blogchain/2023/kadena-tech-bulletin-5-2023-08-31.md
@@ -110,7 +110,7 @@ and more efficient, thereby reducing errors and making code reviews smoother!
 The newest version of Chainweb has been released! Chainweb 2.20 brings you some
 exciting updates, including but not limited to internal changes, Pact 4.8
 updates, and most significantly, a fresh Chainweb Version called
-“fast-development” designed for Pact developers.
+“development” designed for Pact developers.
 
 Official GitHub Link:
 [https://github.com/kadena-io/chainweb-node/releases/tag/2.20](https://github.com/kadena-io/chainweb-node/releases/tag/2.20)

--- a/packages/apps/docs/src/docs/build/guides/election-dapp-tutorial/start-a-local-blockchain.md
+++ b/packages/apps/docs/src/docs/build/guides/election-dapp-tutorial/start-a-local-blockchain.md
@@ -198,7 +198,7 @@ To explore using TypeScript and Kadena client:
     "deploy-gas-station:devnet": "KADENA_NETWORK=devnet ts-node ./deploy-gas-station.ts",
     "deploy-module:devnet": "KADENA_NETWORK=devnet ts-node ./deploy-module.ts",
     "format": "prettier --write .",
-    "generate-types:coin:devnet": "pactjs contract-generate --contract coin --api http://localhost:8080/chainweb/0.0/fast-development/chain/1/pact",
+    "generate-types:coin:devnet": "pactjs contract-generate --contract coin --api http://localhost:8080/chainweb/0.0/development/chain/1/pact",
     "list-modules:devnet": "KADENA_NETWORK=devnet ts-node ./list-modules.ts",
     "transfer-create:devnet": "KADENA_NETWORK=devnet ts-node ./transfer-create.ts",
     "transfer:devnet": "KADENA_NETWORK=devnet ts-node ./transfer.ts"
@@ -222,7 +222,7 @@ To explore using TypeScript and Kadena client:
 
    Notice that when the environment variable `KADENA_NETWORK` is set to `devnet`, the functions exported from this file return the following:
 
-   - The network identifier `fast-development`.
+   - The network identifier `development`.
    - The chain identifier `1`
    - The API base URL `localhost:8080`—the host and port for the node you previously specified for the development network—and appended with the network id and chain id.
 

--- a/packages/apps/graph/.env.example
+++ b/packages/apps/graph/.env.example
@@ -14,9 +14,9 @@ PRISMA_LOG_FILENAME="prisma.log"
 # This variable determines the maximum calculated block confirmation depth.
 MAX_CALCULATED_BLOCK_CONFIRMATION_DEPTH=7
 
-# The following variables are used to configure the network endpoints for the GraphQL API. The default values are localhost:8080 and fast-development.
+# The following variables are used to configure the network endpoints for the GraphQL API. The default values are localhost:8080 and development.
 NETWORK_HOST="http://localhost:8080"
-NETWORK_ID="fast-development"
+NETWORK_ID="development"
 
 # Server
 PORT=4000

--- a/packages/apps/graph/src/utils/dotenv.ts
+++ b/packages/apps/graph/src/utils/dotenv.ts
@@ -52,7 +52,7 @@ export const dotenv: {
     10,
   ),
   NETWORK_HOST: or(process.env.NETWORK_HOST, 'http://localhost:8080'),
-  NETWORK_ID: or(process.env.NETWORK_ID, 'fast-development'),
+  NETWORK_ID: or(process.env.NETWORK_ID, 'development'),
   PORT: parseInt(or(process.env.PORT, '4000'), 10),
   PRISMA_LOGGING_ENABLED: or(
     process.env.PRISMA_LOGGING_ENABLED?.toLocaleLowerCase() === 'true',

--- a/packages/apps/tools/src/components/Global/AddNetworkModal/AddNetworkModal.tsx
+++ b/packages/apps/tools/src/components/Global/AddNetworkModal/AddNetworkModal.tsx
@@ -104,7 +104,7 @@ export const AddNetworkModal: FC<IAddNetworkModalProps> = (props) => {
                       {...register('networkId')}
                       onValueChange={setNetworkId}
                       value={networkId}
-                      placeholder="fast-development"
+                      placeholder="development"
                       isInvalid={!!errors?.networkId}
                       errorMessage={errors?.networkId?.message ?? ''}
                     />

--- a/packages/apps/tools/src/utils/getExplorerLink.ts
+++ b/packages/apps/tools/src/utils/getExplorerLink.ts
@@ -11,5 +11,5 @@ export const getExplorerLink = (
   }
   const networkData = networksData.find((item) => item.networkId === network);
 
-  return `http://${networkData.API}/explorer/fast-development/tx/${requestKey}`;
+  return `http://${networkData.API}/explorer/development/tx/${requestKey}`;
 };

--- a/packages/libs/client-examples/src/example-contract/devnet-coin-get-balance.ts
+++ b/packages/libs/client-examples/src/example-contract/devnet-coin-get-balance.ts
@@ -2,7 +2,7 @@ import type { ChainId } from '@kadena/client';
 import { createClient, Pact } from '@kadena/client';
 
 const DEVNET_HOST: string = 'localhost:8080';
-const NETWORK_ID: string = 'fast-development';
+const NETWORK_ID: string = 'development';
 const CHAIN_ID: string = '0';
 
 async function getBalance(account: string): Promise<void> {
@@ -15,7 +15,7 @@ async function getBalance(account: string): Promise<void> {
     .setMeta({
       chainId: CHAIN_ID as ChainId,
     })
-    .setNetworkId('fast-development')
+    .setNetworkId('development')
     .createTransaction();
 
   const result = client.local(transaction, { preflight: false });

--- a/packages/libs/client-examples/src/example-contract/functional/transfer-fp.ts
+++ b/packages/libs/client-examples/src/example-contract/functional/transfer-fp.ts
@@ -67,7 +67,7 @@ doTransfer(
     signerPublicKey:
       'dc20ab800b0420be9b1075c97e80b104b073b0405b5e2b78afd29dd74aaf5e46',
     chainId: '0',
-    networkId: 'fast-development',
+    networkId: 'development',
   }),
 )
   .then(console.log)

--- a/packages/libs/client-examples/src/example-contract/util/client.ts
+++ b/packages/libs/client-examples/src/example-contract/util/client.ts
@@ -15,7 +15,7 @@ export const apiHostGenerator = ({
       return `https://api.chainweb.com/chainweb/0.0/${networkId}/chain/${
         chainId ?? '1'
       }/pact`;
-    case 'fast-development':
+    case 'development':
       return `http://localhost:8080/chainweb/0.0/${networkId}/chain/${
         chainId ?? '1'
       }/pact`;

--- a/packages/libs/client-utils/README.md
+++ b/packages/libs/client-utils/README.md
@@ -34,7 +34,7 @@ import { signWithChainweaver } from "@kadena/client"
 
 const balance = await getBalance(
   accountOne.account,
-  'fast-development',
+  'development',
   '0',
   'http://localhost:8080',
  );

--- a/packages/libs/client-utils/src/integration-tests/built-in.int.test.ts
+++ b/packages/libs/client-utils/src/integration-tests/built-in.int.test.ts
@@ -6,7 +6,7 @@ import { describeModule } from '../built-in/describe-module';
 const config = {
   host: 'http://127.0.0.1:8080',
   defaults: {
-    networkId: 'fast-development',
+    networkId: 'development',
     meta: { chainId: '0' },
   },
 } as const;

--- a/packages/libs/client-utils/src/integration-tests/coin.int.test.ts
+++ b/packages/libs/client-utils/src/integration-tests/coin.int.test.ts
@@ -51,7 +51,7 @@ describe('transferCreate', () => {
       {
         host: 'http://127.0.0.1:8080',
         defaults: {
-          networkId: 'fast-development',
+          networkId: 'development',
         },
         sign: createSignWithKeypair([sender00Account]),
       },
@@ -105,7 +105,7 @@ describe('getBalance', () => {
   it("should return the account's balance", async () => {
     const balance = await getBalance(
       accountOne.account,
-      'fast-development',
+      'development',
       '0',
       'http://127.0.0.1:8080',
     );
@@ -117,7 +117,7 @@ describe('getDetails', () => {
   it("should return the account's details", async () => {
     const data = await details(
       accountOne.account,
-      'fast-development',
+      'development',
       '0',
       'http://127.0.0.1:8080',
     );
@@ -150,7 +150,7 @@ describe('createAccount', () => {
       {
         host: 'http://127.0.0.1:8080',
         defaults: {
-          networkId: 'fast-development',
+          networkId: 'development',
         },
         sign: createSignWithKeypair([sender00Account]),
       },
@@ -175,7 +175,7 @@ describe('transfer', () => {
       {
         host: 'http://127.0.0.1:8080',
         defaults: {
-          networkId: 'fast-development',
+          networkId: 'development',
         },
         sign: createSignWithKeypair([accountOne]),
       },
@@ -185,7 +185,7 @@ describe('transfer', () => {
 
     const balance = await getBalance(
       accountTwo.account,
-      'fast-development',
+      'development',
       '0',
       'http://127.0.0.1:8080',
     );
@@ -216,7 +216,7 @@ describe('cross chain transfer', () => {
       {
         host: 'http://127.0.0.1:8080',
         defaults: {
-          networkId: 'fast-development',
+          networkId: 'development',
         },
         sign: createSignWithKeypair([sender00Account]),
       },
@@ -226,7 +226,7 @@ describe('cross chain transfer', () => {
 
     const balance = await getBalance(
       accountOne.account,
-      'fast-development',
+      'development',
       '1',
       'http://127.0.0.1:8080',
     );
@@ -239,7 +239,7 @@ describe('safeTransfer', () => {
   it('should transfer kda from sender00 account to receiverAccount if both receiver and sender sign', async () => {
     const initialBalance = await getBalance(
       accountOne.account,
-      'fast-development',
+      'development',
       '0',
       'http://127.0.0.1:8080',
     );
@@ -259,7 +259,7 @@ describe('safeTransfer', () => {
       {
         host: 'http://127.0.0.1:8080',
         defaults: {
-          networkId: 'fast-development',
+          networkId: 'development',
         },
         sign: createSignWithKeypair([sender00Account, accountOne]),
       },
@@ -275,7 +275,7 @@ describe('safeTransfer', () => {
 
     const balanceAfterTransfer = await getBalance(
       accountOne.account,
-      'fast-development',
+      'development',
       '0',
       'http://127.0.0.1:8080',
     );
@@ -306,7 +306,7 @@ describe('safeTransfer', () => {
       {
         host: 'http://127.0.0.1:8080',
         defaults: {
-          networkId: 'fast-development',
+          networkId: 'development',
         },
         sign: createSignWithKeypair([sender00Account]),
       },
@@ -334,7 +334,7 @@ describe('safeTransfer', () => {
       {
         host: 'http://127.0.0.1:8080',
         defaults: {
-          networkId: 'fast-development',
+          networkId: 'development',
         },
         sign: createSignWithKeypair([sender00Account]),
       },
@@ -346,7 +346,7 @@ describe('safeTransfer', () => {
   it('uses normal transfer if gasPayer is the same as receiver', async () => {
     const initialBalance = await getBalance(
       accountOne.account,
-      'fast-development',
+      'development',
       '0',
       'http://127.0.0.1:8080',
     );
@@ -370,7 +370,7 @@ describe('safeTransfer', () => {
       {
         host: 'http://127.0.0.1:8080',
         defaults: {
-          networkId: 'fast-development',
+          networkId: 'development',
         },
         sign: createSignWithKeypair([sender00Account, accountOne]),
       },
@@ -388,7 +388,7 @@ describe('safeTransfer', () => {
     expect(result).toBe('Write succeeded');
     const balanceAfterTransfer = await getBalance(
       accountOne.account,
-      'fast-development',
+      'development',
       '0',
       'http://127.0.0.1:8080',
     );

--- a/packages/libs/client-utils/src/integration-tests/support/NetworkIds.ts
+++ b/packages/libs/client-utils/src/integration-tests/support/NetworkIds.ts
@@ -1,3 +1,3 @@
 export const NetworkIds = {
-  fast_development: 'fast-development',
+  fast_development: 'development',
 };

--- a/packages/libs/client-utils/src/integration-tests/utils.int.test.ts
+++ b/packages/libs/client-utils/src/integration-tests/utils.int.test.ts
@@ -38,7 +38,7 @@ describe('estimateGas', () => {
     const gasEstimation = await estimateGas(
       composePactCommand(
         transferCreateCommand(inputs),
-        setNetworkId('fast-development'),
+        setNetworkId('development'),
       ),
       'http://127.0.0.1:8080',
     );
@@ -48,7 +48,7 @@ describe('estimateGas', () => {
     // check if the gas estimation is correct
     const transferResult = await transferCreate(inputs, {
       defaults: {
-        networkId: 'fast-development',
+        networkId: 'development',
         meta: { ...gasEstimation } as IPactCommand['meta'],
       },
       host: 'http://127.0.0.1:8080',

--- a/packages/libs/client/src/integration-tests/helpers/client.ts
+++ b/packages/libs/client/src/integration-tests/helpers/client.ts
@@ -9,7 +9,7 @@ export const apiHostGenerator = ({
   chainId: ChainId;
 }): string => {
   switch (networkId) {
-    case 'fast-development':
+    case 'development':
       return `http://127.0.0.1:8080/chainweb/0.0/${networkId}/chain/${
         chainId ?? '1'
       }/pact`;

--- a/packages/libs/client/src/integration-tests/support/enums.ts
+++ b/packages/libs/client/src/integration-tests/support/enums.ts
@@ -1,3 +1,3 @@
 export enum NetworkId {
-  fast_development = 'fast-development',
+  fast_development = 'development',
 }

--- a/packages/tools/e2e-tests/src/support/constants/network.constants.ts
+++ b/packages/tools/e2e-tests/src/support/constants/network.constants.ts
@@ -2,7 +2,7 @@ import type { ChainId } from '@kadena/types';
 
 export const ns = 'common';
 export const devnetHost = 'http://localhost:8080';
-export const networkId = 'fast-development';
+export const networkId = 'development';
 export const grapHost = 'http://localhost:4000/graphql';
 
 export const devnetUrl = (chainId: ChainId) => {

--- a/packages/tools/e2e-tests/src/support/page-objects/tools-app/storageState.json
+++ b/packages/tools/e2e-tests/src/support/page-objects/tools-app/storageState.json
@@ -2,7 +2,7 @@
   "cookies": [
     {
       "name": "_persist%3Anetwork",
-      "value": "%2522fast-development%2522",
+      "value": "%2522development%2522",
       "domain": "localhost",
       "path": "/",
       "expires": -1,
@@ -22,7 +22,7 @@
     },
     {
       "name": "_persist%3Anetworks",
-      "value": "%255B%257B%2522networkId%2522%253A%2522mainnet01%2522%252C%2522label%2522%253A%2522Mainnet%2522%252C%2522API%2522%253A%2522api.chainweb.com%2522%252C%2522ESTATS%2522%253A%2522estats.chainweb.com%2522%257D%252C%257B%2522networkId%2522%253A%2522testnet04%2522%252C%2522label%2522%253A%2522Testnet%2522%252C%2522API%2522%253A%2522api.testnet.chainweb.com%2522%252C%2522ESTATS%2522%253A%2522estats.testnet.chainweb.com%2522%257D%252C%257B%2522label%2522%253A%2522devnet%2522%252C%2522networkId%2522%253A%2522fast-development%2522%252C%2522API%2522%253A%2522localhost%253A8080%2522%252C%2522ESTATS%2522%253A%2522localhost%253A8080%2522%257D%255D",
+      "value": "%255B%257B%2522networkId%2522%253A%2522mainnet01%2522%252C%2522label%2522%253A%2522Mainnet%2522%252C%2522API%2522%253A%2522api.chainweb.com%2522%252C%2522ESTATS%2522%253A%2522estats.chainweb.com%2522%257D%252C%257B%2522networkId%2522%253A%2522testnet04%2522%252C%2522label%2522%253A%2522Testnet%2522%252C%2522API%2522%253A%2522api.testnet.chainweb.com%2522%252C%2522ESTATS%2522%253A%2522estats.testnet.chainweb.com%2522%257D%252C%257B%2522label%2522%253A%2522devnet%2522%252C%2522networkId%2522%253A%2522development%2522%252C%2522API%2522%253A%2522localhost%253A8080%2522%252C%2522ESTATS%2522%253A%2522localhost%253A8080%2522%257D%255D",
       "domain": "localhost",
       "path": "/",
       "expires": -1,

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/accountDetails.test.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/accountDetails.test.ts
@@ -33,7 +33,7 @@ describe('accountDetails', () => {
   it('should return error if account does not exist', async () => {
     server.use(
       http.post(
-        'https://localhost:8080/chainweb/0.0/fast-development/chain/1/pact/api/v1/local',
+        'https://localhost:8080/chainweb/0.0/development/chain/1/pact/api/v1/local',
         () => {
           return HttpResponse.json({ error: 'row not found' }, { status: 404 });
         },

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/getAccountDetails.test.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/getAccountDetails.test.ts
@@ -35,7 +35,7 @@ describe('getAccountDetailsFromChain', () => {
   it('should throw an error when account details are undefined from chain', async () => {
     server.use(
       http.post(
-        'https://localhost:8080/chainweb/0.0/fast-development/chain/1/pact/api/v1/local',
+        'https://localhost:8080/chainweb/0.0/development/chain/1/pact/api/v1/local',
         () => {
           return HttpResponse.json(
             {
@@ -63,7 +63,7 @@ describe('getAccountDetailsFromChain', () => {
   it('should throw an error when account is not available on chain', async () => {
     server.use(
       http.post(
-        'https://localhost:8080/chainweb/0.0/fast-development/chain/1/pact/api/v1/local',
+        'https://localhost:8080/chainweb/0.0/development/chain/1/pact/api/v1/local',
         () => {
           return HttpResponse.json({ error: 'row not found' }, { status: 404 });
         },
@@ -109,7 +109,7 @@ describe('getAccountDetailsForAddAccount', () => {
   it('should return undefined when account details throws an error with row not found', async () => {
     server.use(
       http.post(
-        'https://localhost:8080/chainweb/0.0/fast-development/chain/1/pact/api/v1/local',
+        'https://localhost:8080/chainweb/0.0/development/chain/1/pact/api/v1/local',
         () => {
           return HttpResponse.json({ error: 'row not found' }, { status: 404 });
         },
@@ -128,7 +128,7 @@ describe('getAccountDetailsForAddAccount', () => {
   it('should throw an error when account details throws an error', async () => {
     server.use(
       http.post(
-        'https://localhost:8080/chainweb/0.0/fast-development/chain/1/pact/api/v1/local',
+        'https://localhost:8080/chainweb/0.0/development/chain/1/pact/api/v1/local',
         () => {
           return HttpResponse.json(
             { error: 'something went wrong' },

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/mocks.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/mocks.ts
@@ -11,7 +11,7 @@ export const testNetworkConfigMock: INetworkCreateOptions = {
 export const devNetConfigMock: INetworkCreateOptions = {
   networkHost: 'https://localhost:8080',
   networkExplorerUrl: 'https://localhost:8080/explorer',
-  networkId: 'fast-development',
+  networkId: 'development',
   network: 'devnet',
 };
 

--- a/packages/tools/kadena-cli/src/constants/devnets.ts
+++ b/packages/tools/kadena-cli/src/constants/devnets.ts
@@ -51,6 +51,6 @@ export const defaultAccount = sender00;
  * Provides the default simulation configurations.
  */
 export const simulationDefaults = {
-  NETWORK_ID: 'fast-development',
+  NETWORK_ID: 'development',
   CHAIN_COUNT: 20,
 };

--- a/packages/tools/kadena-cli/src/constants/networks.ts
+++ b/packages/tools/kadena-cli/src/constants/networks.ts
@@ -24,7 +24,7 @@ export const networkDefaults: IDefaultNetworkOptions = {
   },
   devnet: {
     network: 'devnet',
-    networkId: 'fast-development',
+    networkId: 'development',
     networkHost: 'http://localhost:8080/',
     networkExplorerUrl: 'http://localhost:8080/explorer',
   },

--- a/packages/tools/kadena-cli/src/devnet/commands/devnetSimulation.ts
+++ b/packages/tools/kadena-cli/src/devnet/commands/devnetSimulation.ts
@@ -34,7 +34,7 @@ export const simulateCommand: CreateCommandReturnType = createCommand(
 
       await simulateCoin({
         network: {
-          id: 'fast-development',
+          id: 'development',
           host: config.networkConfig.networkHost,
         },
         maxAmount: config.simulationMaxTransferAmount,

--- a/packages/tools/kadena-cli/src/mocks/handlers.ts
+++ b/packages/tools/kadena-cli/src/mocks/handlers.ts
@@ -12,7 +12,7 @@ interface IPayloadData {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const handlers: any = [
   http.post(
-    'https://localhost:8080/chainweb/0.0/fast-development/chain/1/pact/api/v1/local',
+    'https://localhost:8080/chainweb/0.0/development/chain/1/pact/api/v1/local',
     () => {
       return HttpResponse.json(accountDetailsSuccessData, { status: 200 });
     },

--- a/packages/tools/kadena-cli/src/utils/client.ts
+++ b/packages/tools/kadena-cli/src/utils/client.ts
@@ -20,7 +20,7 @@ export const apiHostGenerator = ({
       return `https://api.chainweb.com/chainweb/0.0/${networkId}/chain/${
         chainId ?? '1'
       }/pact`;
-    case 'fast-development':
+    case 'development':
       return `http://localhost:8080/chainweb/0.0/${networkId}/chain/${
         chainId ?? '1'
       }/pact`;

--- a/packages/tools/kda-cli/src/questions/deploy.ts
+++ b/packages/tools/kda-cli/src/questions/deploy.ts
@@ -203,7 +203,7 @@ export const deployQuestions: IQuestion[] = [
           chainIds: l1Chains,
           setDeployChainSettings: setDeployChainSettings({
             endpoint: 'http://localhost:8080',
-            network: 'fast-development',
+            network: 'development',
             signer,
           }),
           setDeploySettings: deployCommand,
@@ -214,7 +214,7 @@ export const deployQuestions: IQuestion[] = [
           chainIds: l2Chains,
           setDeployChainSettings: setDeployChainSettings({
             endpoint: 'http://localhost:8081',
-            network: 'fast-development',
+            network: 'development',
             signer,
           }),
           setDeploySettings: deployCommand,

--- a/packages/tools/kda-cli/src/questions/fund.ts
+++ b/packages/tools/kda-cli/src/questions/fund.ts
@@ -29,7 +29,7 @@ export const fundQuestions: IQuestion[] = [
     message: 'On wich network would you like to fund the account?',
     name: 'network',
     type: 'input',
-    defaultValue: 'fast-development',
+    defaultValue: 'development',
     when: fundCondition,
   },
   {


### PR DESCRIPTION
This PR renames all references to `fast-development ` to `development`