### PR TITLE
[@kadena/graph] Added more filters to Events query and subscription

### DIFF
--- a/.changeset/cool-laws-punch.md
+++ b/.changeset/cool-laws-punch.md
@@ -1,0 +1,5 @@
+---
+'@kadena/graph': patch
+---
+
+Added more filter options to the events query and subscription

--- a/packages/apps/graph/README.md
+++ b/packages/apps/graph/README.md
@@ -230,7 +230,7 @@ Every type accepts an optional parameter called `networkId` to override the defa
 
 Some columns in the database are of type `jsonb`. To query these columns, you can supply a stringified JSON object that matches the [JSON object property filters](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-json-fields#filter-on-object-property) from Prisma.
 
-An example of such a filter parameter value could be: `{ params: "{\"array_starts_with\": \"k:97636f47cede6f22f78e2b5ad9e50d11e4e805d414be40b87d3e2cf781998f27\"}" }`, in which case, the `params` column is a `jsonb` type column which is filtered to only include rows where the value contains an array that has the string `k:97636f47cede6f22f78e2b5ad9e50d11e4e805d414be40b87d3e2cf781998f27` on index 0.
+An example of such a filter parameter value could be: `events(parametersFilter: "{\"array_starts_with\": \"k:abcdefg\"}")`, in which case, the `parameters` column is a `jsonb` type column which is filtered to only include rows where the value contains an array that has the string `k:abcdefg` on index 0.
 
 Queries that allow such filters:
 

--- a/packages/apps/graph/README.md
+++ b/packages/apps/graph/README.md
@@ -27,6 +27,7 @@ A GraphQL endpoint that interacts with chainweb-data and chainweb-node.
   - [Tracing and trace analysis](#tracing-and-trace-analysis)
   - [Query Complexity](#query-complexity)
   - [Gas Limit Estimations](#gas-limit-estimations)
+  - [Prisma JSON field queries](#prisma-json-field-queries)
 
 # Getting started
 
@@ -224,3 +225,13 @@ You can get the gas limit estimation for any transaction by using the `gasLimitE
 - `code`: The code of an execution. Required parameters: `code` and `chainId`.
 
 Every type accepts an optional parameter called `networkId` to override the default value from the environment variables.
+
+### Prisma JSON field queries
+
+Some columns in the database are of type `jsonb`. To query these columns, you can supply a stringified JSON object that matches the [JSON object property filters](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-json-fields#filter-on-object-property) from Prisma.
+
+An example of such a filter parameter value could be: `{ params: "{\"array_starts_with\": \"k:97636f47cede6f22f78e2b5ad9e50d11e4e805d414be40b87d3e2cf781998f27\"}" }`, in which case, the `params` column is a `jsonb` type column which is filtered to only include rows where the value contains an array that has the string `k:97636f47cede6f22f78e2b5ad9e50d11e4e805d414be40b87d3e2cf781998f27` on index 0.
+
+Queries that allow such filters:
+
+- `parametersFilter` on the `events` query and `events` subscription.

--- a/packages/apps/graph/generated-schema.graphql
+++ b/packages/apps/graph/generated-schema.graphql
@@ -65,6 +65,7 @@ type Event implements Node {
   """
   orderIndex: BigInt!
   parameterText: String!
+  parameters: String
 
   """
   The full eventname, containing module and eventname, e.g. coin.TRANSFER
@@ -251,7 +252,7 @@ type Query {
   event(blockHash: String!, orderIndex: Int!, requestKey: String!): Event
 
   """Retrieve events."""
-  events(after: String, before: String, first: Int, last: Int, qualifiedEventName: String!): QueryEventsConnection!
+  events(after: String, before: String, chainId: String, first: Int, last: Int, parametersFilter: String, qualifiedEventName: String!): QueryEventsConnection!
 
   """
   Retrieve an fungible specific account by its name and fungible, such as coin.
@@ -372,7 +373,7 @@ type Signer implements Node {
 
 type Subscription {
   """Listen for events by qualifiedName (e.g. `coin.TRANSFER`)."""
-  events(qualifiedEventName: String!): [ID!]
+  events(chainId: String, parametersFilter: String, qualifiedEventName: String!): [ID!]
 
   """Subscribe to new blocks."""
   newBlocks(chainIds: [Int!]): [ID!]

--- a/packages/apps/graph/src/graph/objects/event.ts
+++ b/packages/apps/graph/src/graph/objects/event.ts
@@ -1,6 +1,7 @@
 import { prismaClient } from '@db/prisma-client';
 import { COMPLEXITY } from '@services/complexity';
 import { normalizeError } from '@utils/errors';
+import { nullishOrEmpty } from '@utils/nullish-or-empty';
 import { builder } from '../builder';
 
 export default builder.prismaNode('Event', {
@@ -24,6 +25,17 @@ export default builder.prismaNode('Event', {
     moduleName: t.exposeString('moduleName'),
     name: t.exposeString('name'),
     parameterText: t.exposeString('parameterText'),
+    parameters: t.string({
+      nullable: true,
+      select: {
+        parameters: true,
+      },
+      resolve({ parameters }) {
+        return nullishOrEmpty(parameters)
+          ? undefined
+          : JSON.stringify(parameters);
+      },
+    }),
     qualifiedName: t.exposeString('qualifiedName', {
       description:
         'The full eventname, containing module and eventname, e.g. coin.TRANSFER',

--- a/packages/apps/graph/src/graph/query/events.ts
+++ b/packages/apps/graph/src/graph/query/events.ts
@@ -39,6 +39,8 @@ builder.queryField('events', (t) =>
     edgesNullable: false,
     args: {
       qualifiedEventName: t.arg.string({ required: true }),
+      chainId: t.arg.string(),
+      parametersFilter: t.arg.string(),
     },
     type: 'Event',
     cursor: 'blockHash_orderIndex_requestKey',
@@ -69,6 +71,12 @@ builder.queryField('events', (t) =>
             transaction: {
               NOT: [],
             },
+            ...(args.chainId && {
+              chainId: parseInt(args.chainId),
+            }),
+            ...(args.parametersFilter && {
+              parameters: JSON.parse(args.parametersFilter),
+            }),
           },
           orderBy: {
             id: 'desc',

--- a/packages/apps/graph/src/graph/query/events.ts
+++ b/packages/apps/graph/src/graph/query/events.ts
@@ -1,6 +1,7 @@
 import { prismaClient } from '@db/prisma-client';
 import { getDefaultConnectionComplexity } from '@services/complexity';
 import { normalizeError } from '@utils/errors';
+import { parsePrismaJsonColumn } from '@utils/prisma-json-columns';
 import { builder } from '../builder';
 
 builder.queryField('event', (t) =>
@@ -63,7 +64,11 @@ builder.queryField('events', (t) =>
               chainId: parseInt(args.chainId),
             }),
             ...(args.parametersFilter && {
-              parameters: JSON.parse(args.parametersFilter),
+              parameters: parsePrismaJsonColumn(args.parametersFilter, {
+                query: 'events',
+                queryParameter: 'parametersFilter',
+                column: 'parameters',
+              }),
             }),
           },
         });
@@ -84,7 +89,11 @@ builder.queryField('events', (t) =>
               chainId: parseInt(args.chainId),
             }),
             ...(args.parametersFilter && {
-              parameters: JSON.parse(args.parametersFilter),
+              parameters: parsePrismaJsonColumn(args.parametersFilter, {
+                query: 'events',
+                queryParameter: 'parametersFilter',
+                column: 'parameters',
+              }),
             }),
           },
           orderBy: {

--- a/packages/apps/graph/src/graph/query/events.ts
+++ b/packages/apps/graph/src/graph/query/events.ts
@@ -56,6 +56,15 @@ builder.queryField('events', (t) =>
         return await prismaClient.event.count({
           where: {
             qualifiedName: args.qualifiedEventName,
+            transaction: {
+              NOT: [],
+            },
+            ...(args.chainId && {
+              chainId: parseInt(args.chainId),
+            }),
+            ...(args.parametersFilter && {
+              parameters: JSON.parse(args.parametersFilter),
+            }),
           },
         });
       } catch (error) {

--- a/packages/apps/graph/src/graph/subscription/events.ts
+++ b/packages/apps/graph/src/graph/subscription/events.ts
@@ -10,11 +10,18 @@ builder.subscriptionField('events', (t) =>
     description: 'Listen for events by qualifiedName (e.g. `coin.TRANSFER`).',
     args: {
       qualifiedEventName: t.arg.string({ required: true }),
+      chainId: t.arg.string(),
+      parametersFilter: t.arg.string(),
     },
     type: ['ID'],
     nullable: true,
     subscribe: (__root, args, context) =>
-      iteratorFn(args.qualifiedEventName, context),
+      iteratorFn(
+        args.qualifiedEventName,
+        context,
+        args.chainId,
+        args.parametersFilter,
+      ),
     resolve: (parent) => parent,
   }),
 );
@@ -22,8 +29,15 @@ builder.subscriptionField('events', (t) =>
 async function* iteratorFn(
   qualifiedEventName: string,
   context: IContext,
+  chainId?: string | null,
+  parametersFilter?: string | null,
 ): AsyncGenerator<string[] | undefined, void, unknown> {
-  const eventResult = await getLastEvents(qualifiedEventName);
+  const eventResult = await getLastEvents(
+    qualifiedEventName,
+    undefined,
+    chainId,
+    parametersFilter,
+  );
   let lastEvent;
 
   if (!nullishOrEmpty(eventResult)) {
@@ -38,7 +52,12 @@ async function* iteratorFn(
   }
 
   while (!context.req.socket.destroyed) {
-    const newEvents = await getLastEvents(qualifiedEventName, lastEvent?.id);
+    const newEvents = await getLastEvents(
+      qualifiedEventName,
+      lastEvent?.id,
+      chainId,
+      parametersFilter,
+    );
 
     if (!nullishOrEmpty(newEvents)) {
       lastEvent = newEvents[0];
@@ -58,6 +77,8 @@ async function* iteratorFn(
 async function getLastEvents(
   eventName: string,
   id?: number,
+  chainId?: string | null,
+  parametersFilter?: string | null,
 ): Promise<
   { blockHash: string; orderIndex: bigint; requestKey: string; id: number }[]
 > {
@@ -83,6 +104,12 @@ async function getLastEvents(
       transaction: {
         NOT: [],
       },
+      ...(chainId && {
+        chainId: parseInt(chainId),
+      }),
+      ...(parametersFilter && {
+        parameters: JSON.parse(parametersFilter),
+      }),
     },
     select: {
       id: true,

--- a/packages/apps/graph/src/graph/subscription/events.ts
+++ b/packages/apps/graph/src/graph/subscription/events.ts
@@ -1,6 +1,7 @@
 import { prismaClient } from '@db/prisma-client';
 import { createID } from '@utils/global-id';
 import { nullishOrEmpty } from '@utils/nullish-or-empty';
+import { parsePrismaJsonColumn } from '@utils/prisma-json-columns';
 import type { IContext } from '../builder';
 import { builder } from '../builder';
 import GQLEvent from '../objects/event';
@@ -108,7 +109,11 @@ async function getLastEvents(
         chainId: parseInt(chainId),
       }),
       ...(parametersFilter && {
-        parameters: JSON.parse(parametersFilter),
+        parameters: parsePrismaJsonColumn(parametersFilter, {
+          subscription: 'events',
+          queryParameter: 'parametersFilter',
+          column: 'parameters',
+        }),
       }),
     },
     select: {

--- a/packages/apps/graph/src/utils/errors.ts
+++ b/packages/apps/graph/src/utils/errors.ts
@@ -1,10 +1,12 @@
 import {
   PrismaClientInitializationError,
   PrismaClientKnownRequestError,
+  PrismaClientValidationError,
 } from '@prisma/client/runtime/library';
 import { GasLimitEstimationError } from '@services/chainweb-node/estimate-gas-limit';
 import { PactCommandError } from '@services/chainweb-node/utils';
 import { GraphQLError } from 'graphql';
+import { PrismaJsonColumnParsingError } from './prisma-json-columns';
 
 /**
  * Checks what type of error it is and returns a normalized GraphQLError with the correct type, message and a description that clearly translates to the user what the error means.
@@ -49,6 +51,40 @@ export function normalizeError(error: any): GraphQLError {
         },
       });
     }
+  }
+
+  if (error instanceof PrismaClientValidationError) {
+    if (error.message.includes('Unknown argument')) {
+      error.message =
+        'Unknown argument' + error.message.split('Unknown argument')[1];
+    }
+
+    return new GraphQLError('Prisma Client Validation Error', {
+      extensions: {
+        type: error.name,
+        message: error.message,
+        description:
+          'The Prisma client failed to validate the input. Check the input and try again. If you are trying to filter on a JSON column, make sure the JSON is in the correct format. See the README for the allowed JSON format.',
+        data: error.stack,
+      },
+    });
+  }
+
+  if (error instanceof PrismaJsonColumnParsingError) {
+    return new GraphQLError('Prisma JSON Column Parsing Error', {
+      extensions: {
+        type: error.name,
+        message: error.message,
+        description:
+          'Error parsing JSON for filtering on the Prisma jsonb column. See the README for the allowed JSON format.',
+        data: {
+          query: error.query,
+          subscription: error.subscription,
+          queryParameter: error.queryParameter,
+          column: error.column,
+        },
+      },
+    });
   }
 
   if (error instanceof PactCommandError) {

--- a/packages/apps/graph/src/utils/prisma-json-columns.ts
+++ b/packages/apps/graph/src/utils/prisma-json-columns.ts
@@ -1,0 +1,42 @@
+export class PrismaJsonColumnParsingError extends Error {
+  query?: string;
+  subscription?: string;
+  queryParameter: string;
+  column: string;
+
+  constructor(options: {
+    message: string;
+    query?: string;
+    subscription?: string;
+    queryParameter: string;
+    column: string;
+  }) {
+    super(options.message);
+    this.query = options.query;
+    this.subscription = options.subscription;
+    this.queryParameter = options.queryParameter;
+    this.column = options.column;
+  }
+}
+
+export function parsePrismaJsonColumn(
+  value: string,
+  meta: {
+    query?: string;
+    subscription?: string;
+    queryParameter: string;
+    column: string;
+  },
+) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new PrismaJsonColumnParsingError({
+      message: `Unable to parse '${value}' as JSON.`,
+      query: meta.query,
+      subscription: meta.subscription,
+      queryParameter: meta.queryParameter,
+      column: meta.column,
+    });
+  }
+}


### PR DESCRIPTION
### Prisma JSON field queries

Some columns in the database are of type `jsonb`. To query these columns, you can supply a stringified JSON object that matches the [JSON object property filters](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-json-fields#filter-on-object-property) from Prisma.

An example of such a filter parameter value could be: `events(parametersFilter: "{\"array_starts_with\": \"k:abcdefg\"}")`, in which case, the `parameters` column is a `jsonb` type column which is filtered to only include rows where the value contains an array that has the string `k:abcdefg` on index 0.

Queries that allow such filters:

- `parametersFilter` on the `events` query and `events` subscription.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206592009540818