### PR TITLE
fix(account): restrict k-account + one public key predicate

### DIFF
--- a/packages/tools/kadena-cli/src/account/commands/accountAddManual.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountAddManual.ts
@@ -3,6 +3,7 @@ import { createCommand } from '../../utils/createCommand.js';
 import { globalOptions } from '../../utils/globalOptions.js';
 import { log } from '../../utils/logger.js';
 import { accountOptions } from '../accountOptions.js';
+import { isValidForOnlyKeysAllPredicate } from '../utils/accountHelpers.js';
 import { addAccount } from '../utils/addAccount.js';
 import { displayAddAccountSuccess } from '../utils/addHelpers.js';
 import { getAccountDetails } from '../utils/getAccountDetails.js';
@@ -51,11 +52,22 @@ export const createAddAccountManualCommand = createCommand(
 
     let publicKeysPrompt;
     let predicate = 'keys-all';
+    let isKeysAllPredicate = false;
 
     // If the user choose not to overwrite the account, we need to ask for the public keys and predicate
     if (!accountOverwrite) {
       publicKeysPrompt = await option.publicKeys();
-      predicate = (await option.predicate()).predicate || 'keys-all';
+      isKeysAllPredicate = isValidForOnlyKeysAllPredicate(
+        accountName,
+        publicKeysPrompt.publicKeysConfig,
+      );
+      const allowedPredicates = isKeysAllPredicate ? ['keys-all'] : undefined;
+      predicate =
+        (
+          await option.predicate({
+            allowedPredicates,
+          })
+        ).predicate || 'keys-all';
     }
 
     const { publicKeys, publicKeysConfig = [] } = publicKeysPrompt ?? {};
@@ -65,6 +77,12 @@ export const createAddAccountManualCommand = createCommand(
     if (!hasAccountDetails && !publicKeysConfig.length) {
       throw new Error(
         'Missing required argument PublicKeys: "-p, --public-keys <publicKeys>"',
+      );
+    }
+
+    if (isKeysAllPredicate && predicate !== 'keys-all') {
+      throw new Error(
+        `Predicate should be keys-all for single public key account with "${accountName}"`,
       );
     }
 

--- a/packages/tools/kadena-cli/src/account/commands/accountAddManual.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountAddManual.ts
@@ -1,3 +1,4 @@
+import { KEYS_ALL_PRED_ERROR_MESSAGE } from '../../constants/account.js';
 import { assertCommandError } from '../../utils/command.util.js';
 import { createCommand } from '../../utils/createCommand.js';
 import { globalOptions } from '../../utils/globalOptions.js';
@@ -81,9 +82,7 @@ export const createAddAccountManualCommand = createCommand(
     }
 
     if (isKeysAllPredicate && predicate !== 'keys-all') {
-      throw new Error(
-        `Predicate should be keys-all for single public key account with "${accountName}"`,
-      );
+      throw new Error(KEYS_ALL_PRED_ERROR_MESSAGE);
     }
 
     const validPublicKeys = publicKeysConfig.filter((key) => !!key);

--- a/packages/tools/kadena-cli/src/account/commands/accountCreate.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountCreate.ts
@@ -1,4 +1,5 @@
 import ora from 'ora';
+import { KEYS_ALL_PRED_ERROR_MESSAGE } from '../../constants/account.js';
 import { assertCommandError } from '../../utils/command.util.js';
 import { createCommand } from '../../utils/createCommand.js';
 import { globalOptions } from '../../utils/globalOptions.js';
@@ -24,12 +25,11 @@ export const createAccountCreateCommand = createCommand(
   async (option) => {
     const { accountName } = await option.accountName();
     const { publicKeysConfig } = await option.publicKeys();
-    const allowedPredicates = isValidForOnlyKeysAllPredicate(
+    const isOnlyKeysAllPredicate = isValidForOnlyKeysAllPredicate(
       accountName,
       publicKeysConfig,
-    )
-      ? ['keys-all']
-      : undefined;
+    );
+    const allowedPredicates = isOnlyKeysAllPredicate ? ['keys-all'] : undefined;
 
     const { predicate } = (await option.predicate({
       allowedPredicates,
@@ -39,6 +39,10 @@ export const createAccountCreateCommand = createCommand(
 
     const { chainId } = await option.chainId();
     const fungible = (await option.fungible()).fungible || 'coin';
+
+    if (isOnlyKeysAllPredicate && predicate !== 'keys-all') {
+      throw new Error(KEYS_ALL_PRED_ERROR_MESSAGE);
+    }
 
     const config = {
       accountName,

--- a/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
+++ b/packages/tools/kadena-cli/src/account/utils/accountHelpers.ts
@@ -209,3 +209,11 @@ export const getTransactionExplorerUrl = (
   const baseURL = explorerURL.endsWith('/') ? explorerURL : `${explorerURL}/`;
   return `${baseURL}${requestKey}`;
 };
+
+export const isKAccount = (accountName: string): boolean =>
+  accountName.startsWith('k:');
+
+export const isValidForOnlyKeysAllPredicate = (
+  accountName: string,
+  publicKeys: string[],
+): boolean => isKAccount(accountName) && publicKeys.length === 1;

--- a/packages/tools/kadena-cli/src/constants/account.ts
+++ b/packages/tools/kadena-cli/src/constants/account.ts
@@ -19,3 +19,5 @@ export const NO_ACCOUNTS_FOUND_ERROR_MESSAGE =
 
 export const CHAIN_ID_ACTION_ERROR_MESSAGE = 'Please provide a valid Chain ID.';
 export const CHAIN_ID_RANGE_ERROR_MESSAGE = `Enter a valid chainId: between 0-${MAX_CHAIN_VALUE}`;
+export const KEYS_ALL_PRED_ERROR_MESSAGE =
+  'Only "keys-all" predicate is allowed for the given public keys and account name';

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -48,7 +48,7 @@ export const accountAliasPrompt: IPrompt<string> = async () =>
 
 export const accountNamePrompt: IPrompt<string> = async () =>
   await input({
-    message: 'Enter an account name:',
+    message: 'Enter an account name (optional):',
   });
 
 export const accountKdnAddressPrompt: IPrompt<string> = async () =>
@@ -82,7 +82,12 @@ export const fungiblePrompt: IPrompt<string> = async () =>
     message: 'Enter the name of a fungible:',
   });
 
-export const predicatePrompt: IPrompt<string> = async () => {
+export const predicatePrompt: IPrompt<string> = async (previousQuestions) => {
+  const allowedPredicates =
+    previousQuestions.allowedPredicates !== undefined
+      ? (previousQuestions.allowedPredicates as string[])
+      : [];
+
   const choices = [
     {
       value: 'keys-all',
@@ -102,9 +107,15 @@ export const predicatePrompt: IPrompt<string> = async () => {
     },
   ];
 
+  const filteredChoices = choices.filter(
+    (choice) =>
+      allowedPredicates.length === 0 ||
+      allowedPredicates.includes(choice.value),
+  );
+
   const selectedPredicate = await select({
     message: 'Select a keyset predicate.',
-    choices: choices,
+    choices: filteredChoices,
   });
 
   if (selectedPredicate === 'custom') {


### PR DESCRIPTION
As part of account creation if the account is `k:account` and only one publicKeys are passed then the predicate should always be `keys-all`. When user tries to create an account with different predicates like `keys-any` or `key-2` then anyway we get the error from chain as a `Single-key account protocol violation` . 

As part of this PR, when account is k account and only one public keys are selected we make sure to display only `keys-all`  as part of predicate prompt.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206767453052195