### PR TITLE
fix(account): add default values when user use --quiet option

### DIFF
--- a/.changeset/cuddly-dogs-turn.md
+++ b/.changeset/cuddly-dogs-turn.md
@@ -1,0 +1,5 @@
+---
+'@kadena/kadena-cli': minor
+---
+
+Fix account add command for --quiet flag

--- a/packages/tools/kadena-cli/src/account/commands/accountAddFromWallet.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountAddFromWallet.ts
@@ -55,7 +55,7 @@ export const createAddAccountFromWalletCommand = createCommandFlexible(
   'Add an account from a key wallet',
   [
     globalOptions.accountAlias(),
-    globalOptions.keyWalletSelectWithAll(),
+    globalOptions.keyWalletSelect(),
     globalOptions.fungible(),
     globalOptions.networkSelect(),
     globalOptions.chainId(),
@@ -79,14 +79,14 @@ export const createAddAccountFromWalletCommand = createCommandFlexible(
       return;
     }
 
-    const fungible = (await option.fungible()).fungible;
+    const fungible = (await option.fungible()).fungible || 'coin';
     const { network, networkConfig } = await option.network();
     const chainId = (await option.chainId()).chainId;
     const { publicKeys, publicKeysConfig } = await option.publicKeys({
       values,
       keyWalletConfig: keyWallet.keyWalletConfig,
     });
-    const predicate = (await option.predicate()).predicate;
+    const predicate = (await option.predicate()).predicate || 'keys-all';
     const config = {
       accountAlias,
       keyWallet,

--- a/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
+++ b/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
@@ -11,7 +11,7 @@ import { services } from '../../services/index.js';
 import { notEmpty } from '../../utils/helpers.js';
 import { isEmpty } from './addHelpers.js';
 
-const accountAliasFileSchema = z.object({
+export const accountAliasFileSchema = z.object({
   name: z.string(),
   fungible: z.string(),
   publicKeys: z.array(z.string()),

--- a/packages/tools/kadena-cli/src/account/utils/createAccountConfigFile.ts
+++ b/packages/tools/kadena-cli/src/account/utils/createAccountConfigFile.ts
@@ -1,6 +1,7 @@
 import yaml from 'js-yaml';
 import { services } from '../../services/index.js';
 import type { IAddAccountConfig } from '../types.js';
+import { accountAliasFileSchema, formatZodErrors } from './accountHelpers.js';
 
 export async function writeAccountAlias(
   config: IAddAccountConfig,
@@ -8,15 +9,19 @@ export async function writeAccountAlias(
 ): Promise<void> {
   const { publicKeysConfig, predicate, accountName, fungible } = config;
   await services.filesystem.ensureDirectoryExists(filePath);
-  await services.filesystem.writeFile(
-    filePath,
-    yaml.dump({
+  try {
+    const aliasData = {
       name: accountName,
       fungible,
       publicKeys: publicKeysConfig,
       predicate,
-    }),
-  );
+    };
+    accountAliasFileSchema.parse(aliasData);
+    await services.filesystem.writeFile(filePath, yaml.dump(aliasData));
+  } catch (error) {
+    const errorMessage = formatZodErrors(error);
+    throw new Error(`Error writing alias file: ${filePath}\n ${errorMessage}`);
+  }
 }
 
 export async function createAccountConfigFile(

--- a/packages/tools/kadena-cli/src/utils/globalOptions.ts
+++ b/packages/tools/kadena-cli/src/utils/globalOptions.ts
@@ -96,7 +96,7 @@ export const globalOptions = {
     ),
     expand: async (publicKeys: string) => {
       return publicKeys
-        .split(',')
+        ?.split(',')
         .map((value) => value.trim())
         .filter((key) => !!key);
     },


### PR DESCRIPTION
account commands with `--quiet` flag needs few defaults and additional check. Fixing those as part of this PR. 

