### PR TITLE
fix(cli): test feedback on network set-default and account details command

### DIFF
--- a/packages/tools/kadena-cli/README.md
+++ b/packages/tools/kadena-cli/README.md
@@ -660,6 +660,7 @@ kadena account fund [arguments]
 | --amount                | Amount to fund                                                                                                                            |              |
 | --network               | Name of the network to be used                                                                                                            |              |
 | --chain-id              | Provide the chain ID associated with the account<br/>Supports individual IDs, ranges (e.g., "1-5" or 2,5), <br/> or "all" for all chains. |              |
+| --fungible              | Fungible e.g coin (by default coin is used)                                                                                               |              |
 
 Example: **Single Chain ID:**
 

--- a/packages/tools/kadena-cli/README.md
+++ b/packages/tools/kadena-cli/README.md
@@ -217,18 +217,18 @@ kadena network set-default [options]
 | **Arguments & Options**        | **Description**                               | **Required** |
 | ------------------------------ | --------------------------------------------- | ------------ |
 | --network                      | Select name of network to set default         |              |
-| --network-default-confirmation | Confirmation for default network to set/unset |              |
+| --confirm                      | Confirmation for default network to set/unset |              |
 
 example for setting default network:
 
 ```
-kadena network set-default --network="testnet" --network-default-confirmation
+kadena network set-default --network="testnet" --confirm
 ```
 
 example for removing default network:
 
 ```
-kadena network set-default --network="none" --network-default-confirmation
+kadena network set-default --network="none" --confirm
 ```
 
 ## Passing a network as "none" will remove the default network
@@ -854,7 +854,7 @@ signers:
   - public: '{{key:from}}'
     caps:
       - name: 'coin.TRANSFER'
-        args: ['{{{account:from}}}', '{{{account:to}}}', {{ decimal:amount }}]
+        args: ['{{{account:from}}}', '{{{account:to}}}', { { decimal:amount } }]
       - name: 'coin.GAS'
         args: []
 networkId: '{{network:networkId}}'

--- a/packages/tools/kadena-cli/README.md
+++ b/packages/tools/kadena-cli/README.md
@@ -602,7 +602,9 @@ kadena account details [arguments]
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
 | --account               | Provide account alias/name to retrieve its details                                                                                        |              |
 | --network               | Name of the network to be used                                                                                                            |              |
+| --fungible              | Type of fungible asset (e.g., "coin").                                                                                                    |              |
 | --chain-id              | Provide the chain ID associated with the account<br/>Supports individual IDs, ranges (e.g., "1-5" or 2,5), <br/> or "all" for all chains. |              |
+
 
 Example: **Single Chain ID:**
 
@@ -611,12 +613,14 @@ using account alias:
 ```
 kadena account details --account="myalias" --network="mainnet" --chain-id="1"
 ```
+Note: Fungible type is retrieved from the account alias file.
 
 using account name:
 
 ```
 kadena account details --account="k:PUBLIC_KEY" --network="mainnet" --chain-id="1"
 ```
+Note: Specify `--fungible` if using an account name. Defaults to "coin" if not provided.
 
 **Chain ID Range:**
 
@@ -660,7 +664,7 @@ kadena account fund [arguments]
 | --amount                | Amount to fund                                                                                                                            |              |
 | --network               | Name of the network to be used                                                                                                            |              |
 | --chain-id              | Provide the chain ID associated with the account<br/>Supports individual IDs, ranges (e.g., "1-5" or 2,5), <br/> or "all" for all chains. |              |
-| --fungible              | Fungible e.g coin (by default coin is used)                                                                                               |              |
+| --fungible              | Type of fungible asset (e.g., "coin") Defaults to "coin" if not provided                                                                  |              |
 
 Example: **Single Chain ID:**
 
@@ -855,7 +859,7 @@ signers:
   - public: '{{key:from}}'
     caps:
       - name: 'coin.TRANSFER'
-        args: ['{{{account:from}}}', '{{{account:to}}}', { { decimal:amount } }]
+        args: ['{{{account:from}}}', '{{{account:to}}}', {{ decimal:amount }}]
       - name: 'coin.GAS'
         args: []
 networkId: '{{network:networkId}}'

--- a/packages/tools/kadena-cli/src/account/commands/accountDetails.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountDetails.ts
@@ -26,11 +26,11 @@ interface IAccountDetails {
 
 const formatWarnings = (warnings: string[]): string | null => {
   if (warnings.length === 0) return null;
-  const [prefix, ...chainIds] = warnings;
+  const [prefix, suffix, ...chainIds] = warnings;
   const sortedChainIds = chainIds.sort(
     (a, b) => parseInt(a, 10) - parseInt(b, 10),
   );
-  return `${prefix} ${sortedChainIds.join(',')}`;
+  return `${prefix} ${sortedChainIds.join(',')} ${suffix}`;
 };
 
 export async function accountDetails(
@@ -55,8 +55,9 @@ export async function accountDetails(
           if (error.message.includes('row not found') === true) {
             if (warnings.length === 0) {
               warnings.push(
-                `\nAccount "${config.accountName}" is not available on\nfollowing chain(s) of the "${config.networkId}" network:`,
+                `\nAccount "${config.accountName}" is not available on\nfollowing chain(s):`,
               );
+              warnings.push(`on network "${config.networkId}"`);
             }
             warnings.push(chainId);
             return null;

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/accountDetails.test.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/accountDetails.test.ts
@@ -50,7 +50,7 @@ describe('accountDetails', () => {
       networkHost: devNetConfigMock.networkHost,
       fungible: 'coin',
     });
-    const warningMsg = `\nAccount "k:accountName" is not available on\nfollowing chain(s) of the "development" network: 1`;
+    const warningMsg = `\nAccount "k:accountName" is not available on\nfollowing chain(s): 1 on network "development"`;
     expect(result.warnings).toStrictEqual([warningMsg]);
   });
 });

--- a/packages/tools/kadena-cli/src/networks/commands/networkDefault.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkDefault.ts
@@ -98,13 +98,12 @@ export const createNetworkSetDefaultCommand: (
       confirmationErrorMsg = 'The default network will not be removed.';
     }
 
-    const { networkDefaultConfirmation } =
-      await option.networkDefaultConfirmation({
-        action,
-        network: networkName,
-      });
+    const { confirm } = await option.confirm({
+      action,
+      network: networkName,
+    });
 
-    if (networkDefaultConfirmation === false) {
+    if (confirm === false) {
       log.warning(confirmationErrorMsg);
       return;
     }

--- a/packages/tools/kadena-cli/src/networks/networkOptions.ts
+++ b/packages/tools/kadena-cli/src/networks/networkOptions.ts
@@ -85,11 +85,11 @@ export const networkOptions = {
     ),
   }),
   networkDefaultConfirmation: createOption({
-    key: 'networkDefaultConfirmation' as const,
+    key: 'confirm' as const,
     prompt: networks.networkDefaultConfirmationPrompt,
     validation: z.boolean(),
     option: new Option(
-      '-c, --network-default-confirmation',
+      '-c, --confirm',
       'Confirm to set/unset the network as default',
     ),
   }),


### PR DESCRIPTION
- Add fungible flag in the readme docs for account details and fund command - https://app.asana.com/0/0/1206807019750931/1206951762878090/f
- Improve error message for account not found https://app.asana.com/0/0/1206807019750931/1206957916687828/f
- Update network default confirmation flag from `--networkDefaultConfirmation` to `--confirm` https://app.asana.com/0/0/1206807019750943/1206951762878094/f