### PR TITLE
[@kadena/graph] Alter condition to get non-fungible related transactions (Feat)

### DIFF
--- a/.changeset/friendly-fireants-exist.md
+++ b/.changeset/friendly-fireants-exist.md
@@ -1,0 +1,6 @@
+---
+'@kadena/graph': patch
+---
+
+Changed non-fungible account query to accomodate all transactions made with
+marmalade-v2

--- a/packages/apps/graph/src/graph/objects/non-fungible-account.ts
+++ b/packages/apps/graph/src/graph/objects/non-fungible-account.ts
@@ -101,7 +101,7 @@ export default builder.node(
                 senderAccount: parent.accountName,
                 events: {
                   some: {
-                    moduleName: 'marmalade-v2.ledger',
+                    moduleName: { startsWith: 'marmalade-v2' },
                   },
                 },
               },
@@ -118,7 +118,7 @@ export default builder.node(
                 senderAccount: parent.accountName,
                 events: {
                   some: {
-                    moduleName: 'marmalade-v2.ledger',
+                    moduleName: { startsWith: 'marmalade-v2' },
                   },
                 },
               },

--- a/packages/apps/graph/src/graph/objects/non-fungible-chain-account.ts
+++ b/packages/apps/graph/src/graph/objects/non-fungible-chain-account.ts
@@ -75,7 +75,7 @@ export default builder.node(
               senderAccount: parent.accountName,
               events: {
                 some: {
-                  moduleName: 'marmalade-v2.ledger',
+                  moduleName: { startsWith: 'marmalade-v2' },
                 },
               },
               chainId: parseInt(parent.chainId),
@@ -90,7 +90,7 @@ export default builder.node(
                 senderAccount: parent.accountName,
                 events: {
                   some: {
-                    moduleName: 'marmalade-v2.ledger',
+                    moduleName: { startsWith: 'marmalade-v2' },
                   },
                 },
                 chainId: parseInt(parent.chainId),


### PR DESCRIPTION
After discussing with Jermaine we reached some conclusions:
- By changing the `moduleName` to match `marmalade-v2` instead of `marmalade-v2.ledger` we include the policy-manager and concrete policies-related transactions: with this change we do get 90% of all the marmalade traffic
- There is no deterministic way to get all the transactions related to non-fungibles: a token creator can add his own policy with custom events we don't know about 


<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206939031903713