### PR TITLE
refactor: get signed/unsigned transactions list

### DIFF
--- a/packages/tools/kadena-cli/src/prompts/tx.ts
+++ b/packages/tools/kadena-cli/src/prompts/tx.ts
@@ -38,7 +38,7 @@ export const SignatureOrUndefinedOrNull = z.union([
 export const ICommandSchema = z.object({
   cmd: CommandPayloadStringifiedJSONSchema,
   hash: PactTransactionHashSchema,
-  sigs: z.array(ISignatureJsonSchema),
+  sigs: z.array(SignatureOrUndefinedOrNull),
 });
 
 export const IUnsignedCommandSchema = z.object({
@@ -47,12 +47,11 @@ export const IUnsignedCommandSchema = z.object({
   sigs: z.array(SignatureOrUndefinedOrNull),
 });
 
-// export const ISignatureJsonSchema = z.union([
-//   z.object({
-//     sig: z.string(),
-//   }),
-//   z.null(),
-// ]);
+export const ISignedCommandSchema = z.object({
+  cmd: CommandPayloadStringifiedJSONSchema,
+  hash: PactTransactionHashSchema,
+  sigs: z.array(ISignatureJsonSchema),
+});
 
 export async function txUnsignedCommandPrompt(): Promise<IUnsignedCommand> {
   const result = await input({

--- a/packages/tools/kadena-cli/src/tx/commands/txList.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txList.ts
@@ -3,7 +3,7 @@ import { createCommand } from '../../utils/createCommand.js';
 import { log } from '../../utils/logger.js';
 import { txOptions } from '../txOptions.js';
 import { printTx } from '../utils/txDisplayHelper.js';
-import { getTransactions } from '../utils/txHelpers.js';
+import { getAllTransactionFileNames } from '../utils/txHelpers.js';
 
 export const createTxListCommand: (program: Command, version: string) => void =
   createCommand(
@@ -14,11 +14,7 @@ export const createTxListCommand: (program: Command, version: string) => void =
       log.debug('list-tx:action');
 
       const { directory } = await option.directory();
-      const transactions: string[] = await getTransactions(
-        false,
-        directory,
-        true,
-      );
+      const transactions = await getAllTransactionFileNames(directory);
 
       transactions.sort((a, b) => {
         const aIsSigned = a.includes('-signed') ? 1 : -1;

--- a/packages/tools/kadena-cli/src/tx/commands/txList.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txList.ts
@@ -3,7 +3,7 @@ import { createCommand } from '../../utils/createCommand.js';
 import { log } from '../../utils/logger.js';
 import { txOptions } from '../txOptions.js';
 import { printTx } from '../utils/txDisplayHelper.js';
-import { getAllTransactionFileNames } from '../utils/txHelpers.js';
+import { getAllTransactions } from '../utils/txHelpers.js';
 
 export const createTxListCommand: (program: Command, version: string) => void =
   createCommand(
@@ -14,11 +14,11 @@ export const createTxListCommand: (program: Command, version: string) => void =
       log.debug('list-tx:action');
 
       const { directory } = await option.directory();
-      const transactions = await getAllTransactionFileNames(directory);
+      const transactions = await getAllTransactions(directory);
 
       transactions.sort((a, b) => {
-        const aIsSigned = a.includes('-signed') ? 1 : -1;
-        const bIsSigned = b.includes('-signed') ? 1 : -1;
+        const aIsSigned = a.signed === true ? 1 : -1;
+        const bIsSigned = b.signed === true ? 1 : -1;
         return bIsSigned - aIsSigned;
       });
 

--- a/packages/tools/kadena-cli/src/tx/txOptions.ts
+++ b/packages/tools/kadena-cli/src/tx/txOptions.ts
@@ -158,7 +158,7 @@ export const txOptions = {
   txSignedTransactionFile: createOption({
     key: 'txSignedTransactionFile',
     prompt: tx.transactionSelectPrompt,
-    validation: tx.ICommandSchema,
+    validation: tx.ISignedCommandSchema,
     option: new Option(
       '-s, --tx-signed-transaction-file <txSignedTransactionFile>',
       'provide your signed transaction file',

--- a/packages/tools/kadena-cli/src/tx/utils/txDisplayHelper.ts
+++ b/packages/tools/kadena-cli/src/tx/utils/txDisplayHelper.ts
@@ -8,7 +8,12 @@ const displaySeparator = (): void => {
   log.info(log.color.green('-'.padEnd(formatLength, '-')));
 };
 
-export async function printTx(transactions: string[]): Promise<void> {
+export async function printTx(
+  transactions: {
+    fileName: string;
+    signed: boolean;
+  }[],
+): Promise<void> {
   const header: TableHeader = ['Filename', 'Signed'];
   const rows: TableRow[] = [];
 
@@ -17,8 +22,11 @@ export async function printTx(transactions: string[]): Promise<void> {
     return;
   }
 
-  for (const key of transactions) {
-    rows.push([key ?? 'N/A', key.includes('signed') === true ? 'Yes' : 'No']);
+  for (const transaction of transactions) {
+    rows.push([
+      transaction.fileName ?? 'N/A',
+      transaction.signed === true ? 'Yes' : 'No',
+    ]);
   }
 
   log.output(log.generateTableString(header, rows));

--- a/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
+++ b/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
@@ -18,7 +18,7 @@ import type { IWallet } from '../../keys/utils/keysHelpers.js';
 import { getWalletKey } from '../../keys/utils/keysHelpers.js';
 import type { IKeyPair as IKeyPairLocal } from '../../keys/utils/storage.js';
 import { tx } from '../../prompts/index.js';
-import { ICommandSchema, IUnsignedCommandSchema } from '../../prompts/tx.js';
+import { ICommandSchema } from '../../prompts/tx.js';
 import { services } from '../../services/index.js';
 import type { CommandResult } from '../../utils/command.util.js';
 import { notEmpty } from '../../utils/helpers.js';
@@ -73,17 +73,15 @@ export async function getAllTransactions(
           const content = await services.filesystem.readFile(filePath);
           if (content === null) return null;
           const JSONParsedContent = JSON.parse(content);
-          const isSignedTx =
-            'sigs' in JSONParsedContent &&
-            isSignedTransaction(JSONParsedContent);
-          const schema = isSignedTx ? ICommandSchema : IUnsignedCommandSchema;
-          const parsed = schema.safeParse(JSON.parse(content));
+          const parsed = ICommandSchema.safeParse(JSONParsedContent);
           if (parsed.success) {
+            const isSignedTx = isSignedTransaction(JSONParsedContent);
             return {
               fileName,
               signed: isSignedTx,
             };
           }
+
           return null;
         }),
       )
@@ -308,7 +306,7 @@ export async function getTransactionFromFile(
     }
     const transaction = JSON.parse(fileContent);
     if (signed) {
-      return tx.ICommandSchema.parse(transaction);
+      return tx.ISignedCommandSchema.parse(transaction);
     }
     const result = tx.IUnsignedCommandSchema.parse(transaction);
     return result as IUnsignedCommand; // typecast because `IUnsignedCommand` uses undefined instead of null


### PR DESCRIPTION
- Removed the temporary fix of using `all` param
- Improved the `tx list` display instead of relying on filename extension using the transaction signed key

https://app.asana.com/0/1205969628270714/1206751469972661/f 