### PR TITLE
fix: add missing space to log message

### DIFF
--- a/packages/tools/kadena-cli/src/account/commands/accountCreate.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountCreate.ts
@@ -38,6 +38,6 @@ export const createAccountCreateCommand = createCommand(
     });
 
     assertCommandError(result, loader);
-    log.info(log.color.green(`Account "${result.data}"created successfully`));
+    log.info(log.color.green(`Account "${result.data}" created successfully`));
   },
 );


### PR DESCRIPTION
This PR fixes a small typo in one of the responses provided by Kadena CLI.