### PR TITLE
refactor(cli): move errors from helper to action

### DIFF
--- a/packages/tools/kadena-cli/src/account/accountOptions.ts
+++ b/packages/tools/kadena-cli/src/account/accountOptions.ts
@@ -80,23 +80,6 @@ export const accountOptions = {
       '-a, --account-alias <account>',
       'Enter your account alias file',
     ),
-    expand: async (
-      accountAlias: string,
-    ): Promise<IAliasAccountData | undefined> => {
-      try {
-        if (accountAlias === 'all') {
-          return;
-        }
-
-        const accountDetails = await readAccountFromFile(accountAlias);
-        return accountDetails;
-      } catch (error) {
-        if (error.message.includes('file not exist') === true) {
-          return;
-        }
-        throw new Error(error.message);
-      }
-    },
   }),
   accountMultiSelect: createOption({
     key: 'accountAlias' as const,

--- a/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDelete.ts
@@ -8,7 +8,7 @@ import { createCommand } from '../../utils/createCommand.js';
 import { isNotEmptyString } from '../../utils/helpers.js';
 import { log } from '../../utils/logger.js';
 import { accountOptions } from '../accountOptions.js';
-import { getAllAccounts } from '../utils/accountHelpers.js';
+import { ensureAccountAliasFilesExists } from '../utils/accountHelpers.js';
 
 async function deleteAccountDir(): Promise<CommandResult<null>> {
   try {
@@ -55,14 +55,12 @@ export const createAccountDeleteCommand = createCommand(
     accountOptions.accountDeleteConfirmation({ isOptional: false }),
   ],
   async (option) => {
-    const allAccounts = await getAllAccounts();
-    if (allAccounts.length === 0) {
+    const isAccountAliasesExist = await ensureAccountAliasFilesExists();
+    if (!isAccountAliasesExist) {
       return log.error(NO_ACCOUNTS_FOUND_ERROR_MESSAGE);
     }
 
-    const { accountAlias } = await option.accountAlias({
-      accounts: allAccounts,
-    });
+    const { accountAlias } = await option.accountAlias();
 
     if (!isNotEmptyString(accountAlias.trim())) {
       return log.error('\nAccount alias is not provided or invalid.\n');

--- a/packages/tools/kadena-cli/src/account/commands/accountDetails.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDetails.ts
@@ -1,4 +1,3 @@
-import { NO_ACCOUNTS_FOUND_ERROR_MESSAGE } from '../../constants/account.js';
 import type { CommandResult } from '../../utils/command.util.js';
 import { assertCommandError } from '../../utils/command.util.js';
 import { createCommand } from '../../utils/createCommand.js';
@@ -7,7 +6,6 @@ import { maskStringPreservingStartAndEnd } from '../../utils/helpers.js';
 import { log } from '../../utils/logger.js';
 import { accountOptions } from '../accountOptions.js';
 import type { IAccountDetailsResult } from '../types.js';
-import { getAllAccounts } from '../utils/accountHelpers.js';
 import type { IGetAccountDetailsParams } from '../utils/getAccountDetails.js';
 import { getAccountDetailsFromChain } from '../utils/getAccountDetails.js';
 
@@ -65,13 +63,7 @@ export const createAccountDetailsCommand = createCommand(
     globalOptions.fungible({ isOptional: true }),
   ],
   async (option) => {
-    const allAccounts = await getAllAccounts();
-    if (allAccounts.length === 0) {
-      return log.error(NO_ACCOUNTS_FOUND_ERROR_MESSAGE);
-    }
-
     const { account, accountConfig } = await option.account({
-      accounts: allAccounts,
       isAllowManualInput: true,
     });
 

--- a/packages/tools/kadena-cli/src/account/commands/accountFund.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountFund.ts
@@ -9,9 +9,11 @@ import ora from 'ora';
 import { assertCommandError } from '../../utils/command.util.js';
 import { createCommand } from '../../utils/createCommand.js';
 // import { createOption } from '../../utils/createOption.js';
+import { NO_ACCOUNTS_FOUND_ERROR_MESSAGE } from '../../constants/account.js';
 import { globalOptions } from '../../utils/globalOptions.js';
 import { log } from '../../utils/logger.js';
 import { accountOptions } from '../accountOptions.js';
+import { getAllAccounts } from '../utils/accountHelpers.js';
 import { fund } from '../utils/fund.js';
 
 // const deployDevnet = createOption({
@@ -34,6 +36,11 @@ export const createAccountFundCommand = createCommand(
     // deployDevnet(),
   ],
   async (option) => {
+    const allAccounts = await getAllAccounts();
+    if (allAccounts.length === 0) {
+      return log.error(NO_ACCOUNTS_FOUND_ERROR_MESSAGE);
+    }
+
     const { account, accountConfig } = await option.account();
     const { amount } = await option.amount();
     const { network, networkConfig } = await option.network({

--- a/packages/tools/kadena-cli/src/account/commands/accountFund.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountFund.ts
@@ -13,7 +13,7 @@ import { NO_ACCOUNTS_FOUND_ERROR_MESSAGE } from '../../constants/account.js';
 import { globalOptions } from '../../utils/globalOptions.js';
 import { log } from '../../utils/logger.js';
 import { accountOptions } from '../accountOptions.js';
-import { getAllAccounts } from '../utils/accountHelpers.js';
+import { ensureAccountAliasFilesExists } from '../utils/accountHelpers.js';
 import { fund } from '../utils/fund.js';
 
 // const deployDevnet = createOption({
@@ -36,8 +36,9 @@ export const createAccountFundCommand = createCommand(
     // deployDevnet(),
   ],
   async (option) => {
-    const allAccounts = await getAllAccounts();
-    if (allAccounts.length === 0) {
+    const isAccountAliasesExist = await ensureAccountAliasFilesExists();
+
+    if (!isAccountAliasesExist) {
       return log.error(NO_ACCOUNTS_FOUND_ERROR_MESSAGE);
     }
 

--- a/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
+++ b/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
@@ -4,7 +4,6 @@ import type { ZodError, ZodIssue } from 'zod';
 import { z } from 'zod';
 import type { IAliasAccountData } from './../types.js';
 
-import { NO_ACCOUNTS_FOUND_ERROR_MESSAGE } from '../../constants/account.js';
 import { ACCOUNT_DIR } from '../../constants/config.js';
 import { services } from '../../services/index.js';
 import { notEmpty } from '../../utils/helpers.js';
@@ -60,14 +59,22 @@ export const readAccountFromFile = async (
   }
 };
 
-export async function ensureAccountExists(): Promise<void> {
-  if (!(await services.filesystem.directoryExists(ACCOUNT_DIR))) {
-    throw new Error(NO_ACCOUNTS_FOUND_ERROR_MESSAGE);
+export async function ensureAccountAliasDirectoryExists(): Promise<boolean> {
+  return await services.filesystem.directoryExists(ACCOUNT_DIR);
+}
+
+export async function ensureAccountAliasFilesExists(): Promise<boolean> {
+  if (!(await ensureAccountAliasDirectoryExists())) {
+    return false;
   }
+
+  const files = await services.filesystem.readDir(ACCOUNT_DIR);
+
+  return files.length > 0;
 }
 
 export async function getAllAccounts(): Promise<IAliasAccountData[]> {
-  if (!(await services.filesystem.directoryExists(ACCOUNT_DIR))) {
+  if (!(await ensureAccountAliasDirectoryExists())) {
     return [];
   }
 

--- a/packages/tools/kadena-cli/src/constants/account.ts
+++ b/packages/tools/kadena-cli/src/constants/account.ts
@@ -13,5 +13,5 @@ export const NAMESPACES_MAP: { [key: string]: string } = {
   testnet04: NAMESPACES.TEST_NET,
 };
 
-export const NO_ACCOUNT_ERROR_MESSAGE =
-  'No valid accounts found. To create an account use `account add-manual` or `account add-from-wallet` command.';
+export const NO_ACCOUNTS_FOUND_ERROR_MESSAGE =
+  'No account aliases found. To add an account use `account add-manual` or `account add-from-wallet` command.';


### PR DESCRIPTION
- Removed the directory not exists error from `getAllAccounts` helper method and moved to specific actions. Because this was making an prompt to thrown an error.
- Made account details output as tabular data