### PR TITLE
feat(network): implement network set-default command

### DIFF
--- a/.changeset/big-ears-burn.md
+++ b/.changeset/big-ears-burn.md
@@ -1,0 +1,5 @@
+---
+'@kadena/kadena-cli': minor
+---
+
+Added default network setup

--- a/packages/tools/kadena-cli/README.md
+++ b/packages/tools/kadena-cli/README.md
@@ -166,6 +166,7 @@ Tool to add and manage networks
 | list           | List all available networks |                   |
 | update         | Manage networks             |                   |
 | add            | Add new network             |                   |
+| set-default    | Set default network         |                   |
 | delete         | Delete existing network     |                   |
 
 ---
@@ -184,13 +185,13 @@ kadena network update [arguments]
 example:
 
 ```
-kadena networks update --network-name="mainnet" --network-id="mainnet01" --network-host="https://api.chainweb.com" --network-explorer-url="https://explorer.chainweb.com/mainnet/tx/
+kadena network update --network-name="mainnet" --network-id="mainnet01" --network-host="https://api.chainweb.com" --network-explorer-url="https://explorer.chainweb.com/mainnet/tx/
 ```
 
 ---
 
 ```
-kadena networks add [arguments]
+kadena network add [arguments]
 ```
 
 | **Arguments & Options** | **Description**                      | **Required** |
@@ -208,9 +209,23 @@ kadena network add --network-name="mainnet" --network-id="mainnet01" --network-h
 ```
 
 ---
+```
+kadena network set-default [arguments]
+```
+
+| **Arguments & Options**               | **Description**                       | **Required** |
+| ------------------------------------- | ------------------------------------- | ------------ |
+| --network                             | Select name of network to set default |              |
+| --network-default-confirmation        | Confirmation for default network      |              |
+
+example:
+```
+kadena network set-default --network="testnet" --network-default-confirmation
+```
+---
 
 ```
-kadena networks delete [arguments]
+kadena network delete [arguments]
 ```
 
 | **Arguments & Options** | **Description**                  | **Required** |

--- a/packages/tools/kadena-cli/src/constants/config.ts
+++ b/packages/tools/kadena-cli/src/constants/config.ts
@@ -33,6 +33,9 @@ export const TX_TEMPLATE_FOLDER = `${KADENA_DIR}/transaction-templates`;
 // account path
 export const ACCOUNT_DIR: string = `${KADENA_DIR}/accounts`;
 
+// Default settings path
+export const DEFAULT_SETTINGS_PATH = `${KADENA_DIR}/defaults`;
+
 // key extensions
 export const WALLET_EXT = '.wallet';
 export const WALLET_LEGACY_EXT = '.legacy.wallet';

--- a/packages/tools/kadena-cli/src/constants/networks.ts
+++ b/packages/tools/kadena-cli/src/constants/networks.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import type { INetworkCreateOptions } from '../networks/utils/networkHelpers.js';
-import { NETWORKS_DIR } from './config.js';
+import { DEFAULT_SETTINGS_PATH, NETWORKS_DIR } from './config.js';
 
 export interface IDefaultNetworkOptions {
   [key: string]: INetworkCreateOptions;
@@ -38,6 +38,10 @@ export const networkDefaults: IDefaultNetworkOptions = {
 };
 
 export const defaultNetworksPath: string = NETWORKS_DIR;
+export const defaultNetworksSettingsPath = join(
+  DEFAULT_SETTINGS_PATH,
+  'networks',
+);
 export const standardNetworks: string[] = ['mainnet', 'testnet'];
 export const defaultNetwork: string = 'testnet';
 

--- a/packages/tools/kadena-cli/src/constants/networks.ts
+++ b/packages/tools/kadena-cli/src/constants/networks.ts
@@ -63,3 +63,6 @@ export const networkFiles: INetworkFiles = Object.keys(networkDefaults).reduce(
   },
   {} as INetworkFiles,
 );
+
+export const NETWORK_CONFIG_NOT_FOUND_MESSAGE =
+  'No network configuration found for a network name';

--- a/packages/tools/kadena-cli/src/constants/networks.ts
+++ b/packages/tools/kadena-cli/src/constants/networks.ts
@@ -42,6 +42,11 @@ export const defaultNetworksSettingsPath = join(
   DEFAULT_SETTINGS_PATH,
   'networks',
 );
+export const defaultNetworksSettingsFilePath = join(
+  defaultNetworksSettingsPath,
+  '__default__.yaml',
+);
+
 export const standardNetworks: string[] = ['mainnet', 'testnet'];
 export const defaultNetwork: string = 'testnet';
 

--- a/packages/tools/kadena-cli/src/networks/commands/networkDefault.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkDefault.ts
@@ -23,7 +23,7 @@ export const setNetworkDefault = async (
 
     if (!(await services.filesystem.fileExists(filePath))) {
       return {
-        success: false,
+        status: 'error',
         errors: [
           `The network configuration for network "${network}" does not exist.`,
         ],
@@ -44,12 +44,12 @@ export const setNetworkDefault = async (
     );
 
     return {
-      success: true,
+      status: 'success',
       data: {},
     };
   } catch (error) {
     return {
-      success: false,
+      status: 'error',
       errors: [error.message],
     };
   }
@@ -79,7 +79,7 @@ export const createNetworkSetDefaultCommand: (
     const { networkDefaultConfirmation } =
       await option.networkDefaultConfirmation();
 
-    if (!networkDefaultConfirmation) {
+    if (networkDefaultConfirmation === false) {
       log.warning(`The default network will not be set.`);
       return;
     }

--- a/packages/tools/kadena-cli/src/networks/commands/networkDefault.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkDefault.ts
@@ -1,0 +1,74 @@
+import { Command } from 'commander';
+import path from 'node:path';
+import {
+  defaultNetworksPath,
+  defaultNetworksSettingsPath,
+} from '../../constants/networks.js';
+import { services } from '../../services/index.js';
+import { createCommand } from '../../utils/createCommand.js';
+import { globalOptions } from '../../utils/globalOptions.js';
+import { log } from '../../utils/logger.js';
+import { networkOptions } from '../networkOptions.js';
+
+export const createNetworkSetDefaultCommand: (
+  program: Command,
+  version: string,
+) => void = createCommand(
+  'set-default',
+  'Set default network configuration',
+  [
+    globalOptions.networkSelect({ isOptional: false }),
+    networkOptions.networkDefaultConfirmation({
+      isOptional: true,
+    }),
+  ],
+  async (option) => {
+    const config = await option.network();
+    log.debug('network-set-default:action', config);
+
+    const { network } = config;
+
+    const filePath = path.join(defaultNetworksPath, `${network}.yaml`);
+    if (!(await services.filesystem.fileExists(filePath))) {
+      log.warning(
+        `\nThe network configuration "${config.network}" does not exist.\n`,
+      );
+      return;
+    }
+
+    const defaultNetworkSettingsFilePath = path.join(
+      defaultNetworksSettingsPath,
+      '__default__.yaml',
+    );
+
+    const defaultNetworkAlreadyExists = await services.filesystem.fileExists(
+      defaultNetworkSettingsFilePath,
+    );
+
+    if (defaultNetworkAlreadyExists) {
+      const { networkDefaultConfirmation } =
+        await option.networkDefaultConfirmation();
+      if (!networkDefaultConfirmation) {
+        log.warning(
+          `\nThe default network configuration will not be updated.\n`,
+        );
+        return;
+      }
+    }
+
+    await services.filesystem.ensureDirectoryExists(
+      defaultNetworksSettingsPath,
+    );
+
+    await services.filesystem.writeFile(
+      defaultNetworkSettingsFilePath,
+      network,
+    );
+
+    log.info(
+      log.color.green(
+        `\nThe network configuration "${config.network}" has been set as default.\n`,
+      ),
+    );
+  },
+);

--- a/packages/tools/kadena-cli/src/networks/commands/networkDefault.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkDefault.ts
@@ -1,7 +1,9 @@
 import { Command } from 'commander';
+import yaml from 'js-yaml';
 import path from 'node:path';
 import {
   defaultNetworksPath,
+  defaultNetworksSettingsFilePath,
   defaultNetworksSettingsPath,
 } from '../../constants/networks.js';
 import { services } from '../../services/index.js';
@@ -36,13 +38,8 @@ export const createNetworkSetDefaultCommand: (
       return;
     }
 
-    const defaultNetworkSettingsFilePath = path.join(
-      defaultNetworksSettingsPath,
-      '__default__.yaml',
-    );
-
     const defaultNetworkAlreadyExists = await services.filesystem.fileExists(
-      defaultNetworkSettingsFilePath,
+      defaultNetworksSettingsFilePath,
     );
 
     if (defaultNetworkAlreadyExists) {
@@ -60,9 +57,13 @@ export const createNetworkSetDefaultCommand: (
       defaultNetworksSettingsPath,
     );
 
+    const data = {
+      name: network,
+    };
+
     await services.filesystem.writeFile(
-      defaultNetworkSettingsFilePath,
-      network,
+      defaultNetworksSettingsFilePath,
+      yaml.dump(data),
     );
 
     log.info(

--- a/packages/tools/kadena-cli/src/networks/commands/networkDefault.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkDefault.ts
@@ -1,4 +1,4 @@
-import { Command } from 'commander';
+import type { Command } from 'commander';
 import yaml from 'js-yaml';
 import path from 'node:path';
 import {
@@ -7,50 +7,27 @@ import {
   defaultNetworksSettingsPath,
 } from '../../constants/networks.js';
 import { services } from '../../services/index.js';
+import type { CommandResult } from '../../utils/command.util.js';
+import { assertCommandError } from '../../utils/command.util.js';
 import { createCommand } from '../../utils/createCommand.js';
 import { globalOptions } from '../../utils/globalOptions.js';
+import { isNotEmptyObject } from '../../utils/helpers.js';
 import { log } from '../../utils/logger.js';
 import { networkOptions } from '../networkOptions.js';
 
-export const createNetworkSetDefaultCommand: (
-  program: Command,
-  version: string,
-) => void = createCommand(
-  'set-default',
-  'Set default network configuration',
-  [
-    globalOptions.networkSelect({ isOptional: false }),
-    networkOptions.networkDefaultConfirmation({
-      isOptional: true,
-    }),
-  ],
-  async (option) => {
-    const config = await option.network();
-    log.debug('network-set-default:action', config);
-
-    const { network } = config;
-
+export const setNetworkDefault = async (
+  network: string,
+): Promise<CommandResult<{}>> => {
+  try {
     const filePath = path.join(defaultNetworksPath, `${network}.yaml`);
+
     if (!(await services.filesystem.fileExists(filePath))) {
-      log.warning(
-        `\nThe network configuration "${config.network}" does not exist.\n`,
-      );
-      return;
-    }
-
-    const defaultNetworkAlreadyExists = await services.filesystem.fileExists(
-      defaultNetworksSettingsFilePath,
-    );
-
-    if (defaultNetworkAlreadyExists) {
-      const { networkDefaultConfirmation } =
-        await option.networkDefaultConfirmation();
-      if (!networkDefaultConfirmation) {
-        log.warning(
-          `\nThe default network configuration will not be updated.\n`,
-        );
-        return;
-      }
+      return {
+        success: false,
+        errors: [
+          `The network configuration for network "${network}" does not exist.`,
+        ],
+      };
     }
 
     await services.filesystem.ensureDirectoryExists(
@@ -66,9 +43,53 @@ export const createNetworkSetDefaultCommand: (
       yaml.dump(data),
     );
 
+    return {
+      success: true,
+      data: {},
+    };
+  } catch (error) {
+    return {
+      success: false,
+      errors: [error.message],
+    };
+  }
+};
+
+export const createNetworkSetDefaultCommand: (
+  program: Command,
+  version: string,
+) => void = createCommand(
+  'set-default',
+  'Set default network from the list of available networks.',
+  [
+    globalOptions.network({ isOptional: false }),
+    networkOptions.networkDefaultConfirmation({ isOptional: false }),
+  ],
+  async (option) => {
+    const config = await option.network();
+    log.debug('network-set-default:action', config);
+
+    const { network, networkConfig } = config;
+
+    if (!isNotEmptyObject(networkConfig)) {
+      log.warning(`The network configuration "${network}" does not exist.`);
+      return;
+    }
+
+    const { networkDefaultConfirmation } =
+      await option.networkDefaultConfirmation();
+
+    if (!networkDefaultConfirmation) {
+      log.warning(`The default network will not be set.`);
+      return;
+    }
+
+    const result = await setNetworkDefault(network);
+    assertCommandError(result);
+
     log.info(
       log.color.green(
-        `\nThe network configuration "${config.network}" has been set as default.\n`,
+        `The network configuration "${config.network}" has been set as default.`,
       ),
     );
   },

--- a/packages/tools/kadena-cli/src/networks/commands/networkDelete.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkDelete.ts
@@ -1,8 +1,12 @@
 import { globalOptions } from '../../utils/globalOptions.js';
-import { removeNetwork } from '../utils/networkHelpers.js';
+import {
+  removeDefaultNetwork,
+  removeNetwork,
+} from '../utils/networkHelpers.js';
 
 import type { Command } from 'commander';
 import { createCommand } from '../../utils/createCommand.js';
+import { getDefaultNetworkName } from '../../utils/helpers.js';
 import { log } from '../../utils/logger.js';
 import { networkOptions } from '../networkOptions.js';
 
@@ -17,8 +21,12 @@ export const deleteNetworksCommand: (
     networkOptions.networkDelete(),
   ],
   async (option) => {
+    const defaultNetworkName = await getDefaultNetworkName();
     const networkData = await option.network();
-    const deleteNetwork = await option.networkDelete();
+    const isDefaultNetwork = networkData.network === defaultNetworkName;
+    const deleteNetwork = await option.networkDelete({
+      isDefaultNetwork,
+    });
 
     log.debug('delete-network:action', {
       ...networkData,
@@ -35,6 +43,7 @@ export const deleteNetworksCommand: (
     }
 
     await removeNetwork(networkData.networkConfig);
+    await removeDefaultNetwork();
 
     log.info(
       log.color.green(

--- a/packages/tools/kadena-cli/src/networks/commands/networkDelete.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkDelete.ts
@@ -22,7 +22,10 @@ export const deleteNetworksCommand: (
   ],
   async (option) => {
     const defaultNetworkName = await getDefaultNetworkName();
-    const networkData = await option.network();
+    const networkData = await option.network({
+      default: defaultNetworkName,
+    });
+
     const isDefaultNetwork = networkData.network === defaultNetworkName;
     const deleteNetwork = await option.networkDelete({
       isDefaultNetwork,

--- a/packages/tools/kadena-cli/src/networks/index.ts
+++ b/packages/tools/kadena-cli/src/networks/index.ts
@@ -1,4 +1,5 @@
 import { createNetworksCommand } from './commands/networkCreate.js';
+import { createNetworkSetDefaultCommand } from './commands/networkDefault.js';
 import { deleteNetworksCommand } from './commands/networkDelete.js';
 import { listNetworksCommand } from './commands/networkList.js';
 import { manageNetworksCommand } from './commands/networkManage.js';
@@ -15,8 +16,9 @@ export function networksCommandFactory(
     .command(SUBCOMMAND_ROOT)
     .description(`Tool to create and manage networks`);
 
-  listNetworksCommand(networksProgram, version);
-  manageNetworksCommand(networksProgram, version);
   createNetworksCommand(networksProgram, version);
+  createNetworkSetDefaultCommand(networksProgram, version);
+  manageNetworksCommand(networksProgram, version);
   deleteNetworksCommand(networksProgram, version);
+  listNetworksCommand(networksProgram, version);
 }

--- a/packages/tools/kadena-cli/src/networks/networkOptions.ts
+++ b/packages/tools/kadena-cli/src/networks/networkOptions.ts
@@ -83,4 +83,13 @@ export const networkOptions = {
       'Delete the configuration for network (yes/no)',
     ),
   }),
+  networkDefaultConfirmation: createOption({
+    key: 'networkDefaultConfirmation' as const,
+    prompt: networks.networkDefaultConfirmationPrompt,
+    validation: z.boolean(),
+    option: new Option(
+      '-c, --network-default-confirmation <networkDefaultConfirmation>',
+      'Confirm selected network as default',
+    ),
+  }),
 };

--- a/packages/tools/kadena-cli/src/networks/utils/networkDisplay.ts
+++ b/packages/tools/kadena-cli/src/networks/utils/networkDisplay.ts
@@ -5,7 +5,10 @@ import {
 
 import { log } from '../../utils/logger.js';
 
-import { getExistingNetworks } from '../../utils/helpers.js';
+import {
+  getDefaultNetworkName,
+  getExistingNetworks,
+} from '../../utils/helpers.js';
 import type {
   ICustomNetworkChoice,
   INetworkCreateOptions,
@@ -22,9 +25,10 @@ export async function displayNetworksConfig(): Promise<void> {
     'Network ID',
     'Network Host',
     'Network Explorer URL',
+    'Default Network',
   ];
   const rows: TableRow[] = [];
-
+  const defaultNetworkName = await getDefaultNetworkName();
   const existingNetworks: ICustomNetworkChoice[] = await getExistingNetworks();
   for (const { value } of existingNetworks) {
     const networkFilePath = path.join(defaultNetworksPath, `${value}.yaml`);
@@ -41,6 +45,7 @@ export async function displayNetworksConfig(): Promise<void> {
       networkConfig.networkId ?? 'Not Set',
       networkConfig.networkHost ?? 'Not Set',
       networkConfig.networkExplorerUrl ?? 'Not Set',
+      value === defaultNetworkName ? 'Yes' : 'No',
     ]);
   }
 

--- a/packages/tools/kadena-cli/src/networks/utils/networkHelpers.ts
+++ b/packages/tools/kadena-cli/src/networks/utils/networkHelpers.ts
@@ -1,5 +1,6 @@
 import {
   defaultNetworksPath,
+  defaultNetworksSettingsFilePath,
   networkDefaults,
   networkFiles,
 } from '../../constants/networks.js';
@@ -111,6 +112,10 @@ export async function removeNetwork(
   );
 
   await services.filesystem.deleteFile(networkFilePath);
+}
+
+export async function removeDefaultNetwork(): Promise<void> {
+  await services.filesystem.deleteFile(defaultNetworksSettingsFilePath);
 }
 
 export async function loadNetworkConfig(

--- a/packages/tools/kadena-cli/src/networks/utils/networkHelpers.ts
+++ b/packages/tools/kadena-cli/src/networks/utils/networkHelpers.ts
@@ -6,6 +6,7 @@ import {
 
 import {
   formatZodError,
+  getDefaultNetworkName,
   mergeConfigs,
   sanitizeFilename,
 } from '../../utils/helpers.js';
@@ -133,4 +134,36 @@ export async function ensureNetworksConfiguration(): Promise<void> {
       await writeNetworks(networkDefaults[network]);
     }
   }
+}
+
+interface INetworkChoiceOption {
+  network?: string;
+  name?: string;
+}
+
+export async function getNetworksInOrder<T extends INetworkChoiceOption>(
+  networks: T[],
+): Promise<T[]> {
+  const defaultNetworkName = await getDefaultNetworkName();
+
+  const partitionedNetworks = networks.reduce(
+    (acc, obj) => {
+      const networkKey = obj.network ?? obj.name;
+      if (networkKey === defaultNetworkName) {
+        acc.defaultNetworks.push(obj);
+      } else {
+        acc.remainingNetworks.push(obj);
+      }
+      return acc;
+    },
+    { defaultNetworks: [], remainingNetworks: [] } as {
+      defaultNetworks: T[];
+      remainingNetworks: T[];
+    },
+  );
+
+  return [
+    ...partitionedNetworks.defaultNetworks,
+    ...partitionedNetworks.remainingNetworks,
+  ];
 }

--- a/packages/tools/kadena-cli/src/prompts/network.ts
+++ b/packages/tools/kadena-cli/src/prompts/network.ts
@@ -5,11 +5,13 @@ import { defaultNetworksPath } from '../constants/networks.js';
 import type { ICustomNetworkChoice } from '../networks/utils/networkHelpers.js';
 import {
   ensureNetworksConfiguration,
+  getNetworksInOrder,
   loadNetworkConfig,
 } from '../networks/utils/networkHelpers.js';
 import { services } from '../services/index.js';
 import type { IPrompt } from '../utils/createOption.js';
 import {
+  getDefaultNetworkName,
   getExistingNetworks,
   isAlphabetic,
   isNotEmptyString,
@@ -161,10 +163,13 @@ export const networkSelectPrompt: IPrompt<string> = async (
     );
   }
 
-  const choices: ICustomNetworkChoice[] = filteredNetworks.map((network) => ({
+  const networksInOrder = await getNetworksInOrder(filteredNetworks);
+
+  const choices: ICustomNetworkChoice[] = networksInOrder.map((network) => ({
     value: network.value,
     name: network.name,
   }));
+
   if (isOptional === true) {
     choices.unshift({
       value: 'skip',
@@ -228,7 +233,9 @@ export const networkSelectOnlyPrompt: IPrompt<string> = async (
     );
   }
 
-  const choices: ICustomNetworkChoice[] = filteredNetworks.map((network) => ({
+  const networksInOrder = await getNetworksInOrder(filteredNetworks);
+
+  const choices: ICustomNetworkChoice[] = networksInOrder.map((network) => ({
     value: network.value,
     name: network.name,
   }));

--- a/packages/tools/kadena-cli/src/prompts/network.ts
+++ b/packages/tools/kadena-cli/src/prompts/network.ts
@@ -259,3 +259,23 @@ export const networkDeletePrompt: IPrompt<string> = async (
     ],
   });
 };
+
+export const networkDefaultConfirmationPrompt: IPrompt<boolean> = async (
+  previousQuestions,
+  args,
+  isOptional,
+) => {
+  const defaultValue = args.defaultValue ?? previousQuestions.network;
+  if (defaultValue === undefined) {
+    throw new Error('Network name is required to set the default network.');
+  }
+
+  const message = `Are you sure you want to set "${defaultValue}" as the default network?`;
+  return await select({
+    message,
+    choices: [
+      { value: true, name: 'Yes' },
+      { value: false, name: 'No' },
+    ],
+  });
+};

--- a/packages/tools/kadena-cli/src/prompts/network.ts
+++ b/packages/tools/kadena-cli/src/prompts/network.ts
@@ -257,7 +257,12 @@ export const networkDeletePrompt: IPrompt<string> = async (
   if (previousQuestions.network === undefined) {
     throw new Error('Network name is required for the delete prompt.');
   }
-  const message = `Are you sure you want to delete the configuration for network "${defaultValue}"?`;
+
+  let message = `Are you sure you want to delete the configuration for network "${defaultValue}"?`;
+  if (previousQuestions.isDefaultNetwork) {
+    message += `\nThis is the "default network". If you delete it, then the default network settings will also be deleted.`;
+  }
+
   return await select({
     message,
     choices: [

--- a/packages/tools/kadena-cli/src/prompts/network.ts
+++ b/packages/tools/kadena-cli/src/prompts/network.ts
@@ -11,7 +11,6 @@ import {
 import { services } from '../services/index.js';
 import type { IPrompt } from '../utils/createOption.js';
 import {
-  getDefaultNetworkName,
   getExistingNetworks,
   isAlphabetic,
   isNotEmptyString,
@@ -259,7 +258,7 @@ export const networkDeletePrompt: IPrompt<string> = async (
   }
 
   let message = `Are you sure you want to delete the configuration for network "${defaultValue}"?`;
-  if (previousQuestions.isDefaultNetwork) {
+  if (isNotEmptyString(previousQuestions.isDefaultNetwork)) {
     message += `\nThis is the "default network". If you delete it, then the default network settings will also be deleted.`;
   }
 

--- a/packages/tools/kadena-cli/src/utils/createCommand.ts
+++ b/packages/tools/kadena-cli/src/utils/createCommand.ts
@@ -41,7 +41,7 @@ export async function executeOption<Option extends OptionType>(
     if (args.quiet !== true && args.quiet !== 'true') {
       prompted = true;
       value = await (option.prompt as PromptFn)(args, originalArgs);
-    } else if (args.quiet === true || args.quiet !== 'true') {
+    } else if (args.quiet === true || args.quiet === 'true') {
       value = option.defaultValue;
     } else if (
       option.isOptional === false &&

--- a/packages/tools/kadena-cli/src/utils/createCommand.ts
+++ b/packages/tools/kadena-cli/src/utils/createCommand.ts
@@ -3,7 +3,7 @@ import { CLINAME } from '../constants/config.js';
 import { CommandError, printCommandError } from './command.util.js';
 import type { OptionType, createOption } from './createOption.js';
 import { globalOptions } from './globalOptions.js';
-import { handlePromptError, isNotEmptyString, notEmpty } from './helpers.js';
+import { handlePromptError, notEmpty } from './helpers.js';
 import { log } from './logger.js';
 import { readStdin } from './stdin.js';
 import type { FlattenObject, Fn, Prettify } from './typeUtilities.js';
@@ -34,16 +34,19 @@ export async function executeOption<Option extends OptionType>(
     prompted: boolean;
   }>
 > {
-  let value = isNotEmptyString(args[option.key])
-    ? args[option.key]
-    : option.defaultValue;
+  let value = args[option.key];
   let prompted = false;
 
   if (value === undefined && option.isInQuestions) {
     if (args.quiet !== true && args.quiet !== 'true') {
       prompted = true;
       value = await (option.prompt as PromptFn)(args, originalArgs);
-    } else if (option.isOptional === false) {
+    } else if (args.quiet === true || args.quiet !== 'true') {
+      value = option.defaultValue;
+    } else if (
+      option.isOptional === false &&
+      option.defaultValue === undefined
+    ) {
       // Should have been handled earlier, but just in case
       throw new Error(
         `Missing required argument: ${option.key} (${option.option.flags})`,

--- a/packages/tools/kadena-cli/src/utils/createCommand.ts
+++ b/packages/tools/kadena-cli/src/utils/createCommand.ts
@@ -3,7 +3,7 @@ import { CLINAME } from '../constants/config.js';
 import { CommandError, printCommandError } from './command.util.js';
 import type { OptionType, createOption } from './createOption.js';
 import { globalOptions } from './globalOptions.js';
-import { handlePromptError, notEmpty } from './helpers.js';
+import { handlePromptError, isNotEmptyString, notEmpty } from './helpers.js';
 import { log } from './logger.js';
 import { readStdin } from './stdin.js';
 import type { FlattenObject, Fn, Prettify } from './typeUtilities.js';
@@ -34,7 +34,9 @@ export async function executeOption<Option extends OptionType>(
     prompted: boolean;
   }>
 > {
-  let value = args[option.key];
+  let value = isNotEmptyString(args[option.key])
+    ? args[option.key]
+    : option.defaultValue;
   let prompted = false;
 
   if (value === undefined && option.isInQuestions) {
@@ -276,7 +278,10 @@ export function handleQuietOption(
 ): void {
   if (args.quiet === true) {
     const missing = options.filter(
-      (option) => option.isOptional === false && args[option.key] === undefined,
+      (option) =>
+        option.isOptional === false &&
+        args[option.key] === undefined &&
+        option.defaultValue === undefined,
     );
     if (missing.length) {
       log.error(

--- a/packages/tools/kadena-cli/src/utils/createOption.ts
+++ b/packages/tools/kadena-cli/src/utils/createOption.ts
@@ -21,6 +21,7 @@ export interface IOptionCreatorObject {
   prompt: IPrompt<any>;
   validation: z.ZodSchema;
   option: Option;
+  defaultValue?: unknown;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expand?: (value: any, args: Record<string, unknown>) => unknown;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/tools/kadena-cli/src/utils/globalOptions.ts
+++ b/packages/tools/kadena-cli/src/utils/globalOptions.ts
@@ -25,7 +25,7 @@ import {
 import { readKeyFileContent } from '../keys/utils/storage.js';
 import { loadNetworkConfig } from '../networks/utils/networkHelpers.js';
 import { createOption } from './createOption.js';
-import { passwordPromptTransform } from './helpers.js';
+import { getDefaultNetworkName, passwordPromptTransform } from './helpers.js';
 import { log } from './logger.js';
 
 // eslint-disable-next-line @rushstack/typedef-var
@@ -69,13 +69,13 @@ export const globalOptions = {
   network: createOption({
     key: 'network' as const,
     prompt: networks.networkSelectPrompt,
+    defaultValue: await getDefaultNetworkName(),
     validation: z.string(),
     option: new Option(
       '-n, --network <network>',
       'Kadena network (e.g. "mainnet")',
     ),
     expand: async (network: string) => {
-      // await ensureNetworksConfiguration();
       try {
         return await loadNetworkConfig(network);
       } catch (e) {
@@ -91,6 +91,7 @@ export const globalOptions = {
     key: 'network' as const,
     prompt: networks.networkSelectOnlyPrompt,
     defaultIsOptional: false,
+    defaultValue: await getDefaultNetworkName(),
     validation: z.string(),
     option: new Option(
       '-n, --network <network>',

--- a/packages/tools/kadena-cli/src/utils/helpers.ts
+++ b/packages/tools/kadena-cli/src/utils/helpers.ts
@@ -2,9 +2,13 @@ import { load } from 'js-yaml';
 import path from 'path';
 import sanitize from 'sanitize-filename';
 import type { ZodError } from 'zod';
+import z from 'zod';
 import { MAX_CHARACTERS_LENGTH } from '../constants/config.js';
 import { defaultDevnetsPath, devnetDefaults } from '../constants/devnets.js';
-import { defaultNetworksPath } from '../constants/networks.js';
+import {
+  defaultNetworksPath,
+  defaultNetworksSettingsFilePath,
+} from '../constants/networks.js';
 import type { ICustomDevnetsChoice } from '../devnet/utils/devnetHelpers.js';
 import { writeDevnet } from '../devnet/utils/devnetHelpers.js';
 import type { ICustomNetworkChoice } from '../networks/utils/networkHelpers.js';
@@ -440,3 +444,27 @@ export const passwordPromptTransform =
 
       return trimmedPassword;
     };
+
+const defaultNetworkSchema = z.object({
+  name: z.string(),
+});
+
+export const getDefaultNetworkName = async (): Promise<string | undefined> => {
+  const isDefaultNetworkAvailable = await services.filesystem.fileExists(
+    defaultNetworksSettingsFilePath,
+  );
+
+  if (!isDefaultNetworkAvailable) return;
+
+  const content = await services.filesystem.readFile(
+    defaultNetworksSettingsFilePath,
+  );
+
+  const network = content !== null ? load(content) : null;
+
+  const parse = defaultNetworkSchema.safeParse(network);
+
+  if (parse.success) {
+    return parse.data.name;
+  }
+};

--- a/packages/tools/kadena-cli/src/utils/helpers.ts
+++ b/packages/tools/kadena-cli/src/utils/helpers.ts
@@ -336,6 +336,9 @@ export const maskStringPreservingStartAndEnd = (
 export const isNotEmptyString = (value: unknown): value is string =>
   value !== null && value !== undefined && value !== '';
 
+export const isNotEmptyObject = <T extends object>(obj?: T): obj is T =>
+  obj !== undefined && obj !== null && Object.keys(obj).length > 0;
+
 /**
  * Prints zod error issues in format
  * ```code
@@ -467,4 +470,13 @@ export const getDefaultNetworkName = async (): Promise<string | undefined> => {
   if (parse.success) {
     return parse.data.name;
   }
+};
+
+export const getNetworkName = async (
+  network: string,
+): Promise<string | undefined> => {
+  const networkName = isNotEmptyString(network?.trim())
+    ? network
+    : await getDefaultNetworkName();
+  return networkName;
 };

--- a/packages/tools/kadena-cli/src/utils/helpers.ts
+++ b/packages/tools/kadena-cli/src/utils/helpers.ts
@@ -471,12 +471,3 @@ export const getDefaultNetworkName = async (): Promise<string | undefined> => {
     return parse.data.name;
   }
 };
-
-export const getNetworkName = async (
-  network: string,
-): Promise<string | undefined> => {
-  const networkName = isNotEmptyString(network?.trim())
-    ? network
-    : await getDefaultNetworkName();
-  return networkName;
-};


### PR DESCRIPTION
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206807019750943


`kadena network set-default` command

- It sets default network in a specific file `.kadena/defaults/networks/__default__.yaml` 
- When user list the network they could able to see which is the default network

<img width="1153" alt="image" src="https://github.com/kadena-community/kadena.js/assets/7163943/ee75c804-ef56-422b-84ce-6fb3a8c5a3a7">

- When user deletes the network if it's a default network it will prompted with a warning including it will be deleted from defaults
- Whenever account gets prompted it shows the default network at the top of the list

------------------
When the `--quiet` flag is used:
- If a default network is set and no network argument is provided, the default network should be used without errors.
- If no default network is set and no network argument is provided, an error should be thrown for the missing network argument.

