### PR TITLE
Deprecate createXSign and createXQuicksign, replaced by createSignWit…

### DIFF
--- a/.changeset/hip-years-invent.md
+++ b/.changeset/hip-years-invent.md
@@ -1,0 +1,12 @@
+---
+'@kadena/client': patch
+---
+
+Deprecated wallet function names (`createSignWithX`) to provide a clearer naming scheme.
+
+The following functions have been deprecated:
+
+* `createWalletConnectSign` -> `createSignWithWalletConnect`
+* `createWalletConnectQuicksign` -> `createQuicksignWithWalletConnect`
+* `createEckoWalletSign` -> `createSignWithEckoWallet`
+* `createEckoWalletQuicksign` -> `createQuicksignWithEckoWallet`

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -36,11 +36,17 @@ export { ChainId }
 // @public
 export const createClient: ICreateClient;
 
-// @public
-export function createEckoWalletQuicksign(): IEckoSignFunction;
+// @public @deprecated
+export const createEckoWalletQuicksign: typeof createQuicksignWithEckoWallet;
+
+// @public @deprecated
+export const createEckoWalletSign: typeof createSignWithEckoWallet;
 
 // @public
-export function createEckoWalletSign(): IEckoSignSingleFunction;
+export function createQuicksignWithEckoWallet(): IEckoSignFunction;
+
+// @public
+export function createQuicksignWithWalletConnect(client: Client, session: SessionTypes.Struct, walletConnectChainId: TWalletConnectChainId): ISignFunction;
 
 // @public
 export function createSignWithChainweaver(options?: {
@@ -48,7 +54,13 @@ export function createSignWithChainweaver(options?: {
 }): ISignFunction;
 
 // @public
+export function createSignWithEckoWallet(): IEckoSignSingleFunction;
+
+// @public
 export const createSignWithKeypair: ICreateSignWithKeypair;
+
+// @public
+export function createSignWithWalletConnect(client: Client, session: SessionTypes.Struct, walletConnectChainId: TWalletConnectChainId): ISingleSignFunction;
 
 // @public
 export const createTransaction: (pactCommand: IPartialPactCommand) => IUnsignedCommand;
@@ -56,11 +68,11 @@ export const createTransaction: (pactCommand: IPartialPactCommand) => IUnsignedC
 // @public
 export const createTransactionBuilder: (initial?: IPartialPactCommand) => ITransactionBuilder;
 
-// @public
-export function createWalletConnectQuicksign(client: Client, session: SessionTypes.Struct, walletConnectChainId: TWalletConnectChainId): ISignFunction;
+// @public @deprecated
+export const createWalletConnectQuicksign: typeof createQuicksignWithWalletConnect;
 
-// @public
-export function createWalletConnectSign(client: Client, session: SessionTypes.Struct, walletConnectChainId: TWalletConnectChainId): ISingleSignFunction;
+// @public @deprecated
+export const createWalletConnectSign: typeof createSignWithWalletConnect;
 
 // @public
 export const getHostUrl: (hostBaseUrl: string) => ({ networkId, chainId }: INetworkOptions) => string;

--- a/packages/libs/client/src/signing/eckoWallet/quicksignWithEckoWallet.ts
+++ b/packages/libs/client/src/signing/eckoWallet/quicksignWithEckoWallet.ts
@@ -5,11 +5,11 @@ import { connect, isConnected, isInstalled } from './eckoCommon';
 import type { IEckoQuicksignResponse, IEckoSignFunction } from './eckoTypes';
 
 /**
- * Creates the quicksignWithWalletConnect function with interface {@link ISingleSignFunction}
+ * Creates the quicksignWithEckoWallet function with interface {@link ISingleSignFunction}
  *
  * @public
  */
-export function createEckoWalletQuicksign(): IEckoSignFunction {
+export function createQuicksignWithEckoWallet(): IEckoSignFunction {
   const quicksignWithEckoWallet: IEckoSignFunction = (async (
     transactionList: IUnsignedCommand | Array<IUnsignedCommand | ICommand>,
   ) => {
@@ -88,3 +88,11 @@ export function createEckoWalletQuicksign(): IEckoSignFunction {
 
   return quicksignWithEckoWallet;
 }
+
+/**
+ * Creates the quicksignWithEckoWallet function with interface {@link ISingleSignFunction}
+ *
+ * @deprecated Use {@link createQuicksignWithEckoWallet} instead
+ * @public
+ */
+export const createEckoWalletQuicksign = createQuicksignWithEckoWallet;

--- a/packages/libs/client/src/signing/eckoWallet/signWithEckoWallet.ts
+++ b/packages/libs/client/src/signing/eckoWallet/signWithEckoWallet.ts
@@ -21,7 +21,7 @@ declare global {
  *
  * @public
  */
-export function createEckoWalletSign(): IEckoSignSingleFunction {
+export function createSignWithEckoWallet(): IEckoSignSingleFunction {
   const signWithEckoWallet: IEckoSignSingleFunction = async (transaction) => {
     const parsedTransaction = parseTransactionCommand(transaction);
     const signingRequest = pactCommandToSigningRequest(parsedTransaction);
@@ -49,3 +49,14 @@ export function createEckoWalletSign(): IEckoSignSingleFunction {
 
   return signWithEckoWallet;
 }
+
+/**
+ * Creates the signWithEckoWallet function with interface {@link ISingleSignFunction}
+ *
+ * @remarks
+ * It is preferred to use the {@link createQuicksignWithEckoWallet} function
+ *
+ * @deprecated Use {@link createSignWithEckoWallet} instead
+ * @public
+ */
+export const createEckoWalletSign = createSignWithEckoWallet;

--- a/packages/libs/client/src/signing/walletconnect/quicksignWithWalletConnect.ts
+++ b/packages/libs/client/src/signing/walletconnect/quicksignWithWalletConnect.ts
@@ -12,7 +12,7 @@ import type { TWalletConnectChainId } from './walletConnectTypes';
  *
  * @public
  */
-export function createWalletConnectQuicksign(
+export function createQuicksignWithWalletConnect(
   client: Client,
   session: SessionTypes.Struct,
   walletConnectChainId: TWalletConnectChainId,
@@ -89,3 +89,12 @@ export function createWalletConnectQuicksign(
 
   return quicksignWithWalletConnect;
 }
+
+/**
+ * Creates the quicksignWithWalletConnect function with interface {@link ISingleSignFunction}
+ *
+ *
+ * @deprecated Use {@link createQuicksignWithWalletConnect} instead
+ * @public
+ */
+export const createWalletConnectQuicksign = createQuicksignWithWalletConnect;

--- a/packages/libs/client/src/signing/walletconnect/signWithWalletConnect.ts
+++ b/packages/libs/client/src/signing/walletconnect/signWithWalletConnect.ts
@@ -15,11 +15,11 @@ interface ISigningResponse {
  * Creates the signWithWalletConnect function with interface {@link ISingleSignFunction}
  *
  * @remarks
- * It is preferred to use the {@link createWalletConnectQuicksign} function
+ * It is preferred to use the {@link createQuicksignWithWalletConnect} function
  *
  * @public
  */
-export function createWalletConnectSign(
+export function createSignWithWalletConnect(
   client: Client,
   session: SessionTypes.Struct,
   walletConnectChainId: TWalletConnectChainId,
@@ -80,3 +80,14 @@ export function createWalletConnectSign(
 
   return signWithWalletConnect;
 }
+
+/**
+ * Creates the signWithWalletConnect function with interface {@link ISingleSignFunction}
+ *
+ * @remarks
+ * It is preferred to use the {@link createQuicksignWithWalletConnect} function
+ *
+ * @deprecated Use {@link createSignWithWalletConnect} instead
+ * @public
+ */
+export const createWalletConnectSign = createSignWithWalletConnect;

--- a/packages/libs/client/src/signing/walletconnect/tests/quicksignWithWalletConnect.test.ts
+++ b/packages/libs/client/src/signing/walletconnect/tests/quicksignWithWalletConnect.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IPactCommand } from '../../../interfaces/IPactCommand';
 import { createTransaction } from '../../../utils/createTransaction';
 import type { ISignFunction } from '../../ISignFunction';
-import { createWalletConnectQuicksign } from '../quicksignWithWalletConnect';
+import { createQuicksignWithWalletConnect } from '../quicksignWithWalletConnect';
 import type { TWalletConnectChainId } from '../walletConnectTypes';
 
 import type Client from '@walletconnect/sign-client';
@@ -58,7 +58,7 @@ describe('quicksignWithWalletConnect', () => {
     };
 
     const quicksignWithWalletConnect: ISignFunction =
-      createWalletConnectQuicksign(
+      createQuicksignWithWalletConnect(
         client as unknown as Client,
         session,
         walletConnectChainId,
@@ -102,7 +102,7 @@ describe('quicksignWithWalletConnect', () => {
       ),
     };
 
-    quicksignWithWalletConnect = createWalletConnectQuicksign(
+    quicksignWithWalletConnect = createQuicksignWithWalletConnect(
       client as unknown as Client,
       session,
       walletConnectChainId,
@@ -147,7 +147,7 @@ describe('quicksignWithWalletConnect', () => {
       request: vi.fn(() => Promise.resolve()),
     };
 
-    quicksignWithWalletConnect = createWalletConnectQuicksign(
+    quicksignWithWalletConnect = createQuicksignWithWalletConnect(
       client as unknown as Client,
       session,
       walletConnectChainId,
@@ -167,7 +167,7 @@ describe('quicksignWithWalletConnect', () => {
       ),
     };
 
-    quicksignWithWalletConnect = createWalletConnectQuicksign(
+    quicksignWithWalletConnect = createQuicksignWithWalletConnect(
       client as unknown as Client,
       session,
       walletConnectChainId,
@@ -210,7 +210,7 @@ describe('quicksignWithWalletConnect', () => {
       ),
     };
 
-    quicksignWithWalletConnect = createWalletConnectQuicksign(
+    quicksignWithWalletConnect = createQuicksignWithWalletConnect(
       client as unknown as Client,
       session,
       walletConnectChainId,

--- a/packages/libs/client/src/signing/walletconnect/tests/signWithWalletConnect.test.ts
+++ b/packages/libs/client/src/signing/walletconnect/tests/signWithWalletConnect.test.ts
@@ -4,7 +4,7 @@ import type {
   IPactCommand,
 } from '../../../interfaces/IPactCommand';
 import { createTransaction } from '../../../utils/createTransaction';
-import { createWalletConnectSign } from '../signWithWalletConnect';
+import { createSignWithWalletConnect } from '../signWithWalletConnect';
 import type { TWalletConnectChainId } from '../walletConnectTypes';
 
 import type Client from '@walletconnect/sign-client';
@@ -58,7 +58,7 @@ describe('signWithWalletConnect', () => {
       ),
     };
 
-    const signWithWalletConnect = createWalletConnectSign(
+    const signWithWalletConnect = createSignWithWalletConnect(
       client as unknown as Client,
       session,
       walletConnectChainId,
@@ -115,7 +115,7 @@ describe('signWithWalletConnect', () => {
       ),
     };
 
-    const signWithWalletConnect = createWalletConnectSign(
+    const signWithWalletConnect = createSignWithWalletConnect(
       client as unknown as Client,
       session,
       walletConnectChainId,
@@ -140,7 +140,7 @@ describe('signWithWalletConnect', () => {
       ),
     };
 
-    const signWithWalletConnect = createWalletConnectSign(
+    const signWithWalletConnect = createSignWithWalletConnect(
       client as unknown as Client,
       session,
       walletConnectChainId,
@@ -182,7 +182,7 @@ describe('signWithWalletConnect', () => {
       ),
     };
 
-    const signWithWalletConnect = createWalletConnectSign(
+    const signWithWalletConnect = createSignWithWalletConnect(
       client as unknown as Client,
       session,
       walletConnectChainId,


### PR DESCRIPTION
This PR renames some functions, to provide a clearer naming scheme.

`createWalletConnectSign` -> `createSignWithWalletConnect`
`createWalletConnectQuicksign` -> `createQuicksignWithWalletConnect`
`createEckoWalletSign` -> `createSignWithEckoWallet`
`createEckoWalletQuicksign` -> `createQuicksignWithEckoWallet`