### PR TITLE
[@kadena/graph] Dynamic Network Id (Feat)

### DIFF
--- a/.changeset/nasty-onions-think.md
+++ b/.changeset/nasty-onions-think.md
@@ -1,0 +1,5 @@
+---
+'@kadena/graph': patch
+---
+
+Fetch network id from /info instead of getting it fron environment variables

--- a/packages/apps/graph/src/graph/builder.ts
+++ b/packages/apps/graph/src/graph/builder.ts
@@ -57,6 +57,7 @@ interface IDefaultTypesExtension {
 export interface IContext {
   req: IncomingMessage;
   extensions: any;
+  networkId: string;
 }
 
 export const PRISMA = {

--- a/packages/apps/graph/src/graph/objects/transaction.ts
+++ b/packages/apps/graph/src/graph/objects/transaction.ts
@@ -1,7 +1,6 @@
 import { prismaClient } from '@db/prisma-client';
 import { Prisma } from '@prisma/client';
 import { COMPLEXITY } from '@services/complexity';
-import { dotenv } from '@utils/dotenv';
 import { normalizeError } from '@utils/errors';
 import { PRISMA, builder } from '../builder';
 import TransactionCommand from './transaction-command';
@@ -34,7 +33,7 @@ export default builder.prismaNode(Prisma.ModelName.Transaction, {
         code: true,
         requestKey: true,
       },
-      async resolve(parent) {
+      async resolve(parent, __arguments, context) {
         try {
           const signers = await prismaClient.signer.findMany({
             where: {
@@ -62,7 +61,7 @@ export default builder.prismaNode(Prisma.ModelName.Transaction, {
               proof: parent.proof,
             },
             signers,
-            networkId: dotenv.NETWORK_ID,
+            networkId: context.networkId,
           };
         } catch (error) {
           throw normalizeError(error);

--- a/packages/apps/graph/src/index.ts
+++ b/packages/apps/graph/src/index.ts
@@ -11,7 +11,7 @@ moduleAlias.addAliases({
 
 import { runSystemsCheck } from '@services/systems-check';
 import { dotenv } from '@utils/dotenv';
-import { getNetworkId } from '@utils/get-network-id';
+import { NetworkConfig } from '@utils/network';
 import { useServer } from 'graphql-ws/lib/use/ws';
 import { createYoga } from 'graphql-yoga';
 import 'json-bigint-patch';
@@ -32,6 +32,8 @@ const schema = builder.toSchema();
 
 const plugins = [extensionsPlugin()];
 
+export const networkConfig = NetworkConfig.create(dotenv.NETWORK_HOST);
+
 if (dotenv.COMPLEXITY_EXPOSED) {
   plugins.push(complexityPlugin(schema));
 }
@@ -45,7 +47,7 @@ const yogaApp = createYoga({
   context: async () => {
     return {
       extensions: {},
-      networkId: await getNetworkId(dotenv.NETWORK_HOST),
+      networkId: (await networkConfig).networkId,
     };
   },
 });
@@ -96,7 +98,7 @@ httpServer.on('connection', (socket) => {
   httpServer.once('close', () => sockets.delete(socket));
 });
 
-runSystemsCheck()
+runSystemsCheck(networkConfig)
   .then(() => {
     httpServer.listen(dotenv.PORT, () => {
       console.info(

--- a/packages/apps/graph/src/index.ts
+++ b/packages/apps/graph/src/index.ts
@@ -11,6 +11,7 @@ moduleAlias.addAliases({
 
 import { runSystemsCheck } from '@services/systems-check';
 import { dotenv } from '@utils/dotenv';
+import { getNetworkId } from '@utils/get-network-id';
 import { useServer } from 'graphql-ws/lib/use/ws';
 import { createYoga } from 'graphql-yoga';
 import 'json-bigint-patch';
@@ -41,9 +42,10 @@ const yogaApp = createYoga({
   graphiql: {
     subscriptionsProtocol: 'WS',
   },
-  context: () => {
+  context: async () => {
     return {
       extensions: {},
+      networkId: await getNetworkId(dotenv.NETWORK_HOST),
     };
   },
 });

--- a/packages/apps/graph/src/services/chainweb-node/account-details.ts
+++ b/packages/apps/graph/src/services/chainweb-node/account-details.ts
@@ -1,6 +1,7 @@
 import { details } from '@kadena/client-utils/coin';
 import type { ChainId } from '@kadena/types';
 import { dotenv } from '@utils/dotenv';
+import { networkConfig } from '../..';
 import type { Guard } from '../../graph/types/graphql-types';
 import { PactCommandError } from './utils';
 
@@ -20,10 +21,12 @@ export async function getAccountDetails(
   chainId: string,
 ): Promise<FungibleChainAccountDetails | null> {
   let result;
+  const networkId = (await networkConfig).networkId;
+
   try {
     result = (await details(
       accountName,
-      dotenv.NETWORK_ID,
+      networkId,
       chainId as ChainId,
       dotenv.NETWORK_HOST,
       fungibleName,

--- a/packages/apps/graph/src/services/chainweb-node/estimate-gas-limit.ts
+++ b/packages/apps/graph/src/services/chainweb-node/estimate-gas-limit.ts
@@ -3,6 +3,7 @@ import { createClient, createTransaction } from '@kadena/client';
 import { composePactCommand } from '@kadena/client/fp';
 import { hash as hashFunction } from '@kadena/cryptography-utils';
 import { dotenv } from '@utils/dotenv';
+import { networkConfig } from '../..';
 import type { GasLimitEstimation } from '../../graph/types/graphql-types';
 
 export class GasLimitEstimationError extends Error {
@@ -153,6 +154,8 @@ export const estimateGasLimit = async (
   const paredInput = jsonParseInput(rawInput);
   const input = determineInputType(paredInput);
 
+  const networkId = input.networkId || (await networkConfig).networkId;
+
   const returnValue: GasLimitEstimation = {
     amount: 0,
     inputType: input.type,
@@ -185,7 +188,7 @@ export const estimateGasLimit = async (
           { payload: input.payload },
           { meta: input.meta },
           { signers: input.signers },
-          { networkId: input.networkId || dotenv.NETWORK_ID },
+          { networkId },
         )(),
       );
       break;
@@ -199,7 +202,7 @@ export const estimateGasLimit = async (
           { payload: input.payload },
           { meta: input.meta },
           { signers: input.signers },
-          { networkId: input.networkId || dotenv.NETWORK_ID },
+          { networkId },
         )(),
       );
       break;
@@ -240,9 +243,7 @@ export const estimateGasLimit = async (
   try {
     const result = await createClient(
       ({ chainId }) =>
-        `${dotenv.NETWORK_HOST}/chainweb/0.0/${
-          input.networkId || dotenv.NETWORK_ID
-        }/chain/${chainId}/pact`,
+        `${dotenv.NETWORK_HOST}/chainweb/0.0/${networkId}/chain/${chainId}/pact`,
     ).local(transaction, configuration);
 
     returnValue.amount = result.gas;

--- a/packages/apps/graph/src/services/chainweb-node/raw-query.ts
+++ b/packages/apps/graph/src/services/chainweb-node/raw-query.ts
@@ -1,6 +1,7 @@
 import { dirtyReadClient } from '@kadena/client-utils/core';
 import type { ChainId } from '@kadena/types';
 import { dotenv } from '@utils/dotenv';
+import { networkConfig } from '../..';
 import type { CommandData } from './utils';
 import { PactCommandError } from './utils';
 
@@ -10,11 +11,13 @@ export async function sendRawQuery(
   data?: CommandData[],
 ): Promise<string> {
   let result;
+  const networkId = (await networkConfig).networkId;
+
   try {
     result = await dirtyReadClient({
       host: dotenv.NETWORK_HOST,
       defaults: {
-        networkId: dotenv.NETWORK_ID,
+        networkId: networkId,
         meta: { chainId: chainId as ChainId },
         payload: {
           exec: {

--- a/packages/apps/graph/src/services/systems-check.ts
+++ b/packages/apps/graph/src/services/systems-check.ts
@@ -3,11 +3,14 @@ import { createClient, createTransaction } from '@kadena/client';
 import { composePactCommand } from '@kadena/client/fp';
 import { Prisma } from '@prisma/client';
 import { dotenv } from '@utils/dotenv';
+import type { NetworkConfig } from '@utils/network';
 import { readdir } from 'fs/promises';
 import { Listr } from 'listr2';
 import path from 'path';
 
-export async function runSystemsCheck() {
+export async function runSystemsCheck(networkConfig: Promise<NetworkConfig>) {
+  const networkId = (await networkConfig).networkId;
+
   console.log('\n');
   return new Listr([
     {
@@ -54,7 +57,7 @@ export async function runSystemsCheck() {
               task: async () => {
                 await createClient(
                   ({ chainId }) =>
-                    `${dotenv.NETWORK_HOST}/chainweb/0.0/${dotenv.NETWORK_ID}/chain/${chainId}/pact`,
+                    `${dotenv.NETWORK_HOST}/chainweb/0.0/${networkId}/chain/${chainId}/pact`,
                 ).local(
                   createTransaction(
                     composePactCommand(

--- a/packages/apps/graph/src/utils/get-network-id.ts
+++ b/packages/apps/graph/src/utils/get-network-id.ts
@@ -1,0 +1,9 @@
+import { dotenv } from '@utils/dotenv';
+
+export async function getNetworkId(
+  newtorkHost: string = dotenv.NETWORK_HOST,
+): Promise<string> {
+  const res = await fetch(`${newtorkHost}/info`);
+  const data = await res.json();
+  return data.nodeVersion as string;
+}

--- a/packages/apps/graph/src/utils/get-network-id.ts
+++ b/packages/apps/graph/src/utils/get-network-id.ts
@@ -1,9 +1,0 @@
-import { dotenv } from '@utils/dotenv';
-
-export async function getNetworkId(
-  newtorkHost: string = dotenv.NETWORK_HOST,
-): Promise<string> {
-  const res = await fetch(`${newtorkHost}/info`);
-  const data = await res.json();
-  return data.nodeVersion as string;
-}

--- a/packages/apps/graph/src/utils/network.ts
+++ b/packages/apps/graph/src/utils/network.ts
@@ -1,0 +1,23 @@
+export class NetworkConfig {
+  networkHost: string;
+  networkId: string;
+
+  private constructor(networkHost: string, networkId: string) {
+    this.networkHost = networkHost;
+    this.networkId = networkId;
+  }
+
+  static async create(networkHost: string): Promise<NetworkConfig> {
+    const networkId = await getNetworkId(networkHost);
+    return new NetworkConfig(networkHost, networkId);
+  }
+}
+
+export async function getNetworkId(newtorkHost: string): Promise<string> {
+  const res = await fetch(`${newtorkHost}/info`);
+  const data = await res.json();
+
+  if (!data.nodeVersion) throw new Error('Network Id not found');
+
+  return data.nodeVersion as string;
+}


### PR DESCRIPTION
The goal is to dynamically get the `networkId` from `/info` instead of `.env` variable.

**Note**: The simulation and deployment scripts are eventually going to be removed so until then I'll leave the `dotenv.NETWORK_ID`. 
In any case, I have implemented the changes so that only simulation and deployment scripts are dependent on this

<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206753124451137