### PR TITLE
fix(tx-status): add poll option 

### DIFF
--- a/packages/tools/kadena-cli/README.md
+++ b/packages/tools/kadena-cli/README.md
@@ -1026,6 +1026,7 @@ kadena tx send --tx-signed-transaction-files="transaction-I4WaMUwQZDxhaf2r2FZj0T
 ```
 kadena tx status [arguments]
 ```
+The kadena tx status command is used to retrieve the status of a transaction on the Kadena blockchain. By providing a transaction request key and specifying the network and chain id, users can query the current state of their transactions. This command supports additional options for polling, allowing for real-time status updates until the transaction is finalized.
 
 | **Arguments & Options** | **Description**                                       | **Required** |
 | ----------------------- | ----------------------------------------------------- | ------------ |
@@ -1033,12 +1034,23 @@ kadena tx status [arguments]
 | --network               | Select name of the network where transaction happened |              |
 |                         | (e.g. "mainnet, testnet, devnet, ...")                |              |
 | --chain-id              | Chain to be used in the transaction                   |              |
+| --poll                  | Poll status to get transaction details                |              |
 
-example:
-
+To check the status of a transaction, use the following command:
 ```
 kadena tx status --request-key="118mEpX1-6NpJT1kArsWIHHVtJaOERQOeEwNoouOSGU" --network="testnet" --chain-id="0"
 ```
+This will return the current status of the transaction identified by the provided request key.
+
+**With Polling:**
+To continuously monitor the status of a transaction until it is finalized, add the `--poll` option:
+
+```
+kadena tx status --request-key="118mEpX1-6NpJT1kArsWIHHVtJaOERQOeEwNoouOSGU" --network="testnet" --chain-id="0" --poll
+```
+Polling checks the transaction status in real-time and will keep running until the transaction is confirmed.
+
+The default timeout for polling is 60 seconds, but it will attempt to keep polling until confirmation is achieved.
 
 ---
 

--- a/packages/tools/kadena-cli/src/tx/commands/txStatus.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txStatus.ts
@@ -49,7 +49,7 @@ export const getTxStatus = async ({
         status: 'error',
         errors: [
           notFoundErrorMessage,
-          `If the transaction is just submitted, please try with poll flag "kadena tx status --request-key=${requestKey} --chain-id=${chainId} --network=${networkConfig.network} --poll"`,
+          `If the transaction is just submitted, please try with poll flag: kadena tx status --request-key=${requestKey} --chain-id=${chainId} --network=${networkConfig.network} --poll`,
         ],
       };
     }

--- a/packages/tools/kadena-cli/src/tx/commands/txStatus.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txStatus.ts
@@ -10,33 +10,59 @@ import { globalOptions } from '../../utils/globalOptions.js';
 import { log } from '../../utils/logger.js';
 import { txOptions } from '../txOptions.js';
 
-export const getTxStatus = async (config: {
+export const getTxStatus = async ({
+  requestKey,
+  chainId,
+  networkConfig,
+  txPoll,
+}: {
   requestKey: string;
   chainId: ChainId;
-  networkConfig: INetworkCreateOptions;
+  networkConfig: Omit<INetworkCreateOptions, 'networkExplorerUrl'>;
+  txPoll: boolean;
 }): Promise<CommandResult<ICommandResult>> => {
+  const notFoundErrorMessage = `No Transaction found for requestkey "${requestKey}" on network "${networkConfig.networkId}" and chain "${chainId}".`;
   try {
-    const { pollStatus } = createClient(
-      `${config.networkConfig.networkHost}/chainweb/0.0/${config.networkConfig.networkId}/chain/${config.chainId}/pact`,
+    const { getStatus, pollStatus } = createClient(
+      `${networkConfig.networkHost}/chainweb/0.0/${networkConfig.networkId}/chain/${chainId}/pact`,
     );
-    const result = await pollStatus(
-      {
-        requestKey: config.requestKey,
-        chainId: config.chainId,
-        networkId: config.networkConfig.networkId,
-      },
-      { timeout: 25000 },
-    );
+    let result = null;
+    const payload = {
+      requestKey: requestKey,
+      chainId: chainId,
+      networkId: networkConfig.networkId,
+    };
+    if (txPoll) {
+      result = await pollStatus(payload, {
+        timeout: 60000,
+      });
+    } else {
+      result = await getStatus(payload);
+    }
+
+    const trimmedRequestKey = requestKey.endsWith('=')
+      ? requestKey.slice(0, -1)
+      : requestKey;
+
+    if (result[trimmedRequestKey] === undefined) {
+      return {
+        status: 'error',
+        errors: [
+          notFoundErrorMessage,
+          `If the transaction is just submitted, please try with poll flag "kadena tx status --request-key=${requestKey} --chain-id=${chainId} --network=${networkConfig.network} --poll"`,
+        ],
+      };
+    }
 
     return {
       status: 'success',
-      data: result[config.requestKey],
+      data: result[trimmedRequestKey],
     };
   } catch (error) {
     const errorMessage =
       error.message === 'TIME_OUT_REJECT'
-        ? `Transaction request for ${config.requestKey} is timed out. Please check your "chainID" input and try again.`
-        : `Transaction request for ${config.requestKey} is failed with : ${error.message}`;
+        ? `Request timed out.\n ${notFoundErrorMessage}`
+        : `Transaction for request key "${requestKey}" is failed with : ${error.message}`;
     return {
       status: 'error',
       errors: [errorMessage],
@@ -87,14 +113,15 @@ export const createTxStatusCommand: (
     txOptions.requestKey(),
     globalOptions.networkSelect({ isOptional: false }),
     globalOptions.chainId(),
+    txOptions.txPoll(),
   ],
   async (option, { collect }) => {
-    log.debug('status-tx:action');
-
     const config = await collect(option);
+    log.debug('status-tx:action', config);
 
-    const loader = ora('Getting transaction...\n').start();
-
+    const loader = config.txPoll
+      ? ora('Getting transaction...\n').start()
+      : undefined;
     const result = await getTxStatus(config);
     assertCommandError(result, loader);
 


### PR DESCRIPTION
`tx status` by default it uses the `getStatus` method to fetch the data. If the transaction not found returns an error message with an hint for the user to try it out with `poll` flag. 

If user uses the `--poll` option then it uses the `pollStatus` method to fetch the data to keep polling for a minute. If the request not found in a minute then request gets timedout. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206932423881496
  - https://app.asana.com/0/0/1206930586643761