### PR TITLE
fix(cli): networks empty + tx list on unsigned

### DIFF
--- a/packages/tools/kadena-cli/src/prompts/network.ts
+++ b/packages/tools/kadena-cli/src/prompts/network.ts
@@ -185,7 +185,12 @@ export const networkSelectOnlyPrompt: IPrompt<string> = async (
   args,
   isOptional,
 ) => {
-  if ((await services.filesystem.readDir(defaultNetworksPath)).length === 0) {
+  const isNetworksFolderExists =
+    await services.filesystem.directoryExists(defaultNetworksPath);
+  if (
+    !isNetworksFolderExists ||
+    (await services.filesystem.readDir(defaultNetworksPath)).length === 0
+  ) {
     await ensureNetworksConfiguration();
   }
 

--- a/packages/tools/kadena-cli/src/prompts/tx.ts
+++ b/packages/tools/kadena-cli/src/prompts/tx.ts
@@ -23,7 +23,7 @@ const ISignatureJsonSchema = z.object({
   sig: z.string(),
 });
 
-const SignatureOrUndefinedOrNull = z.union([
+export const SignatureOrUndefinedOrNull = z.union([
   ISignatureJsonSchema,
   z.undefined(),
   z.null(),

--- a/packages/tools/kadena-cli/src/tx/commands/txList.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txList.ts
@@ -14,7 +14,11 @@ export const createTxListCommand: (program: Command, version: string) => void =
       log.debug('list-tx:action');
 
       const { directory } = await option.directory();
-      const transactions: string[] = await getTransactions(false, directory);
+      const transactions: string[] = await getTransactions(
+        false,
+        directory,
+        true,
+      );
 
       transactions.sort((a, b) => {
         const aIsSigned = a.includes('-signed') ? 1 : -1;


### PR DESCRIPTION
- Ensure networks configuration for non-existent networks directory or networks directory empty
- List only unsigned transactions on - `tx sign`