### PR TITLE
fix(docs): allow swipe prev/next browser history

### DIFF
--- a/packages/apps/docs/src/components/Layout/basestyles.css.ts
+++ b/packages/apps/docs/src/components/Layout/basestyles.css.ts
@@ -9,7 +9,7 @@ import {
 globalStyle('html, body', {
   margin: 0,
   backgroundColor: tokens.kda.foundation.color.neutral.n0,
-  overscrollBehavior: 'none',
+  overscrollBehaviorY: 'none',
 });
 
 globalStyle('a', {


### PR DESCRIPTION
By default, we can swipe right/left to move next/prev page history using fingers gesture. This is not working as part of docs website. This PR fixes it. 

https://app.asana.com/0/1205619636589593/1206579624288339/f