### PR TITLE
Add checkStatus to Ecko signing functions

### DIFF
--- a/.changeset/quiet-berries-appear.md
+++ b/.changeset/quiet-berries-appear.md
@@ -1,0 +1,5 @@
+---
+'@kadena/client': minor
+---
+
+Add `eckoStatus` to `createEckoWalletQuicksign` and `createEckoWalletSign`.

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -75,6 +75,9 @@ export const createWalletConnectQuicksign: typeof createQuicksignWithWalletConne
 export const createWalletConnectSign: typeof createSignWithWalletConnect;
 
 // @public
+export type EckoStatus = 'success' | 'fail';
+
+// @public
 export const getHostUrl: (hostBaseUrl: string) => ({ networkId, chainId }: INetworkOptions) => string;
 
 // @public (undocumented)
@@ -134,6 +137,8 @@ export { ICommandResult }
 // @public
 export interface ICommonEckoFunctions {
     // (undocumented)
+    checkStatus: (networkId: string) => Promise<IEckoConnectOrStatusResponse | undefined>;
+    // (undocumented)
     connect: (networkId: string) => Promise<boolean>;
     // (undocumented)
     isConnected: (networkId: string) => Promise<boolean>;
@@ -172,6 +177,20 @@ export interface ICreateSignWithKeypair {
     (key: IKeyPair): ISignFunction;
     // (undocumented)
     (keys: IKeyPair[]): ISignFunction;
+}
+
+// @public
+export interface IEckoConnectOrStatusResponse {
+    // (undocumented)
+    account?: {
+        account: string;
+        publicKey: string;
+        connectedSites: string[];
+    };
+    // (undocumented)
+    message?: string;
+    // (undocumented)
+    status: EckoStatus;
 }
 
 // @public

--- a/packages/libs/client/src/signing/eckoWallet/eckoCommon.ts
+++ b/packages/libs/client/src/signing/eckoWallet/eckoCommon.ts
@@ -45,3 +45,25 @@ export const connect: ICommonEckoFunctions['connect'] = async (networkId) => {
 
   return true;
 };
+
+export const checkStatus: ICommonEckoFunctions['checkStatus'] = async (
+  networkId,
+) => {
+  if (!isInstalled()) {
+    throw new Error('Ecko Wallet is not installed');
+  }
+
+  await connect(networkId);
+
+  const checkstatusResponse =
+    await window.kadena?.request<IEckoConnectOrStatusResponse>({
+      method: 'kda_checkStatus',
+      networkId,
+    });
+
+  if (checkstatusResponse?.status === 'fail') {
+    throw new Error('Error getting status from Ecko Wallet');
+  }
+
+  return checkstatusResponse;
+};

--- a/packages/libs/client/src/signing/eckoWallet/eckoTypes.ts
+++ b/packages/libs/client/src/signing/eckoWallet/eckoTypes.ts
@@ -2,6 +2,10 @@ import type { ICommand } from '@kadena/types';
 import type { IQuicksignResponseOutcomes } from '../../signing-api/v1/quicksign';
 import type { ISignFunction, ISingleSignFunction } from '../ISignFunction';
 
+/**
+ * The response status of the Ecko Wallet request
+ * @public
+ */
 export type EckoStatus = 'success' | 'fail';
 
 /**
@@ -12,6 +16,9 @@ export interface ICommonEckoFunctions {
   isInstalled: () => boolean;
   isConnected: (networkId: string) => Promise<boolean>;
   connect: (networkId: string) => Promise<boolean>;
+  checkStatus: (
+    networkId: string,
+  ) => Promise<IEckoConnectOrStatusResponse | undefined>;
 }
 /**
  * Interface to use when writing a signing function for Ecko Wallet that accepts a single transaction
@@ -29,6 +36,10 @@ export interface IEckoSignFunction
   extends ISignFunction,
     ICommonEckoFunctions {}
 
+/**
+ * Interface that describes the response from Ecko Wallet when checking status or connecting
+ * @public
+ */
 export interface IEckoConnectOrStatusResponse {
   status: EckoStatus;
   message?: string;

--- a/packages/libs/client/src/signing/eckoWallet/quicksignWithEckoWallet.ts
+++ b/packages/libs/client/src/signing/eckoWallet/quicksignWithEckoWallet.ts
@@ -1,7 +1,7 @@
 import type { ICommand, IUnsignedCommand } from '@kadena/types';
 import { addSignatures } from '../utils/addSignatures';
 import { parseTransactionCommand } from '../utils/parseTransactionCommand';
-import { connect, isConnected, isInstalled } from './eckoCommon';
+import { checkStatus, connect, isConnected, isInstalled } from './eckoCommon';
 import type { IEckoQuicksignResponse, IEckoSignFunction } from './eckoTypes';
 
 /**
@@ -85,6 +85,7 @@ export function createQuicksignWithEckoWallet(): IEckoSignFunction {
   quicksignWithEckoWallet.isInstalled = isInstalled;
   quicksignWithEckoWallet.isConnected = isConnected;
   quicksignWithEckoWallet.connect = connect;
+  quicksignWithEckoWallet.checkStatus = checkStatus;
 
   return quicksignWithEckoWallet;
 }

--- a/packages/libs/client/src/signing/eckoWallet/signWithEckoWallet.ts
+++ b/packages/libs/client/src/signing/eckoWallet/signWithEckoWallet.ts
@@ -1,6 +1,6 @@
 import { pactCommandToSigningRequest } from '../utils/pactCommandToSigningRequest';
 import { parseTransactionCommand } from '../utils/parseTransactionCommand';
-import { connect, isConnected, isInstalled } from './eckoCommon';
+import { checkStatus, connect, isConnected, isInstalled } from './eckoCommon';
 import type { IEckoSignResponse, IEckoSignSingleFunction } from './eckoTypes';
 
 declare global {
@@ -46,6 +46,7 @@ export function createSignWithEckoWallet(): IEckoSignSingleFunction {
   signWithEckoWallet.isInstalled = isInstalled;
   signWithEckoWallet.isConnected = isConnected;
   signWithEckoWallet.connect = connect;
+  signWithEckoWallet.checkStatus = checkStatus;
 
   return signWithEckoWallet;
 }

--- a/packages/libs/client/src/signing/eckoWallet/tests/eckoCommon.test.ts
+++ b/packages/libs/client/src/signing/eckoWallet/tests/eckoCommon.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 /** @vitest-environment jsdom */
 
-import { connect, isConnected, isInstalled } from '../eckoCommon';
+import { checkStatus, connect, isConnected, isInstalled } from '../eckoCommon';
 
 import { TextDecoder, TextEncoder } from 'util';
 
@@ -106,6 +106,104 @@ describe('eckoCommon', () => {
       });
 
       expect(result).toBeTruthy();
+    });
+
+    it('throws when the user declines the connection', async () => {
+      // mock kda_checkStatus
+      mockEckoRequest.mockResolvedValueOnce({
+        status: 'fail',
+      });
+
+      // mock kda_connect
+      mockEckoRequest.mockResolvedValueOnce({
+        status: 'fail',
+      });
+
+      try {
+        await connect('testnet04');
+      } catch (e) {
+        expect(e.message).toContain('User declined connection');
+      }
+    });
+  });
+
+  describe('checkStatus()', () => {
+    it('throws when Ecko Wallet is not installed', async () => {
+      if (window.kadena) window.kadena.isKadena = false;
+
+      try {
+        await checkStatus('testnet04');
+      } catch (e) {
+        expect(e.message).toContain('Ecko Wallet is not installed');
+      }
+    });
+
+    it('returns the current account when connected', async () => {
+      // mock kda_connect
+      mockEckoRequest.mockResolvedValueOnce({
+        status: 'success',
+      });
+
+      // mock kda_checkStatus
+      mockEckoRequest.mockResolvedValueOnce({
+        status: 'success',
+        account: {
+          account: 'k:abcd',
+          publicKey: 'abcd',
+          connectedSites: ['kadena.io'],
+        },
+      });
+
+      const result = await checkStatus('testnet04');
+
+      expect(result).toEqual({
+        status: 'success',
+        account: {
+          account: 'k:abcd',
+          publicKey: 'abcd',
+          connectedSites: ['kadena.io'],
+        },
+      });
+    });
+
+    it('connects when not connected yet, then returns the checkStatus response', async () => {
+      // mock kda_connect
+      mockEckoRequest.mockResolvedValueOnce({
+        status: 'fail',
+      });
+
+      // mock kda_checkStatus for connect()
+      mockEckoRequest.mockResolvedValueOnce({
+        status: 'success',
+      });
+
+      // mock kda_checkStatus for checkStatus()
+      mockEckoRequest.mockResolvedValueOnce({
+        status: 'success',
+        account: {
+          account: 'k:abcd',
+          publicKey: 'abcd',
+          connectedSites: ['kadena.io'],
+        },
+        publicKey: 'abcd',
+      });
+
+      const result = await checkStatus('testnet04');
+
+      expect(mockEckoRequest).toHaveBeenCalledWith({
+        method: 'kda_checkStatus',
+        networkId: 'testnet04',
+      });
+
+      expect(result).toEqual({
+        status: 'success',
+        account: {
+          account: 'k:abcd',
+          publicKey: 'abcd',
+          connectedSites: ['kadena.io'],
+        },
+        publicKey: 'abcd',
+      });
     });
 
     it('throws when the user declines the connection', async () => {

--- a/packages/libs/client/src/signing/index.ts
+++ b/packages/libs/client/src/signing/index.ts
@@ -1,7 +1,9 @@
 export { IUnsignedCommand } from '@kadena/types';
 export { ISignFunction, ISingleSignFunction } from './ISignFunction';
 export {
+  EckoStatus,
   ICommonEckoFunctions,
+  IEckoConnectOrStatusResponse,
   IEckoSignFunction,
   IEckoSignSingleFunction,
 } from './eckoWallet/eckoTypes';


### PR DESCRIPTION
Adds a wrapper around the `kda_checkStatus` function from Ecko Wallet, which returns the currently connected account.

Closes #1613