### PR TITLE
fix(cli): minor bugs + improvements

### DIFF
--- a/packages/tools/kadena-cli/src/account/commands/accountDetails.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDetails.ts
@@ -19,6 +19,14 @@ export async function accountDetails(
       data: accountDetails,
     };
   } catch (error) {
+    if (error.message.includes('row not found') === true) {
+      return {
+        success: false,
+        errors: [
+          `Account is not available on chain "${config.chainId}" of networkId "${config.networkId}"`,
+        ],
+      };
+    }
     return {
       success: false,
       errors: [error.message],

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/accountDetails.test.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/accountDetails.test.ts
@@ -47,6 +47,8 @@ describe('accountDetails', () => {
       fungible: 'coin',
     });
     assert(!result.success);
-    expect(result.errors).toEqual(['{"error":"row not found"}']);
+    expect(result.errors).toEqual([
+      'Account is not available on chain "1" of networkId "fast-development"',
+    ]);
   });
 });

--- a/packages/tools/kadena-cli/src/keys/commands/keysDecrypt.ts
+++ b/packages/tools/kadena-cli/src/keys/commands/keysDecrypt.ts
@@ -40,7 +40,10 @@ export const createDecryptCommand: (program: Command, version: string) => void =
   createCommand(
     'decrypt',
     'decrypt message',
-    [globalOptions.keyMessage(), globalOptions.securityCurrentPassword()],
+    [
+      globalOptions.keyMessage({ isOptional: false }),
+      globalOptions.securityCurrentPassword({ isOptional: false }),
+    ],
     async (config) => {
       debug('decrypt:action')({ config });
 
@@ -48,9 +51,7 @@ export const createDecryptCommand: (program: Command, version: string) => void =
         throw new Error('Missing keyMessage');
       }
 
-      console.log(
-        chalk.yellow(`You are about to decrypt this this message.\n`),
-      );
+      console.log(chalk.yellow(`You are about to decrypt this message.\n`));
 
       const result = await decrypt(
         config.securityCurrentPassword,

--- a/packages/tools/kadena-cli/src/keys/commands/keysPlainGenerate.ts
+++ b/packages/tools/kadena-cli/src/keys/commands/keysPlainGenerate.ts
@@ -76,7 +76,7 @@ export const createGeneratePlainKeysCommand: (
   'gen-plain',
   'generate plain public/secret key pair(s)',
   [
-    globalOptions.keyAlias(),
+    globalOptions.keyAlias({ isOptional: false }),
     globalOptions.keyAmount({ isOptional: true }),
     globalOptions.legacy({ isOptional: true, disableQuestion: true }),
   ],

--- a/packages/tools/kadena-cli/src/keys/utils/keysDisplay.ts
+++ b/packages/tools/kadena-cli/src/keys/utils/keysDisplay.ts
@@ -13,6 +13,7 @@ import {
   WALLET_LEGACY_EXT,
 } from '../../constants/config.js';
 import { services } from '../../services/index.js';
+import { sanitizeFilename } from '../../utils/helpers.js';
 import type { IWallet } from './keysHelpers.js';
 import type { IKeyPair } from './storage.js';
 
@@ -111,10 +112,11 @@ export function printStoredKeys(
   console.log(chalk.green(message));
   console.log('\n');
 
+  const sanitizedAlias = sanitizeFilename(alias).toLocaleLowerCase();
+
   for (let index = 0; index < keyPairs.length; index++) {
-    const fileNameIndex =
-      keyPairs.length === 1 ? startIndex : startIndex + index;
-    const fileName = `${alias}${fileNameIndex}${ext}`;
+    const fileNameIndex = index > 0 ? `-${index}` : '';
+    const fileName = `${sanitizedAlias}${fileNameIndex}${ext}`;
     console.log(chalk.green(`- ${fileName}`));
   }
 }

--- a/packages/tools/kadena-cli/src/networks/commands/networkDelete.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkDelete.ts
@@ -12,7 +12,7 @@ export const deleteNetworksCommand: (
 ) => void = createCommandFlexible(
   'delete',
   'Delete network',
-  [globalOptions.network(), globalOptions.networkDelete()],
+  [globalOptions.network({ isOptional: false }), globalOptions.networkDelete()],
   async (option) => {
     const networkData = await option.network();
     const deleteNetwork = await option.networkDelete();

--- a/packages/tools/kadena-cli/src/networks/commands/networkManage.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkManage.ts
@@ -18,7 +18,7 @@ export const manageNetworksCommand: (
   'update',
   'Manage networks',
   [
-    globalOptions.network(),
+    globalOptions.network({ isOptional: false }),
     globalOptions.networkExplorerUrl(),
     globalOptions.networkHost(),
     globalOptions.networkId(),

--- a/packages/tools/kadena-cli/src/prompts/network.ts
+++ b/packages/tools/kadena-cli/src/prompts/network.ts
@@ -240,10 +240,11 @@ export const networkDeletePrompt: IPrompt<string> = async (
   args,
   isOptional,
 ) => {
+  const defaultValue = args.defaultValue ?? previousQuestions.network;
   if (previousQuestions.network === undefined) {
     throw new Error('Network name is required for the delete prompt.');
   }
-  const message = `Are you sure you want to delete the configuration for network "${args.defaultValue}"?`;
+  const message = `Are you sure you want to delete the configuration for network "${defaultValue}"?`;
   return await select({
     message,
     choices: [

--- a/packages/tools/kadena-cli/src/utils/globalOptions.ts
+++ b/packages/tools/kadena-cli/src/utils/globalOptions.ts
@@ -520,7 +520,7 @@ export const globalOptions = {
     prompt: security.securityPasswordVerifyPrompt,
     validation: z.string(),
     option: new Option(
-      '-p, --security-verify-password <securityVerifyPassword>',
+      '-vp, --security-verify-password <securityVerifyPassword>',
       'Enter a password to verify with password',
     ),
   }),

--- a/packages/tools/kadena-cli/src/utils/globalOptions.ts
+++ b/packages/tools/kadena-cli/src/utils/globalOptions.ts
@@ -520,7 +520,7 @@ export const globalOptions = {
     prompt: security.securityPasswordVerifyPrompt,
     validation: z.string(),
     option: new Option(
-      '-vp, --security-verify-password <securityVerifyPassword>',
+      '--security-verify-password <securityVerifyPassword>',
       'Enter a password to verify with password',
     ),
   }),


### PR DESCRIPTION
- Improved error message for account details not found in chain
- instead of network name, `undefined` is shown in the network delete confirmation prompt
- Fix keys gen-plain --key-alias="alpha22" --key-amount="5" 
the file name shown in the console and the key's generated are not same 
- keys gen-plain --quiet   => `keyAlias`  and `key message` set required field
- Updated Wallet `verify password` option to `-vp` . `-p` already used by password
- Make network select option as required field as part of network manage and delete command