### PR TITLE
feat(kadena-cli) auto select network or fallback to prompt

### DIFF
--- a/packages/tools/kadena-cli/src/prompts/tx.ts
+++ b/packages/tools/kadena-cli/src/prompts/tx.ts
@@ -519,7 +519,7 @@ function determineNetwork(networkId: string | null): string {
     return 'testnet';
   } else if (id.includes('mainnet')) {
     return 'mainnet';
-  } else if (id.includes('devnet')) {
+  } else if (id.includes('development')) {
     return 'devnet';
   }
   return '';

--- a/packages/tools/kadena-cli/src/tx/commands/txSend.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txSend.ts
@@ -28,6 +28,7 @@ import { parseTransactionsFromStdin } from '../utils/input.js';
 import {
   extractCommandData,
   getTransactionsFromFile,
+  logTransactionDetails,
 } from '../utils/txHelpers.js';
 
 interface INetworkDetails extends INetworkCreateOptions {
@@ -141,6 +142,7 @@ export const sendTransactionAction = async ({
 
       const client = getClient(details);
 
+      await logTransactionDetails(command);
       const localResponse = await client.local(command);
       if (localResponse.result.status === 'failure') {
         throw localResponse.result.error;

--- a/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
+++ b/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
@@ -10,7 +10,12 @@ import {
   kadenaSign as legacyKadenaSign,
   kadenaSignFromRootKey as legacyKadenaSignWithSeed,
 } from '@kadena/hd-wallet/chainweaver';
-import type { ICommand, IKeyPair, IUnsignedCommand } from '@kadena/types';
+import type {
+  ICommand,
+  ICommandPayload,
+  IKeyPair,
+  IUnsignedCommand,
+} from '@kadena/types';
 
 import { isAbsolute, join } from 'path';
 import { z } from 'zod';
@@ -642,4 +647,30 @@ export function displaySignersFromUnsignedCommands(
     );
     log.output(tableString, command.signers);
   });
+}
+
+export async function logTransactionDetails(command: ICommand): Promise<void> {
+  const header = ['Network ID', 'Chain ID'];
+  const rows: Array<Array<string>> = [];
+
+  try {
+    const cmdPayload: ICommandPayload = JSON.parse(command.cmd);
+    const networkId = cmdPayload.networkId ?? 'N/A';
+    const chainId = cmdPayload.meta.chainId ?? 'N/A';
+    const hash = command.hash ?? 'N/A';
+
+    rows.push([networkId, chainId]);
+
+    if (rows.length > 0) {
+      log.info(
+        log.color.green(`\nTransation details for command with hash: ${hash}`),
+      );
+      log.output(log.generateTableString(header, rows), command);
+      log.info('\n\n');
+    } else {
+      log.info(`No transaction details to display for hash: ${hash}`);
+    }
+  } catch (error) {
+    log.info(`No transaction details to display`);
+  }
 }

--- a/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
+++ b/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
@@ -663,7 +663,7 @@ export async function logTransactionDetails(command: ICommand): Promise<void> {
 
     if (rows.length > 0) {
       log.info(
-        log.color.green(`\nTransation details for command with hash: ${hash}`),
+        log.color.green(`\nTransaction detail for command with hash: ${hash}`),
       );
       log.output(log.generateTableString(header, rows), command);
       log.info('\n\n');


### PR DESCRIPTION
[x] Automatically select network (id) when sending or fallback to prompt
[x] Added logging so its more clear what transactions is being send and might fail