### PR TITLE
Fix: build package and dependencies for visual regression test, inste…

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build
         if: steps.changed.outputs.pathFilter == 'true'
-        run: pnpm run build
+        run: pnpm run build --filter=${{ matrix.package }}...
 
       - name: Publish Storybook
         if: steps.changed.outputs.pathFilter == 'true'


### PR DESCRIPTION
This PR makes a minor change to the way our packages our built for visual regression tests. Previously, it would build all workspaces, which is inefficient.

Now only the package under test (docs/react-ui) and it's dependencies will be buillt.