### PR TITLE
Update README.md

### DIFF
--- a/packages/libs/react-ui/README.md
+++ b/packages/libs/react-ui/README.md
@@ -135,7 +135,7 @@ You can use "next-themes" to set this up in Next.js projects by wrapping
 `Component` with the `ThemeProvider` in `__app.tsx`
 
 ```tsx
-import { darkThemeClass } from '@kadena/react-ui';
+import { darkThemeClass } from '@kadena/react-ui/styles';
 import { ThemeProvider } from 'next-themes';
 
 export const MyApp = ({ Component, pageProps }) => {


### PR DESCRIPTION
Updated import path for darkThemeClass

<!--
Thanks for contributing to this project!

- Saw an issue related to export not found for darkThemeClass for react-ui package. Found out that the import path should include /styles as well in the README.md file for that package.
- Link to the related issue => https://github.com/kadena-community/kadena.js/issues/1883
-->
