### PR TITLE
feat(client-utils): global config

### DIFF
--- a/packages/libs/client-utils/etc/client-utils-core.api.md
+++ b/packages/libs/client-utils/etc/client-utils-core.api.md
@@ -10,8 +10,7 @@ import { ICommand } from '@kadena/types';
 import { ICommandResult } from '@kadena/chainweb-node-client';
 import type { INetworkOptions } from '@kadena/client';
 import type { IPactCommand } from '@kadena/client';
-import { IPartialPactCommand } from '@kadena/client/lib/interfaces/IPactCommand';
-import type { IPartialPactCommand as IPartialPactCommand_2 } from '@kadena/client';
+import { IPartialPactCommand } from '@kadena/client';
 import type { ISignFunction } from '@kadena/client';
 import { ITransactionDescriptor } from '@kadena/client';
 import { IUnsignedCommand } from '@kadena/types';
@@ -380,10 +379,14 @@ export const dirtyReadClient: <T = PactValue>(args_0: Omit<IClientConfig, "sign"
 };
 
 // @alpha
-export const estimateGas: (command: IPartialPactCommand_2 | ((cmd?: IPartialPactCommand_2 | (() => IPartialPactCommand_2)) => IPartialPactCommand_2), host?: IClientConfig['host'], client?: IClient) => Promise<unknown>;
+export const estimateGas: (command: IPartialPactCommand | ((cmd?: IPartialPactCommand | (() => IPartialPactCommand)) => IPartialPactCommand), host?: IClientConfig['host'], client?: IClient) => Promise<unknown>;
 
-// @public (undocumented)
-export const getGlobalConfig: () => Partial<IClientConfig>;
+// @alpha (undocumented)
+export const
+/**
+* @alpha
+*/
+getGlobalConfig: () => Partial<IClientConfig>;
 
 // @alpha (undocumented)
 export interface IEmitterWrapper<T extends Array<{
@@ -486,8 +489,12 @@ export const queryAllChainsClient: <T = PactValue>(args_0: Omit<IClientConfig, "
     }[]>>);
 };
 
-// @public (undocumented)
-export const setGlobalConfig: (cfg: Partial<IClientConfig>) => void;
+// @alpha (undocumented)
+export const
+/**
+* @alpha
+*/
+setGlobalConfig: (cfg: Partial<IClientConfig>) => void;
 
 // @alpha (undocumented)
 export const submitClient: <T = PactValue>(args_0: IClientConfig, args_1?: IClient | undefined) => {

--- a/packages/libs/client-utils/etc/client-utils-core.api.md
+++ b/packages/libs/client-utils/etc/client-utils-core.api.md
@@ -382,6 +382,9 @@ export const dirtyReadClient: <T = PactValue>(args_0: Omit<IClientConfig, "sign"
 // @alpha
 export const estimateGas: (command: IPartialPactCommand_2 | ((cmd?: IPartialPactCommand_2 | (() => IPartialPactCommand_2)) => IPartialPactCommand_2), host?: IClientConfig['host'], client?: IClient) => Promise<unknown>;
 
+// @public (undocumented)
+export const getGlobalConfig: () => Partial<IClientConfig>;
+
 // @alpha (undocumented)
 export interface IEmitterWrapper<T extends Array<{
     event: string;
@@ -482,6 +485,9 @@ export const queryAllChainsClient: <T = PactValue>(args_0: Omit<IClientConfig, "
     chainId: ChainId | undefined;
     }[]>>);
 };
+
+// @public (undocumented)
+export const setGlobalConfig: (cfg: Partial<IClientConfig>) => void;
 
 // @alpha (undocumented)
 export const submitClient: <T = PactValue>(args_0: IClientConfig, args_1?: IClient | undefined) => {

--- a/packages/libs/client-utils/src/core/cross-chain.ts
+++ b/packages/libs/client-utils/src/core/cross-chain.ts
@@ -18,6 +18,7 @@ import { asyncPipe } from './utils/asyncPipe';
 import type { IAccount, IClientConfig, IEmit } from './utils/helpers';
 import {
   checkSuccess,
+  composeWithDefaults,
   extractResult,
   getClient,
   safeSign,
@@ -78,7 +79,7 @@ export const crossChain = <T = PactValue>(
     targetChainGasPayer: { account: string; publicKeys?: string[] };
   }) =>
     asyncPipe(
-      composePactCommand(defaults ?? {}),
+      composeWithDefaults(defaults),
       createTransaction,
       safeSign(sign),
       emit('sign'),
@@ -94,7 +95,7 @@ export const crossChain = <T = PactValue>(
       (data) => data,
       continuation,
       createPactCommand(targetChainId, targetChainGasPayer),
-      composePactCommand(defaults ?? {}),
+      composeWithDefaults(defaults),
       createTransaction,
       safeSign(sign),
       emit(

--- a/packages/libs/client-utils/src/core/estimate-gas.ts
+++ b/packages/libs/client-utils/src/core/estimate-gas.ts
@@ -1,10 +1,9 @@
 import type { IPartialPactCommand } from '@kadena/client';
 import { createTransaction } from '@kadena/client';
-import { composePactCommand } from '@kadena/client/fp';
 
 import { asyncPipe } from './utils/asyncPipe';
 import type { IClientConfig } from './utils/helpers';
-import { getClient, throwIfFails } from './utils/helpers';
+import { composeWithDefaults, getClient, throwIfFails } from './utils/helpers';
 
 /**
  * estimate gas for a command
@@ -20,12 +19,13 @@ export const estimateGas = (
   client = getClient(host),
 ) => {
   const pipeLine = asyncPipe(
-    composePactCommand({
-      meta: {
-        gasLimit: 10000,
-        gasPrice: 1.0e-8,
-      } as IPartialPactCommand['meta'],
-    }),
+    (cmd) =>
+      composeWithDefaults(cmd)({
+        meta: {
+          gasLimit: 10000,
+          gasPrice: 1.0e-8,
+        } as IPartialPactCommand['meta'],
+      }),
     createTransaction,
     (tx) => client.local(tx, { preflight: true, signatureVerification: false }),
     throwIfFails,

--- a/packages/libs/client-utils/src/core/global-config.ts
+++ b/packages/libs/client-utils/src/core/global-config.ts
@@ -1,0 +1,15 @@
+import type { IClientConfig } from './utils/helpers';
+
+const createGlobalConfig = () => {
+  let config: Partial<IClientConfig> = {};
+  return {
+    setGlobalConfig: (cfg: Partial<IClientConfig>) => {
+      config = cfg ?? {};
+    },
+    getGlobalConfig: () => {
+      return config;
+    },
+  };
+};
+
+export const { setGlobalConfig, getGlobalConfig } = createGlobalConfig();

--- a/packages/libs/client-utils/src/core/global-config.ts
+++ b/packages/libs/client-utils/src/core/global-config.ts
@@ -12,4 +12,13 @@ const createGlobalConfig = () => {
   };
 };
 
-export const { setGlobalConfig, getGlobalConfig } = createGlobalConfig();
+export const {
+  /**
+   * @alpha
+   */
+  setGlobalConfig,
+  /**
+   * @alpha
+   */
+  getGlobalConfig,
+} = createGlobalConfig();

--- a/packages/libs/client-utils/src/core/index.ts
+++ b/packages/libs/client-utils/src/core/index.ts
@@ -1,4 +1,5 @@
 export * from './client-helpers';
 export * from './estimate-gas';
+export * from './global-config';
 export * from './utils/asyncPipe';
 export * from './utils/with-emitter';

--- a/packages/libs/client-utils/src/core/preflight.ts
+++ b/packages/libs/client-utils/src/core/preflight.ts
@@ -1,10 +1,10 @@
 import { createTransaction } from '@kadena/client';
-import { composePactCommand } from '@kadena/client/fp';
 
 import type { PactValue } from '@kadena/types';
 import { asyncPipe } from './utils/asyncPipe';
 import type { IClientConfig, IEmit } from './utils/helpers';
 import {
+  composeWithDefaults,
   extractResult,
   getClient,
   safeSign,
@@ -18,7 +18,7 @@ export const preflight =
   ) =>
   (emit: IEmit) =>
     asyncPipe(
-      composePactCommand(defaults ?? {}),
+      composeWithDefaults(defaults),
       createTransaction,
       safeSign(sign),
       emit('sign'),

--- a/packages/libs/client-utils/src/core/query-all-chains.ts
+++ b/packages/libs/client-utils/src/core/query-all-chains.ts
@@ -5,7 +5,7 @@ import { composePactCommand, setMeta } from '@kadena/client/fp';
 import type { PactValue } from '@kadena/types';
 import { asyncPipe } from './utils/asyncPipe';
 import type { IClientConfig, IEmit } from './utils/helpers';
-import { extractResult, getClient } from './utils/helpers';
+import { composeWithDefaults, extractResult, getClient } from './utils/helpers';
 
 const chainIds = [...Array(20).keys()].map((key) => `${key}` as ChainId);
 
@@ -16,7 +16,7 @@ export const query =
   ) =>
   (emit: IEmit) =>
     asyncPipe(
-      composePactCommand(defaults ?? {}),
+      composeWithDefaults(defaults),
       createTransaction,
       client.dirtyRead,
       extractResult<T>,
@@ -31,7 +31,7 @@ export const queryAllChains =
   ) =>
   (emit: IEmit) =>
     asyncPipe(
-      composePactCommand(defaults ?? {}),
+      composeWithDefaults(defaults),
       (command) =>
         composePactCommand(command, setMeta({ chainId: undefined }))({}),
       (command: IPartialPactCommand) => {

--- a/packages/libs/client-utils/src/core/read-dirty.ts
+++ b/packages/libs/client-utils/src/core/read-dirty.ts
@@ -1,10 +1,14 @@
 import { createTransaction } from '@kadena/client';
-import { composePactCommand } from '@kadena/client/fp';
 
 import type { PactValue } from '@kadena/types';
 import { asyncPipe } from './utils/asyncPipe';
 import type { IClientConfig, IEmit } from './utils/helpers';
-import { extractResult, getClient, throwIfFails } from './utils/helpers';
+import {
+  composeWithDefaults,
+  extractResult,
+  getClient,
+  throwIfFails,
+} from './utils/helpers';
 
 export const dirtyRead =
   <T = PactValue>(
@@ -13,7 +17,7 @@ export const dirtyRead =
   ) =>
   (emit: IEmit) =>
     asyncPipe(
-      composePactCommand(defaults ?? {}),
+      composeWithDefaults(defaults),
       createTransaction,
       client.dirtyRead,
       emit('dirtyRead'),

--- a/packages/libs/client-utils/src/core/submit-and-listen.ts
+++ b/packages/libs/client-utils/src/core/submit-and-listen.ts
@@ -1,11 +1,11 @@
 import { createTransaction } from '@kadena/client';
-import { composePactCommand } from '@kadena/client/fp';
 
 import type { PactValue } from '@kadena/types';
 import { asyncPipe } from './utils/asyncPipe';
 import type { IClientConfig, IEmit } from './utils/helpers';
 import {
   checkSuccess,
+  composeWithDefaults,
   extractResult,
   getClient,
   safeSign,
@@ -19,7 +19,7 @@ export const submitAndListen =
   ) =>
   (emit: IEmit) =>
     asyncPipe(
-      composePactCommand(defaults ?? {}),
+      composeWithDefaults(defaults),
       createTransaction,
       safeSign(sign),
       emit('sign'),

--- a/packages/libs/client-utils/src/core/test/cross-chain-client.test.ts
+++ b/packages/libs/client-utils/src/core/test/cross-chain-client.test.ts
@@ -81,13 +81,9 @@ describe('crossChainClient', () => {
     )
       .on('sign', (tx) => {
         expect(tx).toEqual({
-          cmd: '{"payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000","networkId":"test-network"}',
-          hash: 'ABVQq4j4C4atHw9SzbY7QuSzhyXIkOGo_MI0m9_wT4s',
-          sigs: [
-            {
-              sig: 'sig-hash',
-            },
-          ],
+          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
+          hash: 'uoS6m3KFHVs-8ByRWfiOweZobK1YzV7WloA1DWM1gd4',
+          sigs: [{ sig: 'sig-hash' }],
         });
       })
       .on('preflight', (result) => {
@@ -135,8 +131,8 @@ describe('crossChainClient', () => {
       })
       .on('gas-station', (data) => {
         expect(data).toEqual({
-          cmd: '{"payload":{"cont":{"data":{},"pactId":"test-pact-id","step":1,"proof":"test-spv-proof","rollback":false}},"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"test-gas-station","ttl":28800,"creationTime":1698278400,"chainId":"2"},"nonce":"kjs:nonce:1698278400000","signers":[],"networkId":"test-network"}',
-          hash: '8-Wg0z3Au36tlTACyDhGp5yrseAd6tboVpv_M6g9jBc',
+          cmd: '{"networkId":"test-network","payload":{"cont":{"data":{},"pactId":"test-pact-id","step":1,"proof":"test-spv-proof","rollback":false}},"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"test-gas-station","ttl":28800,"creationTime":1698278400,"chainId":"2"},"nonce":"kjs:nonce:1698278400000","signers":[]}',
+          hash: '5Wz0TmL_2kKEKpB2BiKwmOlesITo-I19nxrGFtN6mXw',
           sigs: [],
         });
       })
@@ -218,13 +214,9 @@ describe('crossChainClient', () => {
     )
       .on('sign', (tx) => {
         expect(tx).toEqual({
-          cmd: '{"payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000","networkId":"test-network"}',
-          hash: 'ABVQq4j4C4atHw9SzbY7QuSzhyXIkOGo_MI0m9_wT4s',
-          sigs: [
-            {
-              sig: 'sig-hash',
-            },
-          ],
+          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
+          hash: 'uoS6m3KFHVs-8ByRWfiOweZobK1YzV7WloA1DWM1gd4',
+          sigs: [{ sig: 'sig-hash' }],
         });
       })
       .on('preflight', (result) => {
@@ -268,8 +260,8 @@ describe('crossChainClient', () => {
       })
       .on('sign-continuation', (tx) => {
         expect(tx).toEqual({
-          cmd: '{"payload":{"cont":{"data":{},"pactId":"test-pact-id","step":1,"proof":"test-spv-proof","rollback":false}},"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"target-chain-gas-payer","ttl":28800,"creationTime":1698278400,"chainId":"2"},"signers":[{"pubKey":"pk-target-chain-gas-payer","scheme":"ED25519","clist":[{"name":"coin.GAS","args":[]}]}],"nonce":"kjs:nonce:1698278400000","networkId":"test-network"}',
-          hash: 'rz7xLTU5BMIE2fbtyYu9yZ1SEIN9mWuaimb3BskEHrY',
+          cmd: '{"networkId":"test-network","payload":{"cont":{"data":{},"pactId":"test-pact-id","step":1,"proof":"test-spv-proof","rollback":false}},"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"target-chain-gas-payer","ttl":28800,"creationTime":1698278400,"chainId":"2"},"nonce":"kjs:nonce:1698278400000","signers":[{"pubKey":"pk-target-chain-gas-payer","scheme":"ED25519","clist":[{"name":"coin.GAS","args":[]}]}]}',
+          hash: '98unmynMm1cd0PSZtIKTSrGrb4pXckPfFo2huVELHiI',
           sigs: [{ sig: 'sig-cont-hash' }],
         });
       })

--- a/packages/libs/client-utils/src/core/test/preflight-client.test.ts
+++ b/packages/libs/client-utils/src/core/test/preflight-client.test.ts
@@ -40,13 +40,9 @@ describe('preflightClient', () => {
     )
       .on('sign', (tx) => {
         expect(tx).toEqual({
-          cmd: '{"payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000","networkId":"test-network"}',
-          hash: 'ABVQq4j4C4atHw9SzbY7QuSzhyXIkOGo_MI0m9_wT4s',
-          sigs: [
-            {
-              sig: 'sig-hash',
-            },
-          ],
+          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
+          hash: 'uoS6m3KFHVs-8ByRWfiOweZobK1YzV7WloA1DWM1gd4',
+          sigs: [{ sig: 'sig-hash' }],
         });
       })
       .on('preflight', (result) => {

--- a/packages/libs/client-utils/src/core/test/submit-client.test.ts
+++ b/packages/libs/client-utils/src/core/test/submit-client.test.ts
@@ -48,13 +48,9 @@ describe('submitClient', () => {
     )
       .on('sign', (tx) => {
         expect(tx).toEqual({
-          cmd: '{"payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000","networkId":"test-network"}',
-          hash: 'ABVQq4j4C4atHw9SzbY7QuSzhyXIkOGo_MI0m9_wT4s',
-          sigs: [
-            {
-              sig: 'sig-hash',
-            },
-          ],
+          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
+          hash: 'uoS6m3KFHVs-8ByRWfiOweZobK1YzV7WloA1DWM1gd4',
+          sigs: [{ sig: 'sig-hash' }],
         });
       })
       .on('preflight', (result) => {

--- a/packages/libs/client-utils/src/core/utils/helpers.ts
+++ b/packages/libs/client-utils/src/core/utils/helpers.ts
@@ -3,12 +3,14 @@ import type {
   ICommandResult,
   INetworkOptions,
   IPactCommand,
+  IPartialPactCommand,
   ISignFunction,
   IUnsignedCommand,
 } from '@kadena/client';
 import { createClient, getHostUrl, isSignedTransaction } from '@kadena/client';
 import type { PactValue } from '@kadena/types';
 
+import { composePactCommand } from '@kadena/client/fp';
 import { getGlobalConfig } from '../global-config';
 import type { Any } from './types';
 
@@ -139,3 +141,15 @@ export const asyncLock = () => {
   lock.close();
   return lock;
 };
+
+type InitialInput =
+  | Partial<IPartialPactCommand>
+  | (() => Partial<IPartialPactCommand>);
+
+export const composeWithDefaults =
+  (
+    defaults: IPartialPactCommand = {},
+    globalConfig = getGlobalConfig().defaults,
+  ) =>
+  (cmd: InitialInput = {}) =>
+    composePactCommand(defaults, cmd)(globalConfig);

--- a/packages/libs/client-utils/src/core/utils/helpers.ts
+++ b/packages/libs/client-utils/src/core/utils/helpers.ts
@@ -9,6 +9,7 @@ import type {
 import { createClient, getHostUrl, isSignedTransaction } from '@kadena/client';
 import type { PactValue } from '@kadena/types';
 
+import { getGlobalConfig } from '../global-config';
 import type { Any } from './types';
 
 export const inspect =
@@ -38,7 +39,7 @@ export const safeSign =
   (
     sign: (
       transaction: IUnsignedCommand,
-    ) => Promise<IUnsignedCommand | ICommand>,
+    ) => Promise<IUnsignedCommand | ICommand> = getGlobalConfig().sign!,
   ) =>
   async (tx: IUnsignedCommand) => {
     if (tx.sigs.length === 0) return tx as ICommand;
@@ -112,7 +113,10 @@ export const extractResult = <T = PactValue>(response: ICommandResult) => {
 };
 
 export const getClient = (
-  host?: string | ((arg: INetworkOptions) => string),
+  host:
+    | undefined
+    | string
+    | ((arg: INetworkOptions) => string) = getGlobalConfig().host,
 ) =>
   typeof host === 'string'
     ? createClient(getHostUrl(host))

--- a/packages/libs/client-utils/src/core/utils/test/helpers.test.ts
+++ b/packages/libs/client-utils/src/core/utils/test/helpers.test.ts
@@ -4,6 +4,7 @@ import type { ICommandResult } from '@kadena/chainweb-node-client';
 import {
   asyncLock,
   checkSuccess,
+  composeWithDefaults,
   extractResult,
   inspect,
   pickFirst,
@@ -206,5 +207,37 @@ describe('asyncLock', () => {
       wait.then(() => 'should not resolve'),
     ]);
     expect(result).toBe('timeout');
+  });
+});
+
+describe('composeWithDefaults', () => {
+  it('returns a function that returns the input', () => {
+    const command = composeWithDefaults(
+      { meta: { chainId: '1', creationTime: 0 } },
+      {
+        meta: {
+          chainId: '2',
+          creationTime: 1,
+          gasLimit: 1,
+          sender: 'sender',
+          ttl: 1,
+        },
+        networkId: 'networkId',
+      },
+    )({ meta: { chainId: '3', gasPrice: 2 }, nonce: 'nonce', signers: [] });
+
+    expect(command).toEqual({
+      meta: {
+        chainId: '3',
+        creationTime: 0,
+        gasLimit: 1,
+        gasPrice: 2,
+        sender: 'sender',
+        ttl: 1,
+      },
+      networkId: 'networkId',
+      nonce: 'nonce',
+      signers: [],
+    });
   });
 });


### PR DESCRIPTION
Introducing setGlobalConfig for clien-utils functions. 
the function accepts this interface.
```TS
interface IClientConfig {
  host: string | ((options: INetworkOptions) => string);
  defaults: Partial<IPactCommand>;
  sign: ISignFunction;
}
```
by having this you just set this option once and then all helpers use this as the default configuration, of course each helper can still override them by passing the object implicitly. 