### PR TITLE
fix(client): parse as pact value for objects and arrays

### DIFF
--- a/.changeset/fast-humans-admire.md
+++ b/.changeset/fast-humans-admire.md
@@ -1,0 +1,5 @@
+---
+'@kadena/client': patch
+---
+
+Fix parse objects and arrays to pact values

--- a/.changeset/many-crabs-smash.md
+++ b/.changeset/many-crabs-smash.md
@@ -1,0 +1,7 @@
+---
+'@kadena/client-utils': patch
+'@kadena/client': patch
+'@kadena/types': patch
+---
+
+Add Record<string,any> to PactValue type

--- a/packages/libs/client-utils/etc/client-utils-coin.api.md
+++ b/packages/libs/client-utils/etc/client-utils-coin.api.md
@@ -85,7 +85,7 @@ data: ITransactionDescriptor;
 }, {
 event: "listen";
 data: ICommandResult;
-}], [], Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<object> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]>>;
+}], [], Promise<string> | Promise<undefined> | Promise<number> | Promise<false> | Promise<true> | Promise<IPactInt> | Promise<IPactDecimal> | Promise<Date> | Promise<PactValue[]> | Promise<Record<string, any>>>;
 
 // @alpha (undocumented)
 export const safeTransferCommand: ({ sender, receiver, amount, gasPayer, chainId, contract, }: ISafeTransferInput) => (cmd?: (Partial<IPartialPactCommand> | (() => Partial<IPartialPactCommand>)) | undefined) => Partial<IPartialPactCommand>;

--- a/packages/libs/client/src/tests/utils.test.ts
+++ b/packages/libs/client/src/tests/utils.test.ts
@@ -17,7 +17,7 @@ describe('parseType', () => {
   it('returns the input argument if it is neither an object, number, string, nor function', () => {
     const arg = true;
     const result = parseAsPactValue(arg);
-    expect(result).toBe(true);
+    expect(result).toBe('true');
   });
 
   it('wraps string input in double quotes', () => {

--- a/packages/libs/client/src/utils/pact-helpers.ts
+++ b/packages/libs/client/src/utils/pact-helpers.ts
@@ -58,6 +58,7 @@ export const literal = (value: string): Literal => {
 };
 
 const literalRegex: RegExp = /"Literal\(([^\)]*)\)"/gi;
+const literalRegexWithoutQuote: RegExp = /Literal\(([^\)]*)\)/gi;
 /**
  * unpack all of the Literal(string) to string
  * @internal
@@ -65,7 +66,9 @@ const literalRegex: RegExp = /"Literal\(([^\)]*)\)"/gi;
 export function unpackLiterals(value: string): string {
   // literal object is already unpacked if they are direct argument of a function.
   // but if they are inside a json object, they are not unpacked since the toJSON method packs them as Literal(string)
-  return value.replace(literalRegex, (__, literal) => literal);
+  return value
+    .replace(literalRegex, (__, literal) => literal)
+    .replace(literalRegexWithoutQuote, (__, literal) => literal);
 }
 
 /**

--- a/packages/libs/client/src/utils/pact-helpers.ts
+++ b/packages/libs/client/src/utils/pact-helpers.ts
@@ -58,7 +58,6 @@ export const literal = (value: string): Literal => {
 };
 
 const literalRegex: RegExp = /"Literal\(([^\)]*)\)"/gi;
-const literalRegexWithoutQuote: RegExp = /Literal\(([^\)]*)\)/gi;
 /**
  * unpack all of the Literal(string) to string
  * @internal
@@ -66,9 +65,7 @@ const literalRegexWithoutQuote: RegExp = /Literal\(([^\)]*)\)/gi;
 export function unpackLiterals(value: string): string {
   // literal object is already unpacked if they are direct argument of a function.
   // but if they are inside a json object, they are not unpacked since the toJSON method packs them as Literal(string)
-  return value
-    .replace(literalRegex, (__, literal) => literal)
-    .replace(literalRegexWithoutQuote, (__, literal) => literal);
+  return value.replace(literalRegex, (__, literal) => literal);
 }
 
 /**

--- a/packages/libs/client/src/utils/parseAsPactValue.ts
+++ b/packages/libs/client/src/utils/parseAsPactValue.ts
@@ -19,10 +19,10 @@ export function parseAsPactValue(
   switch (typeof input) {
     case 'object': {
       if ('decimal' in input) {
-        return new PactNumber(input.decimal).toDecimal();
+        return new PactNumber(input.decimal as string).toDecimal();
       }
       if ('int' in input) {
-        return new PactNumber(input.int).toInteger();
+        return new PactNumber(input.int as string).toInteger();
       }
       if (isDate(input)) {
         const isoTime = `${input.toISOString().split('.')[0]}Z`;
@@ -33,7 +33,9 @@ export function parseAsPactValue(
       }
 
       return `{${Object.entries(input)
-        .map(([key, value]) => `"${key}": ${parseAsPactValue(value)}`)
+        .map(
+          ([key, value]) => `"${key}": ${parseAsPactValue(value as PactValue)}`,
+        )
         .join(', ')}}`;
     }
     case 'number':

--- a/packages/libs/client/src/utils/parseAsPactValue.ts
+++ b/packages/libs/client/src/utils/parseAsPactValue.ts
@@ -14,7 +14,7 @@ export function parseAsPactValue(
   input: PactValue | (() => string) | Literal,
 ): string {
   if (input instanceof Literal) {
-    return input.toJSON();
+    return input.getValue();
   }
   switch (typeof input) {
     case 'object': {

--- a/packages/libs/client/src/utils/tests/createTransaction.test.ts
+++ b/packages/libs/client/src/utils/tests/createTransaction.test.ts
@@ -75,8 +75,8 @@ describe('createTransaction', () => {
       .setNonce('nonce:1')
       .createTransaction();
     expect(command).toEqual({
-      cmd: '{"payload":{"exec":{"code":"(test.test-fun \\"bob\\" \\"alice\\" guard {\\"test\\":{\\"modules\\":[coin,free.coin]}} 12.0)","data":{}}},"nonce":"nonce:1","signers":[]}',
-      hash: 'Xm1CjhIcGSO7wUxKiLZxyuFi_DuOexD0eq44QW_BRjI',
+      cmd: '{"payload":{"exec":{"code":"(test.test-fun \\"bob\\" \\"alice\\" guard {\\"test\\": {\\"modules\\": [coin free.coin]}} 12.0)","data":{}}},"nonce":"nonce:1","signers":[]}',
+      hash: 'x_3osDNKNpusk2LScpEUwkm8wo0h_G7OXL03rQMYnUE',
       sigs: [],
     });
   });

--- a/packages/libs/client/src/utils/tests/parseAsPactValue.test.ts
+++ b/packages/libs/client/src/utils/tests/parseAsPactValue.test.ts
@@ -45,19 +45,55 @@ describe('parseType', () => {
     expect(parseAsPactValue(() => 'test')).toEqual('test');
   });
 
-  it('returns stringified arg, if its an object', () => {
+  it('parse object', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(parseAsPactValue({ test: 'test' } as any)).toBe(
-      JSON.stringify({ test: 'test' }),
+    expect(parseAsPactValue({ test: { decimal: '2' } } as any)).toEqual(
+      '{"test": 2.0}',
     );
   });
 
-  it('returns arg, if its a boolean', () => {
-    expect(parseAsPactValue(true)).toEqual(true);
+  it('return "true" or "false", if its a boolean', () => {
+    expect(parseAsPactValue(true)).toEqual('true');
+    expect(parseAsPactValue(false)).toEqual('false');
   });
 
   it("returns input, if it doesn't match with any conditions", () => {
     const symbol = Symbol('test');
     expect(parseAsPactValue(symbol as never)).toEqual(symbol);
+  });
+
+  // it('parses an nested object with nested pact values', () => {});
+  it('parses an array with nested pact values', () => {
+    const start = new Date('2023-07-20T14:55:11.139Z');
+    expect(
+      parseAsPactValue([start, start, { decimal: '1' }, { int: '1' }]),
+    ).toEqual(
+      '[(time "2023-07-20T14:55:11Z") (time "2023-07-20T14:55:11Z") 1.0 1]',
+    );
+  });
+
+  it('parses an object with nested pact values', () => {
+    const start = new Date('2023-07-20T14:55:11.139Z');
+    expect(
+      parseAsPactValue({
+        object: {
+          start,
+          end: start,
+          test: { x: { decimal: '1' }, y: { int: '1' } },
+        },
+        simpleArray: [{ decimal: '1' }, { int: '1' }],
+        arrayOfObject: [
+          {
+            time: {
+              start,
+              end: start,
+              test: { x: { decimal: '1' }, y: { int: '1' } },
+            },
+          },
+        ],
+      }),
+    ).toEqual(
+      '{"object": {"start": (time "2023-07-20T14:55:11Z"), "end": (time "2023-07-20T14:55:11Z"), "test": {"x": 1.0, "y": 1}}, "simpleArray": [1.0 1], "arrayOfObject": [{"time": {"start": (time "2023-07-20T14:55:11Z"), "end": (time "2023-07-20T14:55:11Z"), "test": {"x": 1.0, "y": 1}}}]}',
+    );
   });
 });

--- a/packages/libs/types/etc/types.api.md
+++ b/packages/libs/types/etc/types.api.md
@@ -248,7 +248,7 @@ export type Nonce = string;
 export type PactCode = string;
 
 // @alpha
-export type PactLiteral = string | number | IPactInt | IPactDecimal | boolean | Date | object;
+export type PactLiteral = string | number | IPactInt | IPactDecimal | boolean | Date;
 
 // @alpha
 export type PactPayload = {
@@ -261,7 +261,7 @@ export type PactPayload = {
 export type PactTransactionHash = IBase64Url;
 
 // @alpha
-export type PactValue = PactLiteral | Array<PactValue>;
+export type PactValue = PactLiteral | Array<PactValue> | Record<string, any>;
 
 // @alpha (undocumented)
 export type Proof = IBase64Url | undefined;

--- a/packages/libs/types/etc/types.api.md
+++ b/packages/libs/types/etc/types.api.md
@@ -261,9 +261,7 @@ export type PactPayload = {
 export type PactTransactionHash = IBase64Url;
 
 // @alpha
-export type PactValue = PactLiteral | Array<PactValue> | {
-    [Key: string]: PactValue;
-};
+export type PactValue = PactLiteral | Array<PactValue> | Record<string, any>;
 
 // @alpha (undocumented)
 export type Proof = IBase64Url | undefined;

--- a/packages/libs/types/etc/types.api.md
+++ b/packages/libs/types/etc/types.api.md
@@ -261,7 +261,7 @@ export type PactPayload = {
 export type PactTransactionHash = IBase64Url;
 
 // @alpha
-export type PactValue = PactLiteral | Array<PactValue> | Record<string, any>;
+export type PactValue = PactLiteral | Array<PactValue> | Record<string, unknown>;
 
 // @alpha (undocumented)
 export type Proof = IBase64Url | undefined;

--- a/packages/libs/types/etc/types.api.md
+++ b/packages/libs/types/etc/types.api.md
@@ -261,7 +261,9 @@ export type PactPayload = {
 export type PactTransactionHash = IBase64Url;
 
 // @alpha
-export type PactValue = PactLiteral | Array<PactValue> | Record<string, unknown>;
+export type PactValue = PactLiteral | Array<PactValue> | {
+    [Key: string]: PactValue;
+};
 
 // @alpha (undocumented)
 export type Proof = IBase64Url | undefined;

--- a/packages/libs/types/src/PactValue.ts
+++ b/packages/libs/types/src/PactValue.ts
@@ -66,4 +66,4 @@ export type PactLiteral =
 export type PactValue =
   | PactLiteral
   | Array<PactValue>
-  | Record<string, unknown>;
+  | { [Key: string]: PactValue };

--- a/packages/libs/types/src/PactValue.ts
+++ b/packages/libs/types/src/PactValue.ts
@@ -47,8 +47,7 @@ export type PactLiteral =
   | IPactInt
   | IPactDecimal
   | boolean
-  | Date
-  | object;
+  | Date;
 
 /**
  * A sum type representing a `pact` value.
@@ -64,4 +63,7 @@ export type PactLiteral =
  * TODO: add module reference type type.
  * @alpha
  */
-export type PactValue = PactLiteral | Array<PactValue>;
+export type PactValue =
+  | PactLiteral
+  | Array<PactValue>
+  | Record<string, unknown>;

--- a/packages/libs/types/src/PactValue.ts
+++ b/packages/libs/types/src/PactValue.ts
@@ -63,7 +63,4 @@ export type PactLiteral =
  * TODO: add module reference type type.
  * @alpha
  */
-export type PactValue =
-  | PactLiteral
-  | Array<PactValue>
-  | { [Key: string]: PactValue };
+export type PactValue = PactLiteral | Array<PactValue> | Record<string, any>;


### PR DESCRIPTION
This PR fixes the issue with generating pact expression when the arguments are arrays or objects

