### PR TITLE
[@tools-website] Fix: account name is reset on submitting form on Faucet

### DIFF
--- a/packages/apps/tools/src/pages/faucet/new/index.tsx
+++ b/packages/apps/tools/src/pages/faucet/new/index.tsx
@@ -132,6 +132,7 @@ const NewAccountFaucetPage: FC = () => {
     setError,
     getValues,
     resetField,
+    reset,
     control,
     setValue,
   } = useForm<FormData>({
@@ -212,6 +213,7 @@ const NewAccountFaucetPage: FC = () => {
       }
 
       setRequestStatus({ status: 'processing' });
+      reset(undefined, { keepDirtyValues: true });
       setRequestKey('');
       try {
         const submitResponse = (await fundCreateNewAccount(
@@ -270,7 +272,7 @@ const NewAccountFaucetPage: FC = () => {
         setRequestStatus({ status: 'erroneous', message });
       }
     },
-    [chainID, networksData, pred, pubKeys, selectedNetwork, setError, t],
+    [chainID, networksData, pred, pubKeys, selectedNetwork, reset, setError, t],
   );
 
   const mainnetSelected: boolean = selectedNetwork === 'mainnet01';


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->
