### PR TITLE
feat(kadena-cli): convert wallet import mnemonic to prompt or file input

### DIFF
--- a/packages/tools/kadena-cli/src/prompts/keys.ts
+++ b/packages/tools/kadena-cli/src/prompts/keys.ts
@@ -18,8 +18,11 @@ export async function keyAliasPrompt(): Promise<string> {
   });
 }
 
-export async function keyMnemonicPrompt(): Promise<string> {
-  return await input({
+export async function keyMnemonicPrompt(
+  args: Record<string, unknown>,
+): Promise<'-' | { _secret: string }> {
+  if ((args.stdin as string | null) !== null) return '-';
+  const secret = await input({
     message: `Enter your 12-word mnemonic phrase:`,
     validate: function (input) {
       const words = input
@@ -42,6 +45,7 @@ export async function keyMnemonicPrompt(): Promise<string> {
         .join(' ');
     },
   });
+  return { _secret: secret };
 }
 
 export async function keyAmountPrompt(): Promise<string> {

--- a/packages/tools/kadena-cli/src/services/wallet/wallet.service.ts
+++ b/packages/tools/kadena-cli/src/services/wallet/wallet.service.ts
@@ -38,7 +38,7 @@ export interface IWalletService {
   import: (wallet: IWalletImport) => Promise<IWallet>;
   delete: (filepath: string) => Promise<void>;
   generateKey: (data: IWalletKeyCreate) => Promise<IWalletKey>;
-  /** stores given key and mutates key array in wallet */
+  /** Stores given key and returns a new wallet. Note: wallet passed in arguments in not mutated. */
   storeKey: (wallet: IWallet, key: IWalletKey) => Promise<IWallet>;
   getKeyPair: (
     wallet: IWallet,

--- a/packages/tools/kadena-cli/src/utils/globalOptions.ts
+++ b/packages/tools/kadena-cli/src/utils/globalOptions.ts
@@ -225,12 +225,12 @@ export const securityOptions = {
     return createOption({
       key: 'passwordFile' as const,
       prompt: security.passwordPrompt(args),
-      validation: z.string().or(z.object({ _password: z.string() })),
+      validation: z.literal('-').or(z.object({ _password: z.string() })),
       option: new Option(
         '--password-file <passwordFile>',
         'Filepath to the password file',
       ),
-      transform: passwordPromptTransform('--password-file'),
+      transform: passwordPromptTransform('--password-file', args.useStdin),
     })(optionArgs);
   },
   createNewPasswordOption: (
@@ -240,12 +240,12 @@ export const securityOptions = {
     return createOption({
       key: 'newPasswordFile' as const,
       prompt: security.passwordPrompt(args),
-      validation: z.string().or(z.object({ _password: z.string() })),
+      validation: z.literal('-').or(z.object({ _password: z.string() })),
       option: new Option(
         '--new-password-file <newPasswordFile>',
         'Filepath to the new password file',
       ),
-      transform: passwordPromptTransform('--new-password-file'),
+      transform: passwordPromptTransform('--new-password-file', args.useStdin),
     })(optionArgs);
   },
 };

--- a/packages/tools/kadena-cli/src/wallets/walletOptions.ts
+++ b/packages/tools/kadena-cli/src/wallets/walletOptions.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { keys, wallets } from '../prompts/index.js';
 import { services } from '../services/index.js';
 import { createOption } from '../utils/createOption.js';
+import { mnemonicPromptTransform } from '../utils/helpers.js';
 
 export const walletOptions = {
   walletName: createOption({
@@ -26,14 +27,15 @@ export const walletOptions = {
         : await services.wallet.getByAlias(walletName);
     },
   }),
-  keyMnemonic: createOption({
-    key: 'keyMnemonic' as const,
+  mnemonicFile: createOption({
+    key: 'mnemonicFile' as const,
     prompt: keys.keyMnemonicPrompt,
-    validation: z.string(),
+    validation: z.literal('-').or(z.object({ _secret: z.string() })),
     option: new Option(
-      '-m, --key-mnemonic <keyMnemonic>',
-      'Enter your 12-word mnemonic phrase to generate keys from',
+      '-m, --mnemonic-file <mnemonicFile>',
+      'Filepath to your 12-word mnemonic phrase file to generate keys from (can be passed via stdin)',
     ),
+    transform: mnemonicPromptTransform('--mnemonic-file'),
   }),
   createAccount: createOption({
     key: 'createAccount' as const,


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->
