### PR TITLE
[@kadena/graph] Added Events to Block and removed obsolete Block fields

### DIFF
--- a/.changeset/happy-crabs-suffer.md
+++ b/.changeset/happy-crabs-suffer.md
@@ -1,0 +1,6 @@
+---
+'@kadena/graph-client': patch
+'@kadena/graph': patch
+---
+
+Added Events to Block and removed obsolete fields

--- a/packages/apps/graph-client/src/graphql/fields/block.graph.ts
+++ b/packages/apps/graph-client/src/graphql/fields/block.graph.ts
@@ -18,13 +18,12 @@ export const ALL_BLOCK_FIELDS: DocumentNode = gql`
     creationTime
     epoch
     id
-    parentHash
     powHash
-    predicate
 
     # confirmationDepth // default excluded since it's a heavy query
     # minerAccount {}
     # parent {}
     # transactions {}
+    # events {}
   }
 `;

--- a/packages/apps/graph-client/src/graphql/queries.graph.ts
+++ b/packages/apps/graph-client/src/graphql/queries.graph.ts
@@ -106,7 +106,18 @@ export const getBlockFromHash: DocumentNode = gql`
       confirmationDepth
       minerAccount {
         guard {
+          predicate
           keys
+        }
+      }
+      parent {
+        hash
+      }
+      events {
+        edges {
+          node {
+            ...AllEventFields
+          }
         }
       }
     }

--- a/packages/apps/graph-client/src/pages/block/overview/[hash].tsx
+++ b/packages/apps/graph-client/src/pages/block/overview/[hash].tsx
@@ -1,9 +1,10 @@
-import type { BlockTransactionsConnection } from '@/__generated__/sdk';
+import type { BlockTransactionsConnection, Event } from '@/__generated__/sdk';
 import {
   useGetBlockFromHashQuery,
   useGetGraphConfigurationQuery,
 } from '@/__generated__/sdk';
 import { centerBlockClass } from '@/components/common/center-block/styles.css';
+import { EventsTable } from '@/components/events-table/events-table';
 import { GraphQLQueryDialog } from '@/components/graphql-query-dialog/graphql-query-dialog';
 import LoaderAndError from '@/components/loader-and-error/loader-and-error';
 import {
@@ -20,6 +21,7 @@ import {
   BreadcrumbsItem,
   Cell,
   Column,
+  ContentHeader,
   Heading,
   Link,
   Notification,
@@ -144,9 +146,9 @@ const Block: React.FC = () => {
                       </Cell>
                       <Cell>
                         <Link
-                          href={`${routes.BLOCK_OVERVIEW}/${data.block.parentHash}`}
+                          href={`${routes.BLOCK_OVERVIEW}/${data.block.parent?.hash}`}
                         >
-                          {data.block.parentHash}
+                          {data.block.parent?.hash}
                         </Link>
                       </Cell>
                     </Row>
@@ -232,7 +234,7 @@ const Block: React.FC = () => {
                       <Cell>
                         <strong>Predicate</strong>
                       </Cell>
-                      <Cell>{data.block.predicate}</Cell>
+                      <Cell>{data.block.minerAccount.guard.predicate}</Cell>
                     </Row>
                   </TableBody>
                 </Table>
@@ -249,6 +251,22 @@ const Block: React.FC = () => {
                 }
                 description="All transactions present in this block"
               />
+            )}
+
+            <Box margin="md" />
+
+            {data.block.events.edges.length && (
+              <>
+                <ContentHeader
+                  heading="Events"
+                  icon="KIcon"
+                  description="All events of this block"
+                />
+                <Box margin="sm" />
+                <EventsTable
+                  events={data.block.events.edges.map((x) => x.node) as Event[]}
+                />
+              </>
             )}
           </>
         )}

--- a/packages/apps/graph/generated-schema.graphql
+++ b/packages/apps/graph/generated-schema.graphql
@@ -15,18 +15,28 @@ type Block implements Node {
   The moment the difficulty is adjusted to maintain a block validation time of 30 seconds.
   """
   epoch: DateTime!
+  events(after: String, before: String, first: Int, last: Int): BlockEventsConnection!
   hash: ID!
   height: BigInt!
   id: ID!
   minerAccount: FungibleChainAccount!
   parent: Block
-  parentHash: String!
   payloadHash: String!
 
   """The proof of work hash."""
   powHash: String!
-  predicate: String!
   transactions(after: String, before: String, first: Int, last: Int): BlockTransactionsConnection!
+}
+
+type BlockEventsConnection {
+  edges: [BlockEventsConnectionEdge!]!
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type BlockEventsConnectionEdge {
+  cursor: String!
+  node: Event!
 }
 
 type BlockTransactionsConnection {


### PR DESCRIPTION
- Removed Block.parentHash
- Removed Block.predicate: String, predicate can be accessed through MinerAccount
- Added Block.events property to access all events from block
- Added Events to block view in graph-client

https://app.asana.com/0/1205801361945248/1206591792021826