### PR TITLE
fix/ag/broken main

### DIFF
--- a/packages/libs/hd-wallet/package.json
+++ b/packages/libs/hd-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kadena/hd-wallet",
-  "version": "0.3.0",
+  "version": "0.4.0-alpha.0",
   "description": "Key derivation based on Hierarchical Deterministic (HD)/Mnemonic keys and BIP32, for Kadena",
   "repository": {
     "type": "git",

--- a/packages/tools/kadena-cli/package.json
+++ b/packages/tools/kadena-cli/package.json
@@ -53,7 +53,7 @@
     "@kadena/client": "workspace:^",
     "@kadena/client-utils": "workspace:*",
     "@kadena/cryptography-utils": "workspace:*",
-    "@kadena/hd-wallet": "workspace:0.3.0",
+    "@kadena/hd-wallet": "workspace:*",
     "@kadena/pactjs": "workspace:*",
     "@kadena/pactjs-cli": "workspace:^",
     "@kadena/pactjs-generator": "workspace:*",


### PR DESCRIPTION
- chore(hd-wallet): make sure subsequent versions are `alpha`
- chore(kadena-cli): set correct version for workspace dependency
