### PR TITLE
fix(account): fund command additional feedback for sending transactions + check

### DIFF
--- a/packages/tools/kadena-cli/src/account/commands/accountFund.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountFund.ts
@@ -130,9 +130,13 @@ export const createAccountFundCommand = createCommand(
     const result = await fund(config);
     assertCommandError(result);
 
+    const explorerURL = networkConfig.networkExplorerUrl.endsWith('/')
+      ? networkConfig.networkExplorerUrl
+      : `${networkConfig.networkExplorerUrl}/`;
+
     log.info(
       log.color.green(
-        `Explorer URL: ${networkConfig.networkExplorerUrl}\nRequest Key: ${result.data.requestKey}`,
+        `Transaction explorer URL: ${explorerURL}${result.data.requestKey}`,
       ),
     );
     const { pollStatus } = createClient(

--- a/packages/tools/kadena-cli/src/account/commands/accountFund.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountFund.ts
@@ -1,5 +1,6 @@
 // import { describeModule } from '@kadena/client-utils/built-in';
 // import { Option } from 'commander';
+import { createClient } from '@kadena/client';
 import ora from 'ora';
 // import { z } from 'zod';
 // import { FAUCET_MODULE_NAME } from '../../constants/devnets.js';
@@ -126,15 +127,40 @@ export const createAccountFundCommand = createCommand(
     //   }
     // }
 
-    const loader = ora('Funding account...\n').start();
-
     const result = await fund(config);
-    assertCommandError(result, loader);
+    assertCommandError(result);
 
     log.info(
       log.color.green(
-        `"${accountConfig.name}" account funded with "${amount}" ${accountConfig.fungible} on chain ${chainId} in ${networkConfig.networkId} network.`,
+        `Explorer URL: ${networkConfig.networkExplorerUrl}\nRequest Key: ${result.data.requestKey}`,
       ),
     );
+    const { pollStatus } = createClient(
+      `${networkConfig.networkHost}/chainweb/0.0/${networkConfig.networkId}/chain/${chainId}/pact`,
+    );
+
+    const loader = ora('Funding account...\n').start();
+
+    pollStatus(result.data)
+      .then((response) => {
+        const transactionResult = response[result.data.requestKey];
+        if (
+          typeof transactionResult !== 'string' &&
+          transactionResult.result.status === 'failure'
+        ) {
+          throw transactionResult.result.error;
+        }
+
+        loader.succeed('Account funded');
+        log.info(
+          log.color.green(
+            `"${accountConfig.name}" account funded with "${amount}" ${accountConfig.fungible} on chain ${chainId} in ${networkConfig.networkId} network.\nUse "account details" command to check the balance.`,
+          ),
+        );
+      })
+      .catch((e) => {
+        loader.fail('Failed to fund account');
+        log.error(e.message);
+      });
   },
 );

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/createAndTransferFunds.test.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/createAndTransferFunds.test.ts
@@ -52,13 +52,9 @@ describe('createAndTransferFunds', () => {
     });
 
     expect(result).toStrictEqual({
-      result: {
-        reqKey: 'requestKey-1',
-        result: {
-          status: 'success',
-          data: 'Write succeeded',
-        },
-      },
+      chainId: '1',
+      networkId: 'testnet04',
+      requestKey: 'requestKey-1',
     });
   });
 

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/fund.test.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/fund.test.ts
@@ -105,7 +105,7 @@ describe('fund', () => {
     });
   });
 
-  it('should return success false and error message when transfer fund api status returns failure', async () => {
+  it('should return success false and error message when api call fails', async () => {
     server.use(
       http.post(
         'https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/1/pact/api/v1/send',

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/fund.test.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/fund.test.ts
@@ -25,13 +25,9 @@ describe('fund', () => {
     expect(result).toStrictEqual({
       success: true,
       data: {
-        result: {
-          reqKey: 'requestKey-1',
-          result: {
-            status: 'success',
-            data: 'Write succeeded',
-          },
-        },
+        chainId: '1',
+        networkId: 'testnet04',
+        requestKey: 'requestKey-1',
       },
     });
   });
@@ -70,13 +66,9 @@ describe('fund', () => {
     expect(result).toStrictEqual({
       success: true,
       data: {
-        result: {
-          reqKey: 'requestKey-1',
-          result: {
-            status: 'success',
-            data: 'Write succeeded',
-          },
-        },
+        chainId: '1',
+        networkId: 'testnet04',
+        requestKey: 'requestKey-1',
       },
     });
   });
@@ -116,18 +108,11 @@ describe('fund', () => {
   it('should return success false and error message when transfer fund api status returns failure', async () => {
     server.use(
       http.post(
-        'https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/1/pact/api/v1/listen',
+        'https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/1/pact/api/v1/send',
         () => {
           return HttpResponse.json(
-            {
-              result: {
-                status: 'failure',
-                error: {
-                  message: 'coin can be requested only every 30 minutes',
-                },
-              },
-            },
-            { status: 200 },
+            { error: 'something went wrong' },
+            { status: 500 },
           );
         },
       ),
@@ -148,9 +133,7 @@ describe('fund', () => {
 
     expect(result).toStrictEqual({
       success: false,
-      errors: [
-        'Failed to transfer fund : "coin can be requested only every 30 minutes"',
-      ],
+      errors: ['Failed to transfer fund : "{"error":"something went wrong"}"'],
     });
   });
 });

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/transferFund.test.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/transferFund.test.ts
@@ -45,6 +45,39 @@ describe('transferFund', () => {
     });
   });
 
+  it('should throw an error when local api transaction failure', async () => {
+    server.use(
+      http.post(
+        'https://localhost:8080/chainweb/0.0/development/chain/1/pact/api/v1/local',
+        () => {
+          return HttpResponse.json(
+            {
+              result: {
+                status: 'failure',
+                error: {
+                  message: 'shit hit the fan',
+                },
+              },
+            },
+            { status: 200 },
+          );
+        },
+      ),
+    );
+
+    await expect(async () => {
+      await transferFund({
+        accountName: 'accountName',
+        config: {
+          amount: '100',
+          contract: 'coin',
+          chainId: '1',
+          networkConfig: devNetConfigMock,
+        },
+      });
+    }).rejects.toEqual(Error('Failed to transfer fund : "shit hit the fan"'));
+  });
+
   it('should throw an error when any sort of error happens', async () => {
     server.use(
       http.post(

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/transferFund.test.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/transferFund.test.ts
@@ -39,13 +39,9 @@ describe('transferFund', () => {
       },
     });
     expect(result).toStrictEqual({
-      result: {
-        reqKey: 'requestKey-1',
-        result: {
-          status: 'success',
-          data: 'Write succeeded',
-        },
-      },
+      chainId: '1',
+      networkId: 'development',
+      requestKey: 'requestKey-1',
     });
   });
 

--- a/packages/tools/kadena-cli/src/account/utils/createAndTransferFunds.ts
+++ b/packages/tools/kadena-cli/src/account/utils/createAndTransferFunds.ts
@@ -83,11 +83,12 @@ export async function createAndTransferFund({
     );
 
     // Validate the transaction locally before sending it to the network
-    await local(signedTx);
+    const localResult = await local(signedTx);
+    if (localResult.result.status === 'failure') {
+      throw localResult.result.error;
+    }
 
-    const requestKeys = await submit(signedTx);
-
-    return requestKeys;
+    return await submit(signedTx);
   } catch (error) {
     throw Error(`Failed to create an account and transfer fund: ${error}`);
   }

--- a/packages/tools/kadena-cli/src/account/utils/fund.ts
+++ b/packages/tools/kadena-cli/src/account/utils/fund.ts
@@ -1,4 +1,4 @@
-import type { ICommandResult } from '@kadena/client';
+import type { ITransactionDescriptor } from '@kadena/client';
 import type { ChainId } from '@kadena/types';
 import type { INetworkCreateOptions } from '../../networks/utils/networkHelpers.js';
 import type { CommandResult } from '../../utils/command.util.js';
@@ -17,7 +17,7 @@ export async function fund({
   amount: string;
   networkConfig: INetworkCreateOptions;
   chainId: ChainId;
-}): Promise<CommandResult<ICommandResult>> {
+}): Promise<CommandResult<ITransactionDescriptor>> {
   try {
     const accountDetailsFromChain = await getAccountDetails({
       accountName: accountConfig.name,
@@ -51,10 +51,6 @@ export async function fund({
             chainId,
           },
         });
-
-    if (typeof result !== 'string' && result.result.status === 'failure') {
-      throw result.result.error;
-    }
 
     return {
       success: true,

--- a/packages/tools/kadena-cli/src/account/utils/transferFund.ts
+++ b/packages/tools/kadena-cli/src/account/utils/transferFund.ts
@@ -1,4 +1,4 @@
-import type { ICommandResult } from '@kadena/client';
+import type { ITransactionDescriptor } from '@kadena/client';
 import {
   Pact,
   createClient,
@@ -23,7 +23,7 @@ export async function transferFund({
     chainId: ChainId;
     networkConfig: INetworkCreateOptions;
   };
-}): Promise<ICommandResult> {
+}): Promise<ITransactionDescriptor> {
   try {
     const { chainId, amount, networkConfig } = config;
 
@@ -70,19 +70,15 @@ export async function transferFund({
       throw new Error('Transaction is not signed');
     }
 
-    const { submit, listen } = createClient(
+    const { submit, local } = createClient(
       `${networkConfig.networkHost}/chainweb/0.0/${networkConfig.networkId}/chain/${chainId}/pact`,
     );
 
+    // Validate the transaction locally before sending it to the network
+    await local(signedTx);
+
     const requestKeys = await submit(signedTx);
-
-    const response = await listen(requestKeys);
-
-    if (response.result.status === 'failure') {
-      throw response.result.error;
-    }
-
-    return response;
+    return requestKeys;
   } catch (error) {
     throw new Error(`Failed to transfer fund : "${error.message}"`);
   }

--- a/packages/tools/kadena-cli/src/account/utils/transferFund.ts
+++ b/packages/tools/kadena-cli/src/account/utils/transferFund.ts
@@ -75,10 +75,12 @@ export async function transferFund({
     );
 
     // Validate the transaction locally before sending it to the network
-    await local(signedTx);
+    const localResult = await local(signedTx);
+    if (localResult.result.status === 'failure') {
+      throw localResult.result.error;
+    }
 
-    const requestKeys = await submit(signedTx);
-    return requestKeys;
+    return await submit(signedTx);
   } catch (error) {
     throw new Error(`Failed to transfer fund : "${error.message}"`);
   }

--- a/packages/tools/kadena-cli/src/tx/commands/txSend.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txSend.ts
@@ -139,6 +139,11 @@ export const sendTransactionAction = async ({
 
       const client = getClient(details);
 
+      const localResponse = await client.local(command);
+      if (localResponse.result.status === 'failure') {
+        throw localResponse.result.error;
+      }
+
       const response = await client.submit(command);
       successfulCommands.push({
         transaction: command,


### PR DESCRIPTION
- Print request key and explorer url
- Improve help text after funding an account
- Before sending transactions to chain validate using `local` (for account fund and tx send commands)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206794459798420
  - https://app.asana.com/0/0/1206794459798425