### PR TITLE
feat(account): allow manual input for account details

### DIFF
--- a/packages/tools/kadena-cli/src/account/commands/accountDetails.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDetails.ts
@@ -1,7 +1,6 @@
-import type { Command } from 'commander';
 import type { CommandResult } from '../../utils/command.util.js';
 import { assertCommandError } from '../../utils/command.util.js';
-import { createCommand } from '../../utils/createCommand.js';
+import { createCommandFlexible } from '../../utils/createCommandFlexible.js';
 import { globalOptions } from '../../utils/globalOptions.js';
 import { log } from '../../utils/logger.js';
 import type { IAccountDetailsResult } from '../types.js';
@@ -33,33 +32,49 @@ export async function accountDetails(
   }
 }
 
-export const createAccountDetailsCommand: (
-  program: Command,
-  version: string,
-) => void = createCommand(
+export const createAccountDetailsCommand = createCommandFlexible(
   'details',
   'Get details of an account',
   [
     globalOptions.accountSelect(),
     globalOptions.networkSelect(),
     globalOptions.chainId({ isOptional: false }),
+    globalOptions.fungible({ isOptional: true }),
   ],
-  async (config) => {
-    log.debug('account-details:action', { config });
+  async (option, values) => {
+    const { account, accountConfig } = await option.account({
+      isAllowManualInput: true,
+    });
+
+    let fungible = accountConfig?.fungible ?? 'coin';
+    const accountName = accountConfig?.name ?? account;
+
+    if (!accountConfig) {
+      fungible = (await option.fungible()).fungible;
+    }
+
+    const { networkConfig } = await option.network();
+    const { chainId } = await option.chainId();
+
+    log.debug('account-details:action', {
+      account,
+      accountConfig,
+      chainId,
+      networkConfig,
+      fungible,
+    });
 
     const result = await accountDetails({
-      accountName: config.accountConfig.name,
-      chainId: config.chainId,
-      networkId: config.networkConfig.networkId,
-      networkHost: config.networkConfig.networkHost,
-      fungible: config.accountConfig.fungible,
+      accountName: accountName,
+      chainId: chainId,
+      networkId: networkConfig.networkId,
+      networkHost: networkConfig.networkHost,
+      fungible: fungible,
     });
 
     assertCommandError(result);
 
-    log.info(
-      log.color.green(`\nDetails of account "${config.accountConfig.name}":\n`),
-    );
+    log.info(log.color.green(`\nDetails of account "${account}":\n`));
     log.info(log.color.green(`${JSON.stringify(result.data, null, 2)}`));
   },
 );

--- a/packages/tools/kadena-cli/src/account/commands/accountDetails.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDetails.ts
@@ -21,7 +21,7 @@ export async function accountDetails(
       return {
         success: false,
         errors: [
-          `Account is not available on chain "${config.chainId}" of networkId "${config.networkId}"`,
+          `Account "${config.accountName}" is not available on chain "${config.chainId}" of networkId "${config.networkId}"`,
         ],
       };
     }

--- a/packages/tools/kadena-cli/src/account/commands/accountFund.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountFund.ts
@@ -33,12 +33,19 @@ export const createFundCommand = createCommandFlexible(
     // deployDevnet(),
   ],
   async (option, values) => {
-    const { accountConfig } = await option.account();
+    const { account, accountConfig } = await option.account();
     const { amount } = await option.amount();
     const { network, networkConfig } = await option.network({
       allowedNetworkIds: ['testnet04'],
     });
     const { chainId } = await option.chainId();
+
+    if (!accountConfig) {
+      log.error(
+        `\nAccount details are missing. Please check selected "${account}" account alias file.\n`,
+      );
+      return;
+    }
 
     const config = {
       accountConfig,

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/accountDetails.test.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/accountDetails.test.ts
@@ -48,7 +48,7 @@ describe('accountDetails', () => {
     });
     assert(!result.success);
     expect(result.errors).toEqual([
-      'Account is not available on chain "1" of networkId "fast-development"',
+      'Account "k:accountName" is not available on chain "1" of networkId "fast-development"',
     ]);
   });
 });

--- a/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
+++ b/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
@@ -34,7 +34,7 @@ export const readAccountFromFile = async (
 ): Promise<IAliasAccountData> => {
   const filePath = join(ACCOUNT_DIR, accountFile);
   if (!(await services.filesystem.fileExists(filePath))) {
-    throw new Error('file not exist');
+    throw new Error(`Account alias "${accountFile}" file not exist`);
   }
 
   const content = await services.filesystem.readFile(filePath);

--- a/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
+++ b/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
@@ -32,9 +32,12 @@ export const formatZodErrors = (errors: ZodError): string => {
 export const readAccountFromFile = async (
   accountFile: string,
 ): Promise<IAliasAccountData> => {
-  const content = await services.filesystem.readFile(
-    join(ACCOUNT_DIR, accountFile),
-  );
+  const filePath = join(ACCOUNT_DIR, accountFile);
+  if (!(await services.filesystem.fileExists(filePath))) {
+    throw new Error('file not exist');
+  }
+
+  const content = await services.filesystem.readFile(filePath);
   const account = content !== null ? yaml.load(content) : null;
   try {
     const parsedContent = accountAliasFileSchema.parse(account);

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -132,7 +132,11 @@ export const accountOverWritePrompt: IPrompt<boolean> = async () =>
     ],
   });
 
-export const accountSelectPrompt: IPrompt<string> = async () => {
+export const accountSelectPrompt: IPrompt<string> = async (
+  previousQuestions,
+  args,
+  isOptional,
+) => {
   const allAccounts = await getAllAccountNames();
 
   if (allAccounts.length === 0) {
@@ -156,10 +160,30 @@ export const accountSelectPrompt: IPrompt<string> = async () => {
     };
   });
 
+  if (previousQuestions.isAllowManualInput) {
+    allAccountChoices.unshift({
+      value: 'custom',
+      name: 'Enter an account name manually:',
+    });
+  }
+
   const selectedAlias = await select({
     message: 'Select an account:(alias - account name)',
     choices: allAccountChoices,
   });
 
+  if (selectedAlias === 'custom') {
+    const accountName = await input({
+      message: 'Please enter the account name:',
+      validate: function (value: string) {
+        if (!value || !value.trim().length) {
+          return 'Account name cannot be empty.';
+        }
+
+        return true;
+      },
+    });
+    return accountName.trim();
+  }
   return selectedAlias;
 };

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -160,7 +160,7 @@ export const accountSelectPrompt: IPrompt<string> = async (
     };
   });
 
-  if (previousQuestions.isAllowManualInput) {
+  if (previousQuestions.isAllowManualInput === true) {
     allAccountChoices.unshift({
       value: 'custom',
       name: 'Enter an account name manually:',

--- a/packages/tools/kadena-cli/src/utils/globalOptions.ts
+++ b/packages/tools/kadena-cli/src/utils/globalOptions.ts
@@ -664,11 +664,15 @@ export const globalOptions = {
     defaultIsOptional: false,
     validation: z.string(),
     option: new Option('-a, --account <account>', 'Select an account'),
-    expand: async (accountAlias: string): Promise<IAliasAccountData> => {
+    expand: async (accountAlias: string): Promise<IAliasAccountData | null> => {
       try {
         const accountDetails = await readAccountFromFile(accountAlias);
         return accountDetails;
       } catch (error) {
+        if (error.message.includes('file not exist') === true) {
+          return null;
+        }
+
         throw new Error(error.message);
       }
     },


### PR DESCRIPTION
For `account details` command, allow users to enter account name manually

https://app.asana.com/0/1205969628270714/1206634146772867/f