### PR TITLE
feat(account): implement account delete sub command

### DIFF
--- a/packages/tools/kadena-cli/README.md
+++ b/packages/tools/kadena-cli/README.md
@@ -595,13 +595,13 @@ kadena account delete [arguments]
 example for delete a specific account:
 
 ```
-kadena account list --account-alias="accountAlias" --confirm="yes"
+kadena account delete --account-alias="accountAlias" --confirm
 ```
 
 example for delete multiple accounts: (comma separated list of account alias)
 
 ```
-kadena account list --account-alias="accountAlias_1,devnetAlias" --confirm="yes"
+kadena account delete --account-alias="accountAlias_1,devnetAlias" --confirm
 ```
 
 ## kadena tx

--- a/packages/tools/kadena-cli/README.md
+++ b/packages/tools/kadena-cli/README.md
@@ -598,10 +598,10 @@ example for delete a specific account:
 kadena account delete --account-alias="accountAlias" --confirm
 ```
 
-example for delete multiple accounts: (comma separated list of account alias)
+example for delete all accounts:
 
 ```
-kadena account delete --account-alias="accountAlias_1,devnetAlias" --confirm
+kadena account delete --account-alias="all" --confirm
 ```
 
 ## kadena tx

--- a/packages/tools/kadena-cli/README.md
+++ b/packages/tools/kadena-cli/README.md
@@ -423,6 +423,7 @@ Tool to manage / fund accounts of fungibles (e.g. coin')
 | name-to-address | Resolve a .kda name to a k:address (kadenanames) |                   |
 | address-to-name | Resolve a k:address to a .kda name (kadenanames) |                   |
 | list            | List available account(s)                        |                   |
+| delete          | Delete existing account(s)                       |                   |
 
 ---
 
@@ -521,7 +522,7 @@ kadena account fund [arguments]
 example:
 
 ```
-kadena account fund --account="myalias.yaml" --amount="10" --network="testnet" --chain-id="1"
+kadena account fund --account="myalias" --amount="10" --network="testnet" --chain-id="1"
 ```
 
 ---
@@ -568,7 +569,7 @@ kadena account list [arguments]
 | ----------------------- | ------------------------------- |
 | --account-alias         | Provide the name of the account |
 
-example for listing specific accpimt:
+example for listing specific account:
 
 ```
 kadena account list --account-alias="accountAlias"
@@ -581,6 +582,27 @@ kadena account list --account-alias="all"
 ```
 
 ---
+
+```
+kadena account delete [arguments]
+```
+
+| **Arguments & Options** | ** Description**                |
+| ----------------------- | ------------------------------- |
+| --account-alias         | Provide the name of the account |
+| --confirm               | Confirm deletion of account     |
+
+example for delete a specific account:
+
+```
+kadena account list --account-alias="accountAlias" --confirm="yes"
+```
+
+example for delete multiple accounts: (comma separated list of account alias)
+
+```
+kadena account list --account-alias="accountAlias_1,devnetAlias" --confirm="yes"
+```
 
 ## kadena tx
 

--- a/packages/tools/kadena-cli/src/account/accountOptions.ts
+++ b/packages/tools/kadena-cli/src/account/accountOptions.ts
@@ -16,7 +16,7 @@ export const accountOptions = {
     prompt: account.accountAliasPrompt,
     validation: z.string(),
     option: new Option(
-      '-aa, --account-alias <accountAlias>',
+      '--account-alias <accountAlias>',
       'Enter an alias to store your account',
     ),
   }),
@@ -126,12 +126,10 @@ export const accountOptions = {
     },
   }),
   accountDeleteConfirmation: createOption({
-    key: 'accountDeleteConfirmation',
+    key: 'confirm',
+    defaultIsOptional: false,
     validation: z.boolean(),
     prompt: account.accountDeleteConfirmationPrompt,
-    option: new Option(
-      '-d, --account-delete-confirmation',
-      'Confirm account deletion',
-    ),
+    option: new Option('-c, --confirm', 'Confirm account deletion'),
   }),
 };

--- a/packages/tools/kadena-cli/src/account/accountOptions.ts
+++ b/packages/tools/kadena-cli/src/account/accountOptions.ts
@@ -96,12 +96,12 @@ export const accountOptions = {
     },
   }),
   accountMultiSelect: createOption({
-    key: 'account' as const,
+    key: 'accountAlias' as const,
     prompt: account.accountSelectMultiplePrompt,
     defaultIsOptional: false,
     validation: z.string(),
     option: new Option(
-      '-a, --account-aliases <account>',
+      '-a, --account-alias <account>',
       'Enter an alias account(s) separated by a comma',
     ),
   }),

--- a/packages/tools/kadena-cli/src/account/accountOptions.ts
+++ b/packages/tools/kadena-cli/src/account/accountOptions.ts
@@ -91,6 +91,9 @@ export const accountOptions = {
         const accountDetails = await readAccountFromFile(accountAlias);
         return accountDetails;
       } catch (error) {
+        if (error.message.includes('file not exist') === true) {
+          return;
+        }
         throw new Error(error.message);
       }
     },

--- a/packages/tools/kadena-cli/src/account/accountOptions.ts
+++ b/packages/tools/kadena-cli/src/account/accountOptions.ts
@@ -61,9 +61,7 @@ export const accountOptions = {
     option: new Option('-a, --account <account>', 'Select an account'),
     expand: async (accountAlias: string): Promise<IAliasAccountData | null> => {
       try {
-        const accountDetails = await readAccountFromFile(
-          `${accountAlias}.yaml`,
-        );
+        const accountDetails = await readAccountFromFile(accountAlias);
         return accountDetails;
       } catch (error) {
         if (error.message.includes('file not exist') === true) {
@@ -90,9 +88,7 @@ export const accountOptions = {
           return;
         }
 
-        const accountDetails = await readAccountFromFile(
-          `${accountAlias}.yaml`,
-        );
+        const accountDetails = await readAccountFromFile(accountAlias);
         return accountDetails;
       } catch (error) {
         throw new Error(error.message);

--- a/packages/tools/kadena-cli/src/account/accountOptions.ts
+++ b/packages/tools/kadena-cli/src/account/accountOptions.ts
@@ -95,6 +95,16 @@ export const accountOptions = {
       }
     },
   }),
+  accountMultiSelect: createOption({
+    key: 'account' as const,
+    prompt: account.accountSelectMultiplePrompt,
+    defaultIsOptional: false,
+    validation: z.string(),
+    option: new Option(
+      '-a, --account-aliases <account>',
+      'Enter an alias account(s) separated by a comma',
+    ),
+  }),
   fundAmount: createOption({
     key: 'amount' as const,
     prompt: account.fundAmountPrompt,
@@ -114,5 +124,14 @@ export const accountOptions = {
         throw new Error(`Error: -m, --amount ${errorMessage}`);
       }
     },
+  }),
+  accountDeleteConfirmation: createOption({
+    key: 'accountDeleteConfirmation',
+    validation: z.boolean(),
+    prompt: account.accountDeleteConfirmationPrompt,
+    option: new Option(
+      '-d, --account-delete-confirmation',
+      'Confirm account deletion',
+    ),
   }),
 };

--- a/packages/tools/kadena-cli/src/account/accountOptions.ts
+++ b/packages/tools/kadena-cli/src/account/accountOptions.ts
@@ -61,7 +61,9 @@ export const accountOptions = {
     option: new Option('-a, --account <account>', 'Select an account'),
     expand: async (accountAlias: string): Promise<IAliasAccountData | null> => {
       try {
-        const accountDetails = await readAccountFromFile(accountAlias);
+        const accountDetails = await readAccountFromFile(
+          `${accountAlias}.yaml`,
+        );
         return accountDetails;
       } catch (error) {
         if (error.message.includes('file not exist') === true) {
@@ -88,7 +90,9 @@ export const accountOptions = {
           return;
         }
 
-        const accountDetails = await readAccountFromFile(accountAlias);
+        const accountDetails = await readAccountFromFile(
+          `${accountAlias}.yaml`,
+        );
         return accountDetails;
       } catch (error) {
         throw new Error(error.message);

--- a/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
@@ -1,0 +1,76 @@
+import { join } from 'path';
+import { ACCOUNT_DIR } from '../../constants/config.js';
+import { services } from '../../services/index.js';
+import { createCommandFlexible } from '../../utils/createCommandFlexible.js';
+import { log } from '../../utils/logger.js';
+import { accountOptions } from '../accountOptions.js';
+
+async function removeAccount(
+  accountAlias: string,
+): Promise<[string[], string[]]> {
+  const deletedFiles = [];
+  const nonDeletedFiles = [];
+  const aliases = accountAlias.split(',');
+  for (const alias of aliases) {
+    const filePath = join(ACCOUNT_DIR, alias);
+    if (await services.filesystem.fileExists(filePath)) {
+      await services.filesystem.deleteFile(filePath);
+      deletedFiles.push(alias);
+    } else {
+      nonDeletedFiles.push(alias);
+    }
+  }
+  return [deletedFiles, nonDeletedFiles];
+}
+
+export const createAccountDeleteCommand = createCommandFlexible(
+  'delete',
+  'Delete local account',
+  [
+    accountOptions.accountMultiSelect(),
+    accountOptions.accountDeleteConfirmation(),
+  ],
+  async (option) => {
+    const { account } = await option.account();
+    const { accountDeleteConfirmation } =
+      await option.accountDeleteConfirmation({
+        account,
+      });
+
+    log.debug('delete-account:action', {
+      account,
+      accountDeleteConfirmation,
+    });
+
+    if (accountDeleteConfirmation === false) {
+      log.info(
+        log.color.yellow(
+          `\nThe account alias "${account}" will not be deleted.\n`,
+        ),
+      );
+      return;
+    }
+
+    const [deletedFiles, nonDeletedFiles] = await removeAccount(account);
+
+    if (deletedFiles.length) {
+      log.info(
+        log.color.green(
+          `\nThe account alias "${deletedFiles.join(
+            ', ',
+          )}" file(s) has been deleted.\n`,
+        ),
+      );
+    }
+
+    if (nonDeletedFiles.length) {
+      log.info(
+        log.color.yellow(
+          `\nThe account configuration "${nonDeletedFiles.join(
+            ', ',
+          )}" file(s) does not exist.\n`,
+        ),
+      );
+    }
+  },
+);

--- a/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
@@ -4,6 +4,7 @@ import { services } from '../../services/index.js';
 import { createCommandFlexible } from '../../utils/createCommandFlexible.js';
 import { log } from '../../utils/logger.js';
 import { accountOptions } from '../accountOptions.js';
+import { isEmpty } from '../utils/addHelpers.js';
 
 async function removeAccount(
   accountAlias: string,
@@ -28,27 +29,26 @@ export const createAccountDeleteCommand = createCommandFlexible(
   'Delete local account',
   [
     accountOptions.accountMultiSelect(),
-    accountOptions.accountDeleteConfirmation(),
+    accountOptions.accountDeleteConfirmation({ isOptional: false }),
   ],
   async (option) => {
     const { accountAlias } = await option.accountAlias();
 
-    if (!accountAlias || accountAlias.trim().length === 0) {
-      log.error('Account alias is not provided');
+    if (isEmpty(accountAlias) || accountAlias.trim().length === 0) {
+      log.error('Account alias is not provided or Invalid.');
       return;
     }
 
-    const { accountDeleteConfirmation } =
-      await option.accountDeleteConfirmation({
-        accountAlias,
-      });
+    const { confirm } = await option.confirm({
+      accountAlias,
+    });
 
     log.debug('delete-account:action', {
       accountAlias,
-      accountDeleteConfirmation,
+      confirm,
     });
 
-    if (accountDeleteConfirmation === false) {
+    if (confirm === false) {
       log.info(log.color.yellow(`\nThe account alias will not be deleted.\n`));
       return;
     }

--- a/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
@@ -3,7 +3,7 @@ import { ACCOUNT_DIR } from '../../constants/config.js';
 import { services } from '../../services/index.js';
 import type { CommandResult } from '../../utils/command.util.js';
 import { assertCommandError } from '../../utils/command.util.js';
-import { createCommandFlexible } from '../../utils/createCommandFlexible.js';
+import { createCommand } from '../../utils/createCommand.js';
 import { log } from '../../utils/logger.js';
 import { accountOptions } from '../accountOptions.js';
 import { isEmpty } from '../utils/addHelpers.js';
@@ -38,7 +38,7 @@ async function removeAccount(
   };
 }
 
-export const createAccountDeleteCommand = createCommandFlexible(
+export const createAccountDeleteCommand = createCommand(
   'delete',
   'Delete local account',
   [

--- a/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
@@ -26,8 +26,8 @@ async function removeAccount(
 
   const warnings =
     nonDeletedFiles.length === 1
-      ? `\nThe account alias ${nonDeletedFiles[0]} not exist`
-      : `\nThe following account aliases does not exist:\n${nonDeletedFiles.join(
+      ? `\nThe account alias "${nonDeletedFiles[0]}" does not exist`
+      : `\nThe following account aliases do not exist:\n${nonDeletedFiles.join(
           '\n',
         )}`;
 

--- a/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
@@ -18,7 +18,7 @@ async function deleteAccountDir(): Promise<CommandResult<null>> {
   } catch (error) {
     return {
       success: false,
-      errors: ['Failed to delete all keys'],
+      errors: ['Failed to delete all account aliases.'],
     };
   }
 }
@@ -53,9 +53,14 @@ export const createAccountDeleteCommand = createCommand(
     accountOptions.accountDeleteConfirmation({ isOptional: false }),
   ],
   async (option) => {
-    const { accountAlias } = await option.accountAlias();
+    const { accountAlias, accountAliasConfig } = await option.accountAlias();
 
-    if (isEmpty(accountAlias) || accountAlias.trim().length === 0) {
+    if (!accountAliasConfig) {
+      log.error(`\nAccount alias "${accountAlias}" does not exist.\n`);
+      return;
+    }
+
+    if (isEmpty(accountAlias.trim())) {
       log.error('\nAccount alias is not provided or Invalid.\n');
       return;
     }

--- a/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join, parse } from 'path';
 import { ACCOUNT_DIR } from '../../constants/config.js';
 import { services } from '../../services/index.js';
 import type { CommandResult } from '../../utils/command.util.js';
@@ -10,7 +10,7 @@ import { isEmpty } from '../utils/addHelpers.js';
 
 async function getAllAccountAliases(): Promise<string[]> {
   const files = await services.filesystem.readDir(ACCOUNT_DIR);
-  return files.map((file) => file.replace('.yaml', ''));
+  return files.map((file) => parse(file).name);
 }
 
 async function removeAccount(
@@ -19,9 +19,11 @@ async function removeAccount(
   const deletedFiles = [];
   const nonDeletedFiles = [];
   const aliases =
-    accountAlias === 'all' ? await getAllAccountAliases() : [accountAlias];
+    accountAlias === 'all'
+      ? await getAllAccountAliases()
+      : [accountAlias.trim()];
   for (const alias of aliases) {
-    const filePath = join(ACCOUNT_DIR, `${alias.trim()}.yaml`);
+    const filePath = join(ACCOUNT_DIR, `${alias}.yaml`);
     if (await services.filesystem.fileExists(filePath)) {
       await services.filesystem.deleteFile(filePath);
       deletedFiles.push(alias);
@@ -31,9 +33,7 @@ async function removeAccount(
   }
 
   const warnings =
-    nonDeletedFiles.length === 0
-      ? ''
-      : nonDeletedFiles.length === 1
+    nonDeletedFiles.length === 1
       ? `\nThe account alias "${nonDeletedFiles[0]}" does not exist`
       : `\nThe following account aliases do not exist:\n${nonDeletedFiles.join(
           '\n',
@@ -42,7 +42,7 @@ async function removeAccount(
   return {
     data: deletedFiles,
     success: true,
-    warnings: [warnings],
+    warnings: nonDeletedFiles.length > 0 ? [warnings] : undefined,
   };
 }
 
@@ -57,7 +57,7 @@ export const createAccountDeleteCommand = createCommand(
     const { accountAlias } = await option.accountAlias();
 
     if (isEmpty(accountAlias) || accountAlias.trim().length === 0) {
-      log.error('Account alias is not provided or Invalid.');
+      log.error('\nAccount alias is not provided or Invalid.\n');
       return;
     }
 
@@ -71,16 +71,18 @@ export const createAccountDeleteCommand = createCommand(
     });
 
     if (confirm === false) {
-      log.info(log.color.yellow(`The account alias will not be deleted.`));
+      log.info(log.color.yellow(`\nThe account alias will not be deleted.`));
       return;
     }
 
     const result = await removeAccount(accountAlias);
     assertCommandError(result);
     if (result.data.length > 0) {
-      log.info(
-        log.color.green(`Account alias "${accountAlias}" has been deleted.`),
-      );
+      const deleteSuccessMsg =
+        accountAlias === 'all'
+          ? 'All account aliases has been deleted'
+          : `The selected account alias "${accountAlias}" has been deleted`;
+      log.info(log.color.green(`\n${deleteSuccessMsg}`));
     }
   },
 );

--- a/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
@@ -1,4 +1,4 @@
-import { join, parse } from 'path';
+import { join } from 'path';
 import { ACCOUNT_DIR } from '../../constants/config.js';
 import { services } from '../../services/index.js';
 import type { CommandResult } from '../../utils/command.util.js';
@@ -8,42 +8,41 @@ import { log } from '../../utils/logger.js';
 import { accountOptions } from '../accountOptions.js';
 import { isEmpty } from '../utils/addHelpers.js';
 
-async function getAllAccountAliases(): Promise<string[]> {
-  const files = await services.filesystem.readDir(ACCOUNT_DIR);
-  return files.map((file) => parse(file).name);
+async function deleteAccountDir(): Promise<CommandResult<null>> {
+  try {
+    await services.filesystem.deleteDirectory(ACCOUNT_DIR);
+    return {
+      data: null,
+      success: true,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      errors: ['Failed to delete all keys'],
+    };
+  }
 }
 
 async function removeAccount(
   accountAlias: string,
-): Promise<CommandResult<string[]>> {
-  const deletedFiles = [];
-  const nonDeletedFiles = [];
-  const aliases =
-    accountAlias === 'all'
-      ? await getAllAccountAliases()
-      : [accountAlias.trim()];
-  for (const alias of aliases) {
-    const filePath = join(ACCOUNT_DIR, `${alias}.yaml`);
-    if (await services.filesystem.fileExists(filePath)) {
-      await services.filesystem.deleteFile(filePath);
-      deletedFiles.push(alias);
-    } else {
-      nonDeletedFiles.push(alias);
-    }
+): Promise<CommandResult<null>> {
+  if (accountAlias === 'all') {
+    return await deleteAccountDir();
   }
 
-  const warnings =
-    nonDeletedFiles.length === 1
-      ? `\nThe account alias "${nonDeletedFiles[0]}" does not exist`
-      : `\nThe following account aliases do not exist:\n${nonDeletedFiles.join(
-          '\n',
-        )}`;
-
-  return {
-    data: deletedFiles,
-    success: true,
-    warnings: nonDeletedFiles.length > 0 ? [warnings] : undefined,
-  };
+  const filePath = join(ACCOUNT_DIR, `${accountAlias}.yaml`);
+  if (await services.filesystem.fileExists(filePath)) {
+    await services.filesystem.deleteFile(filePath);
+    return {
+      data: null,
+      success: true,
+    };
+  } else {
+    return {
+      success: false,
+      errors: [`The account alias "${accountAlias}" does not exist`],
+    };
+  }
 }
 
 export const createAccountDeleteCommand = createCommand(
@@ -77,12 +76,10 @@ export const createAccountDeleteCommand = createCommand(
 
     const result = await removeAccount(accountAlias);
     assertCommandError(result);
-    if (result.data.length > 0) {
-      const deleteSuccessMsg =
-        accountAlias === 'all'
-          ? 'All account aliases has been deleted'
-          : `The selected account alias "${accountAlias}" has been deleted`;
-      log.info(log.color.green(`\n${deleteSuccessMsg}`));
-    }
+    const deleteSuccessMsg =
+      accountAlias === 'all'
+        ? 'All account aliases has been deleted'
+        : `The selected account alias "${accountAlias}" has been deleted`;
+    log.info(log.color.green(`\n${deleteSuccessMsg}`));
   },
 );

--- a/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
@@ -13,7 +13,7 @@ async function removeAccount(
   const nonDeletedFiles = [];
   const aliases = accountAlias.split(',');
   for (const alias of aliases) {
-    const filePath = join(ACCOUNT_DIR, alias.trim());
+    const filePath = join(ACCOUNT_DIR, `${alias.trim()}.yaml`);
     if (await services.filesystem.fileExists(filePath)) {
       await services.filesystem.deleteFile(filePath);
       deletedFiles.push(alias);

--- a/packages/tools/kadena-cli/src/account/commands/accountFund.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountFund.ts
@@ -23,7 +23,7 @@ import { fund } from '../utils/fund.js';
 
 /* bin/kadena-cli.js account fund --account="testnet.yaml" --amount="20" --network="testnet" --chain-id="0" */
 
-export const createFundCommand = createCommand(
+export const createAccountFundCommand = createCommand(
   'fund',
   'Fund an existing/new account',
   [

--- a/packages/tools/kadena-cli/src/account/commands/accountList.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountList.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { parse } from 'node:path';
 import { createCommand } from '../../utils/createCommand.js';
 import {
   maskStringPreservingStartAndEnd,
@@ -22,7 +23,7 @@ function generateTabularData(accounts: IAliasAccountData[]): {
   ];
 
   const data = accounts.map((account) => [
-    truncateText(account.alias, 32),
+    truncateText(parse(account.alias).name, 32),
     maskStringPreservingStartAndEnd(account.name, 32),
     account.publicKeys
       .map((key) => maskStringPreservingStartAndEnd(key, 24))

--- a/packages/tools/kadena-cli/src/account/commands/accountResolveAddressToName.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountResolveAddressToName.ts
@@ -36,7 +36,7 @@ export const resolveAddressToName = async (
   }
 };
 
-export const resolveAddressToNameCommand = createCommand(
+export const createResolveAddressToNameCommand = createCommand(
   'address-to-name',
   'Resolve a k:address to a .kda name (kadenanames)',
   [

--- a/packages/tools/kadena-cli/src/account/commands/accountResolveNameToAddress.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountResolveNameToAddress.ts
@@ -35,7 +35,7 @@ export const resolveNameToAddress = async (
   }
 };
 
-export const resolveNameToAddressCommand = createCommand(
+export const createResolveNameToAddressCommand = createCommand(
   'name-to-address',
   'Resolve a .kda name to a k:address (kadenanames)',
   [

--- a/packages/tools/kadena-cli/src/account/index.ts
+++ b/packages/tools/kadena-cli/src/account/index.ts
@@ -4,10 +4,10 @@ import { createAddAccountFromWalletCommand } from './commands/accountAddFromWall
 import { createAddAccountManualCommand } from './commands/accountAddManual.js';
 import { createAccountDeleteCommand } from './commands/accountDelete.js';
 import { createAccountDetailsCommand } from './commands/accountDetails.js';
-import { createFundCommand } from './commands/accountFund.js';
+import { createAccountFundCommand } from './commands/accountFund.js';
 import { createAccountListCommand } from './commands/accountList.js';
-import { resolveAddressToNameCommand } from './commands/accountResolveAddressToName.js';
-import { resolveNameToAddressCommand } from './commands/accountResolveNameToAddress.js';
+import { createResolveAddressToNameCommand } from './commands/accountResolveAddressToName.js';
+import { createResolveNameToAddressCommand } from './commands/accountResolveNameToAddress.js';
 
 const SUBCOMMAND_ROOT: 'account' = 'account';
 
@@ -20,8 +20,8 @@ export function accountCommandFactory(program: Command, version: string): void {
   createAddAccountFromWalletCommand(accountProgram, version);
   createAccountDeleteCommand(accountProgram, version);
   createAccountDetailsCommand(accountProgram, version);
+  createAccountFundCommand(accountProgram, version);
   createAccountListCommand(accountProgram, version);
-  createFundCommand(accountProgram, version);
-  resolveNameToAddressCommand(accountProgram, version);
-  resolveAddressToNameCommand(accountProgram, version);
+  createResolveNameToAddressCommand(accountProgram, version);
+  createResolveAddressToNameCommand(accountProgram, version);
 }

--- a/packages/tools/kadena-cli/src/account/index.ts
+++ b/packages/tools/kadena-cli/src/account/index.ts
@@ -2,6 +2,7 @@ import type { Command } from 'commander';
 
 import { createAddAccountFromWalletCommand } from './commands/accountAddFromWallet.js';
 import { createAddAccountManualCommand } from './commands/accountAddManual.js';
+import { createAccountDeleteCommand } from './commands/accountDelete.js';
 import { createAccountDetailsCommand } from './commands/accountDetails.js';
 import { createFundCommand } from './commands/accountFund.js';
 import { createAccountListCommand } from './commands/accountList.js';
@@ -17,6 +18,7 @@ export function accountCommandFactory(program: Command, version: string): void {
 
   createAddAccountManualCommand(accountProgram, version);
   createAddAccountFromWalletCommand(accountProgram, version);
+  createAccountDeleteCommand(accountProgram, version);
   createAccountDetailsCommand(accountProgram, version);
   createAccountListCommand(accountProgram, version);
   createFundCommand(accountProgram, version);

--- a/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
+++ b/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
@@ -1,6 +1,6 @@
 import yaml from 'js-yaml';
 import { readdirSync } from 'node:fs';
-import { basename, extname, join } from 'node:path';
+import { extname, join } from 'node:path';
 import type { ZodError, ZodIssue } from 'zod';
 import { z } from 'zod';
 import type { IAliasAccountData } from './../types.js';

--- a/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
+++ b/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
@@ -1,6 +1,6 @@
 import yaml from 'js-yaml';
 import { readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, extname, join } from 'node:path';
 import type { ZodError, ZodIssue } from 'zod';
 import { z } from 'zod';
 import type { IAliasAccountData } from './../types.js';
@@ -32,7 +32,11 @@ export const formatZodErrors = (errors: ZodError): string => {
 export const readAccountFromFile = async (
   accountFile: string,
 ): Promise<IAliasAccountData> => {
-  const filePath = join(ACCOUNT_DIR, accountFile);
+  const ext = extname(accountFile);
+  const fileWithExt =
+    !ext || ext !== '.yaml' ? `${accountFile}.yaml` : accountFile;
+  const filePath = join(ACCOUNT_DIR, fileWithExt);
+
   if (!(await services.filesystem.fileExists(filePath))) {
     throw new Error(`Account alias "${accountFile}" file not exist`);
   }
@@ -43,7 +47,7 @@ export const readAccountFromFile = async (
     const parsedContent = accountAliasFileSchema.parse(account);
     return {
       ...parsedContent,
-      alias: accountFile,
+      alias: fileWithExt,
     };
   } catch (error) {
     if (isEmpty(content)) {

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -204,7 +204,7 @@ export const accountSelectPrompt: IPrompt<string> = async (
 
 export const accountSelectAllPrompt: IPrompt<string> = async () => {
   return accountSelectionPrompt(['all']);
-}
+};
 
 export const accountSelectMultiplePrompt: IPrompt<string> = async (
   previousQuestions,
@@ -246,14 +246,17 @@ export const accountDeleteConfirmationPrompt: IPrompt<boolean> = async (
   args,
   isOptional,
 ) => {
-  const selectedAccounts = previousQuestions.account ?? undefined;
+  const selectedAccounts = previousQuestions.accountAlias as string;
 
-  if (selectedAccounts === 0) {
-    throw new Error('No accounts selected');
-  }
+  const selectedAccountsLength = selectedAccounts.split(',').length;
+
+  const selectedAccountMessage =
+    selectedAccountsLength > 1
+      ? 'all the selected aliases accounts'
+      : `the ${previousQuestions.account} alias account`;
 
   return await select({
-    message: `Are you sure you want to delete the ${selectedAccounts} alias account?`,
+    message: `Are you sure you want to delete ${selectedAccountMessage}?`,
     choices: [
       {
         value: true,

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -150,7 +150,7 @@ export const accountSelectionPrompt = async (
     const maxLength = maxAliasLength < 25 ? maxAliasLength : 25;
     const paddedAlias = aliasWithoutExtension.padEnd(maxLength, ' ');
     return {
-      value: alias,
+      value: aliasWithoutExtension,
       name: `${truncateText(
         paddedAlias,
         25,
@@ -225,7 +225,7 @@ export const accountSelectMultiplePrompt: IPrompt<string> = async (
     const maxLength = maxAliasLength < 25 ? maxAliasLength : 25;
     const paddedAlias = aliasWithoutExtension.padEnd(maxLength, ' ');
     return {
-      value: alias,
+      value: aliasWithoutExtension,
       name: `${truncateText(
         paddedAlias,
         25,

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -238,7 +238,9 @@ export const accountDeleteConfirmationPrompt: IPrompt<boolean> = async (
   const selectedAccountsLength = selectedAccounts.split(',').length;
 
   const selectedAccountMessage =
-    selectedAccountsLength > 1
+    previousQuestions.accountAlias === 'all'
+      ? 'all the accounts'
+      : selectedAccountsLength > 1
       ? 'all the selected aliases accounts'
       : `the ${selectedAccounts} alias account`;
 

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -253,7 +253,7 @@ export const accountDeleteConfirmationPrompt: IPrompt<boolean> = async (
   const selectedAccountMessage =
     selectedAccountsLength > 1
       ? 'all the selected aliases accounts'
-      : `the ${previousQuestions.account} alias account`;
+      : `the ${selectedAccounts} alias account`;
 
   return await select({
     message: `Are you sure you want to delete ${selectedAccountMessage}?`,


### PR DESCRIPTION
https://app.asana.com/0/1205969628270714/1206634146772872/f

`kadena account delete` sub command 

User can select multiple accounts from the list of aliases

Example commands:

Single alias
`kadena account delete --account-alias="devnet_account" --confirm`

All alias 
`kadena account delete --account-alias="all" --confirm`

~Multiple aliases:~

~`kadena account delete --account-alias="devnet_account,testnet_account" --confirm`~

removed multiple aliases to align with other commands delete option