### PR TITLE
temp: Increase timeout

### DIFF
--- a/packages/libs/react-ui/src/components/Form/Select/Select.test.tsx
+++ b/packages/libs/react-ui/src/components/Form/Select/Select.test.tsx
@@ -18,7 +18,7 @@ describe('Select', () => {
 
     const selectField = screen.getByLabelText('select');
     expect(selectField).toBeInTheDocument();
-  });
+  }, 20000);
 
   it('renders the provided children options when is open', async () => {
     render(
@@ -39,7 +39,7 @@ describe('Select', () => {
 
     expect(option1).toBeInTheDocument();
     expect(option2).toBeInTheDocument();
-  });
+  }, 20000);
 
   it('invokes the onChange event handler when an option is selected', async () => {
     const handleChange = vi.fn();
@@ -71,5 +71,5 @@ describe('Select', () => {
 
     const selectButton = screen.getByRole('button') as HTMLButtonElement;
     expect(selectButton.disabled).toBe(true);
-  });
+  }, 20000);
 });


### PR DESCRIPTION
This PR increases the timeout for a few slow tests, while this solution is far from ideal it is currently blocking other PR's and there is insufficient time to further investigate.

It seems there are various scenario's in which Vitest performs _much_ slower compared to Jest or other alternatives. This primiarly seems to be related to isolation of test cases and how other dependencies are imported in tests (or components under test).

See https://dev.to/thejaredwilcurt/improving-vitest-performance-42c6

We should follow up with further investigation