### PR TITLE
fix(networks): create command

### DIFF
--- a/packages/tools/kadena-cli/src/networks/commands/networkCreate.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkCreate.ts
@@ -3,7 +3,6 @@ import { services } from '../../services/index.js';
 import { createCommand } from '../../utils/createCommand.js';
 import { globalOptions } from '../../utils/globalOptions.js';
 
-import type { INetworkCreateOptions } from '../utils/networkHelpers.js';
 import { writeNetworks } from '../utils/networkHelpers.js';
 
 import chalk from 'chalk';
@@ -19,8 +18,8 @@ export const createNetworksCommand: (
   'Create network',
   [
     globalOptions.networkName({ isOptional: false }),
-    globalOptions.networkId(),
-    globalOptions.networkHost(),
+    globalOptions.networkId({ isOptional: false }),
+    globalOptions.networkHost({ isOptional: false }),
     globalOptions.networkExplorerUrl(),
     globalOptions.networkOverwrite(),
   ],
@@ -44,7 +43,14 @@ export const createNetworksCommand: (
       return;
     }
 
-    await writeNetworks(config as unknown as INetworkCreateOptions);
+    const networkConfig = {
+      network: config.networkName,
+      networkId: config.networkId,
+      networkHost: config.networkHost,
+      networkExplorerUrl: config.networkExplorerUrl,
+    };
+
+    await writeNetworks(networkConfig);
 
     console.log(
       chalk.green(

--- a/packages/tools/kadena-cli/src/prompts/generic.ts
+++ b/packages/tools/kadena-cli/src/prompts/generic.ts
@@ -14,14 +14,25 @@ export async function genericFileNamePrompt(type?: string): Promise<string> {
   });
 }
 
+type ValidateFn = (input: string) => string | boolean;
+
 export async function getInputPrompt(
   message: string,
   defaultValue?: string,
+  validate?: ValidateFn,
 ): Promise<string> {
-  const promptConfig: { message: string; default?: string } = { message };
+  const promptConfig: {
+    message: string;
+    default?: string;
+    validate?: ValidateFn;
+  } = { message };
 
   if (defaultValue !== undefined) {
     promptConfig.default = defaultValue;
+  }
+
+  if (validate !== undefined) {
+    promptConfig.validate = validate;
   }
 
   return await input(promptConfig);

--- a/packages/tools/kadena-cli/src/prompts/network.ts
+++ b/packages/tools/kadena-cli/src/prompts/network.ts
@@ -1,5 +1,6 @@
 import type { ChainId } from '@kadena/types';
 import { readdirSync } from 'fs';
+import { z } from 'zod';
 import { chainIdValidation } from '../account/utils/accountHelpers.js';
 import { defaultNetworksPath } from '../constants/networks.js';
 import type { ICustomNetworkChoice } from '../networks/utils/networkHelpers.js';
@@ -8,7 +9,11 @@ import {
   loadNetworkConfig,
 } from '../networks/utils/networkHelpers.js';
 import type { IPrompt } from '../utils/createOption.js';
-import { getExistingNetworks, isAlphabetic } from '../utils/helpers.js';
+import {
+  getExistingNetworks,
+  isAlphabetic,
+  isNotEmptyString,
+} from '../utils/helpers.js';
 import { input, select } from '../utils/prompts.js';
 import { getInputPrompt } from './generic.js'; // Importing getInputPrompt from another file
 
@@ -57,9 +62,18 @@ export const networkIdPrompt: IPrompt<string> = async (
   isOptional,
 ) => {
   const defaultValue = args.defaultValue as string;
+  const validate = function (input: string): string | boolean {
+    if (isOptional) return true;
+
+    if (!isNotEmptyString(input.trim())) return 'Network id is required.';
+
+    return true;
+  };
+
   return await getInputPrompt(
     'Enter a network id (e.g. "mainnet01")',
     defaultValue,
+    validate,
   );
 };
 
@@ -69,9 +83,21 @@ export const networkHostPrompt: IPrompt<string> = async (
   isOptional,
 ) => {
   const defaultValue = args.defaultValue as string;
+  const validate = function (input: string): string | boolean {
+    if (isOptional && !isNotEmptyString(input.trim())) return true;
+
+    const parse = z.string().url().safeParse(input);
+
+    if (!parse.success)
+      return 'Network host: Invalid URL. Please enter a valid URL.';
+
+    return true;
+  };
+
   return await getInputPrompt(
     'Enter Kadena network host (e.g. "https://api.chainweb.com")',
     defaultValue,
+    validate,
   );
 };
 
@@ -93,7 +119,7 @@ export const networkOverwritePrompt: IPrompt<string> = async (
   isOptional,
 ) => {
   const networkName =
-    args.defaultValue ?? previousQuestions.network ?? args.network;
+    args.defaultValue ?? previousQuestions.networkName ?? args.networkName;
 
   if (networkName === undefined) {
     throw new Error('Network name is required for the overwrite prompt.');

--- a/packages/tools/kadena-cli/src/utils/helpers.ts
+++ b/packages/tools/kadena-cli/src/utils/helpers.ts
@@ -3,7 +3,6 @@ import { existsSync, mkdirSync, readdirSync } from 'fs';
 import path from 'path';
 import sanitize from 'sanitize-filename';
 import type { ZodError } from 'zod';
-
 import { MAX_CHARACTERS_LENGTH } from '../constants/config.js';
 import { defaultDevnetsPath } from '../constants/devnets.js';
 import { defaultNetworksPath } from '../constants/networks.js';


### PR DESCRIPTION
`networks create` command failing in `main`

<img width="1157" alt="image" src="https://github.com/kadena-community/kadena.js/assets/7163943/8bf1f04a-cc7a-4178-bc61-231389bd01fc">


- Also made `networkId` and `networkHost` are required fields. Without networkId and host it's not really makes sense to have a network
- Added zod schema parsing before writing into a network file.
