### PR TITLE
Feat/add confirmation depth to pollStatus

### DIFF
--- a/.changeset/purple-jars-melt.md
+++ b/.changeset/purple-jars-melt.md
@@ -1,0 +1,7 @@
+---
+'@kadena/chainweb-node-client': minor
+'@kadena/client-examples': minor
+'@kadena/client': minor
+---
+
+added support for confirmationDepth in client

--- a/.changeset/purple-jars-melt.md
+++ b/.changeset/purple-jars-melt.md
@@ -5,3 +5,4 @@
 ---
 
 added support for confirmationDepth in client
+added `pollOne` as an alternative to `listen` that uses `/poll` endpoint

--- a/packages/libs/chainweb-node-client/etc/chainweb-node-client.api.md
+++ b/packages/libs/chainweb-node-client/etc/chainweb-node-client.api.md
@@ -178,7 +178,7 @@ export function parseResponse<T>(response: Response): Promise<T>;
 export function parseResponseTEXT(response: Response): Promise<string>;
 
 // @alpha
-export function poll(requestBody: IPollRequestBody, apiHost: string): Promise<IPollResponse>;
+export function poll(requestBody: IPollRequestBody, apiHost: string, confirmationDepth?: number): Promise<IPollResponse>;
 
 // @alpha
 export function send(requestBody: ISendRequestBody, apiHost: string): Promise<SendResponse>;

--- a/packages/libs/chainweb-node-client/src/poll.ts
+++ b/packages/libs/chainweb-node-client/src/poll.ts
@@ -17,10 +17,16 @@ import { stringifyAndMakePOSTRequest } from './stringifyAndMakePOSTRequest';
 export async function poll(
   requestBody: IPollRequestBody,
   apiHost: string,
+  confirmationDepth = 0,
 ): Promise<IPollResponse> {
   const request = stringifyAndMakePOSTRequest(requestBody);
   const pollUrl = new URL(`${apiHost}/api/v1/poll`);
-
+  if (confirmationDepth > 0) {
+    pollUrl.searchParams.append(
+      'confirmationDepth',
+      confirmationDepth.toString(),
+    );
+  }
   const response = await fetch(pollUrl.toString(), request);
   return parseResponse<IPollResponse>(response);
 }

--- a/packages/libs/client-examples/src/example-contract/simple-transfer.ts
+++ b/packages/libs/client-examples/src/example-contract/simple-transfer.ts
@@ -1,16 +1,16 @@
 import type { PactReturnType } from '@kadena/client';
 import { isSignedTransaction, Pact, signWithChainweaver } from '@kadena/client';
 import type { IPactDecimal } from '@kadena/types';
-import { listen, submit } from './util/client';
+import { pollOne, submit } from './util/client';
 import { keyFromAccount } from './util/keyFromAccount';
 
 // npx ts-node simple-transfer.ts
 
 // change these two accounts with your accounts
 const senderAccount: string =
-  'k:dc20ab800b0420be9b1075c97e80b104b073b0405b5e2b78afd29dd74aaf5e46';
-const receiverAccount: string =
   'k:2f48080efe54e6eb670487f664bcaac7684b4ebfcfc8a3330ef080c9c97f7e11';
+const receiverAccount: string =
+  'k:6c63dda2d4b2b6d1d10537484d7279619283371b3ba62957a773676369944b17';
 
 const NETWORK_ID: string = 'testnet04';
 
@@ -38,7 +38,12 @@ async function transfer(
 
   if (isSignedTransaction(signedTr)) {
     const transactionDescriptor = await submit(signedTr);
-    const response = await listen(transactionDescriptor);
+    const response = await pollOne(transactionDescriptor, {
+      confirmationDepth: 2,
+      timeout: 5 * 60 * 1000, // 5 minutes
+      onPoll: (id) =>
+        console.log('time', new Date().toTimeString(), 'polling', id),
+    });
     if (response.result.status === 'failure') {
       throw response.result.error;
     } else {

--- a/packages/libs/client-examples/src/example-contract/util/client.ts
+++ b/packages/libs/client-examples/src/example-contract/util/client.ts
@@ -37,6 +37,7 @@ export const {
   pollStatus,
   getStatus,
   createSpv,
+  pollOne,
 } = createClient(apiHostGenerator);
 
 export const submitOne = async (

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -106,6 +106,7 @@ export interface IClient extends IBaseClient {
     dirtyRead: (transaction: IUnsignedCommand) => Promise<ICommandResult>;
     // @deprecated
     getPoll: (transactionDescriptors: ITransactionDescriptor[] | ITransactionDescriptor) => Promise<IPollResponse>;
+    pollOne: (transactionDescriptor: ITransactionDescriptor, options?: IPollOptions) => Promise<ICommandResult>;
     preflight: (transaction: ICommand | IUnsignedCommand) => Promise<ILocalCommandResult>;
     runPact: (code: string, data: Record<string, unknown>, option: INetworkOptions) => Promise<ICommandResult>;
     // @deprecated
@@ -142,11 +143,15 @@ export interface IContinuationPayloadObject {
 
 // @public (undocumented)
 export interface ICreateClient {
-    (hostUrl: string): IClient;
+    (hostUrl: string, defaults?: {
+        confirmationDepth?: number;
+    }): IClient;
     (hostAddressGenerator?: (options: {
         chainId: ChainId;
         networkId: string;
-    }) => string): IClient;
+    }) => string, defaults?: {
+        confirmationDepth?: number;
+    }): IClient;
 }
 
 // @public
@@ -242,6 +247,8 @@ export interface IPartialPactCommand extends AllPartial<IPactCommand> {
 
 // @public
 export interface IPollOptions {
+    // (undocumented)
+    confirmationDepth?: number;
     // (undocumented)
     interval?: number;
     // (undocumented)

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -144,13 +144,13 @@ export interface IContinuationPayloadObject {
 // @public (undocumented)
 export interface ICreateClient {
     (hostUrl: string, defaults?: {
-        confirmationDepth?: Milliseconds;
+        confirmationDepth?: number;
     }): IClient;
     (hostAddressGenerator?: (options: {
         chainId: ChainId;
         networkId: string;
     }) => string, defaults?: {
-        confirmationDepth?: Milliseconds;
+        confirmationDepth?: number;
     }): IClient;
 }
 
@@ -491,11 +491,6 @@ export type WithCapability<TCode extends string & {
         funs: [TCode];
     };
 }>;
-
-// Warnings were encountered during analysis:
-//
-// src/client/client.ts:258:34 - (ae-incompatible-release-tags) The symbol "confirmationDepth" is marked as @public, but its signature references "Milliseconds" which is marked as @alpha
-// src/client/client.ts:272:18 - (ae-incompatible-release-tags) The symbol "confirmationDepth" is marked as @public, but its signature references "Milliseconds" which is marked as @alpha
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -144,13 +144,13 @@ export interface IContinuationPayloadObject {
 // @public (undocumented)
 export interface ICreateClient {
     (hostUrl: string, defaults?: {
-        confirmationDepth?: number;
+        confirmationDepth?: Milliseconds;
     }): IClient;
     (hostAddressGenerator?: (options: {
         chainId: ChainId;
         networkId: string;
     }) => string, defaults?: {
-        confirmationDepth?: number;
+        confirmationDepth?: Milliseconds;
     }): IClient;
 }
 
@@ -250,11 +250,11 @@ export interface IPollOptions {
     // (undocumented)
     confirmationDepth?: number;
     // (undocumented)
-    interval?: number;
+    interval?: Milliseconds;
     // (undocumented)
     onPoll?: (id: string) => void;
     // (undocumented)
-    timeout?: number;
+    timeout?: Milliseconds;
 }
 
 // @public (undocumented)
@@ -438,6 +438,11 @@ export class Literal {
 
 // @public
 export const literal: (value: string) => Literal;
+
+// @public (undocumented)
+export type Milliseconds = number & {
+    _brand?: 'milliseconds';
+};
 
 // @public
 export const Pact: IPact;

--- a/packages/libs/client/etc/client.api.md
+++ b/packages/libs/client/etc/client.api.md
@@ -249,10 +249,14 @@ export interface IPartialPactCommand extends AllPartial<IPactCommand> {
 export interface IPollOptions {
     // (undocumented)
     confirmationDepth?: number;
+    // Warning: (ae-incompatible-release-tags) The symbol "interval" is marked as @public, but its signature references "Milliseconds" which is marked as @alpha
+    //
     // (undocumented)
     interval?: Milliseconds;
     // (undocumented)
     onPoll?: (id: string) => void;
+    // Warning: (ae-incompatible-release-tags) The symbol "timeout" is marked as @public, but its signature references "Milliseconds" which is marked as @alpha
+    //
     // (undocumented)
     timeout?: Milliseconds;
 }
@@ -439,7 +443,7 @@ export class Literal {
 // @public
 export const literal: (value: string) => Literal;
 
-// @public (undocumented)
+// @alpha (undocumented)
 export type Milliseconds = number & {
     _brand?: 'milliseconds';
 };
@@ -487,6 +491,11 @@ export type WithCapability<TCode extends string & {
         funs: [TCode];
     };
 }>;
+
+// Warnings were encountered during analysis:
+//
+// src/client/client.ts:258:34 - (ae-incompatible-release-tags) The symbol "confirmationDepth" is marked as @public, but its signature references "Milliseconds" which is marked as @alpha
+// src/client/client.ts:272:18 - (ae-incompatible-release-tags) The symbol "confirmationDepth" is marked as @public, but its signature references "Milliseconds" which is marked as @alpha
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/libs/client/src/client/api/status.ts
+++ b/packages/libs/client/src/client/api/status.ts
@@ -24,7 +24,12 @@ export const pollStatus: IPollStatus = (
   requestIds: string[],
   options?: IPollOptions,
 ): IPollRequestPromise<ICommandResult> => {
-  const { onPoll = () => {}, timeout, interval } = options ?? {};
+  const {
+    onPoll = () => {},
+    timeout,
+    interval,
+    confirmationDepth = 0,
+  } = options ?? {};
   let requestKeys = [...requestIds];
   const prs: Record<string, IExtPromise<ICommandResult>> = requestKeys.reduce(
     (acc, requestKey) => ({
@@ -35,7 +40,7 @@ export const pollStatus: IPollStatus = (
   );
   const task = async (): Promise<void> => {
     requestKeys.forEach(onPoll);
-    const pollResponse = await poll({ requestKeys }, host);
+    const pollResponse = await poll({ requestKeys }, host, confirmationDepth);
     Object.values(pollResponse).forEach((item) => {
       prs[item.reqKey].resolve(item);
       requestKeys = requestKeys.filter((key) => key !== item.reqKey);

--- a/packages/libs/client/src/client/client.ts
+++ b/packages/libs/client/src/client/client.ts
@@ -101,7 +101,7 @@ export interface IBaseClient {
    * Calls the '/poll' endpoint multiple times to get the status of all requests.
    *
    * @param transactionDescriptors - transaction descriptors to status polling.
-   * @param options - options to adjust polling (onPoll, timeout, and interval).
+   * @param options - options to adjust polling (onPoll, timeout, interval, and confirmationDepth).
    * @returns A promise that resolves to the poll request promise with the command result.
    */
   pollStatus: (
@@ -235,6 +235,7 @@ export interface IClient extends IBaseClient {
    *
    *
    * @param transactionDescriptors - transaction descriptors to listen for.
+   * @param options - options to adjust polling (onPoll, timeout, interval, and confirmationDepth).
    * @returns A promise that resolves to the command result.
    */
   pollOne: (
@@ -252,6 +253,7 @@ export interface ICreateClient {
    *
    * Useful when you are working with a single network and chainId.
    * @param hostUrl - the URL to use in the client
+   * @param defaults - default options for the client it includes confirmationDepth that is used for polling
    */
   (hostUrl: string, defaults?: { confirmationDepth?: Milliseconds }): IClient;
 
@@ -260,6 +262,7 @@ export interface ICreateClient {
    *
    * Note: The default hostUrlGenerator creates a Kadena testnet or mainnet URL based on networkId.
    * @param hostAddressGenerator - the function that generates the URL based on `chainId` and `networkId` from the transaction
+   * @param defaults - default options for the client it includes confirmationDepth that is used for polling
    */
   (
     hostAddressGenerator?: (options: {

--- a/packages/libs/client/src/client/client.ts
+++ b/packages/libs/client/src/client/client.ts
@@ -16,7 +16,6 @@ import type {
   INetworkOptions,
   IPollOptions,
   IPollRequestPromise,
-  Milliseconds,
 } from './interfaces/interfaces';
 import {
   groupByHost,

--- a/packages/libs/client/src/client/client.ts
+++ b/packages/libs/client/src/client/client.ts
@@ -255,7 +255,7 @@ export interface ICreateClient {
    * @param hostUrl - the URL to use in the client
    * @param defaults - default options for the client it includes confirmationDepth that is used for polling
    */
-  (hostUrl: string, defaults?: { confirmationDepth?: Milliseconds }): IClient;
+  (hostUrl: string, defaults?: { confirmationDepth?: number }): IClient;
 
   /**
    * Generates a client instance by passing a hostUrlGenerator function.
@@ -269,7 +269,7 @@ export interface ICreateClient {
       chainId: ChainId;
       networkId: string;
     }) => string,
-    defaults?: { confirmationDepth?: Milliseconds },
+    defaults?: { confirmationDepth?: number },
   ): IClient;
 }
 

--- a/packages/libs/client/src/client/client.ts
+++ b/packages/libs/client/src/client/client.ts
@@ -16,6 +16,7 @@ import type {
   INetworkOptions,
   IPollOptions,
   IPollRequestPromise,
+  Milliseconds,
 } from './interfaces/interfaces';
 import {
   groupByHost,
@@ -252,7 +253,7 @@ export interface ICreateClient {
    * Useful when you are working with a single network and chainId.
    * @param hostUrl - the URL to use in the client
    */
-  (hostUrl: string, defaults?: { confirmationDepth?: number }): IClient;
+  (hostUrl: string, defaults?: { confirmationDepth?: Milliseconds }): IClient;
 
   /**
    * Generates a client instance by passing a hostUrlGenerator function.
@@ -265,7 +266,7 @@ export interface ICreateClient {
       chainId: ChainId;
       networkId: string;
     }) => string,
-    defaults?: { confirmationDepth?: number },
+    defaults?: { confirmationDepth?: Milliseconds },
   ): IClient;
 }
 

--- a/packages/libs/client/src/client/interfaces/interfaces.ts
+++ b/packages/libs/client/src/client/interfaces/interfaces.ts
@@ -16,6 +16,7 @@ export interface IPollOptions {
   onPoll?: (id: string) => void;
   timeout?: number;
   interval?: number;
+  confirmationDepth?: number;
 }
 
 /**

--- a/packages/libs/client/src/client/interfaces/interfaces.ts
+++ b/packages/libs/client/src/client/interfaces/interfaces.ts
@@ -8,14 +8,16 @@ export interface INetworkOptions {
   chainId: ChainId;
 }
 
+export type Milliseconds = number & { _brand?: 'milliseconds' };
+
 /**
  * Options for any polling action on {@link IClient}
  * @public
  */
 export interface IPollOptions {
   onPoll?: (id: string) => void;
-  timeout?: number;
-  interval?: number;
+  timeout?: Milliseconds;
+  interval?: Milliseconds;
   confirmationDepth?: number;
 }
 

--- a/packages/libs/client/src/client/interfaces/interfaces.ts
+++ b/packages/libs/client/src/client/interfaces/interfaces.ts
@@ -8,6 +8,9 @@ export interface INetworkOptions {
   chainId: ChainId;
 }
 
+/**
+ * @alpha
+ */
 export type Milliseconds = number & { _brand?: 'milliseconds' };
 
 /**


### PR DESCRIPTION
`/poll` endpoint accepts `confirmationDepth` and returns the result if the request meets that length. It means waiting for a certain amount of blocks, then returning the result of the request. It's useful when you need to make sure the data is persisted permanently on the blockchain.

In this PR, we will add the support in the client library.

You can pass it to the `createClient` function to use it as the value on applicable functions.

```
const client = createClient("http://host-url", { confirmationDepth: 5 })
```

You can also pass it with poll options for the `pollStatus` function (which overrides the one you passed to the `createClient`).

```
const result = pollStatus(request, { confirmationDepth: 5 })
```