### PR TITLE
fix: network update command + refactor consistent file name validation

### DIFF
--- a/packages/tools/kadena-cli/src/constants/config.ts
+++ b/packages/tools/kadena-cli/src/constants/config.ts
@@ -42,3 +42,6 @@ export const MAX_CHARACTERS_LENGTH = 80;
 
 export const MAX_CHAIN_IDS: number = 20;
 export const MAX_CHAIN_VALUE: number = MAX_CHAIN_IDS - 1;
+
+export const INVALID_FILE_NAME_ERROR_MSG =
+  'Do not use these characters: \\ / : * ? " < > |. Please choose a different name without these characters';

--- a/packages/tools/kadena-cli/src/networks/commands/networkManage.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkManage.ts
@@ -6,7 +6,11 @@ import { createCommand } from '../../utils/createCommand.js';
 import { globalOptions } from '../../utils/globalOptions.js';
 import { log } from '../../utils/logger.js';
 import { networkOptions } from '../networkOptions.js';
-import { removeNetwork, writeNetworks } from '../utils/networkHelpers.js';
+import {
+  mergeNetworkConfig,
+  removeNetwork,
+  writeNetworks,
+} from '../utils/networkHelpers.js';
 
 /**
  * Creates a command to generate wallets.
@@ -38,7 +42,7 @@ export const manageNetworksCommand: (
     const networkHost = await option.networkHost();
     const networkExplorerUrl = await option.networkExplorerUrl();
 
-    log.debug('manage-networks', {
+    log.debug('update-network:action', {
       networkExplorerUrl,
       networkHost,
       networkId,
@@ -48,16 +52,18 @@ export const manageNetworksCommand: (
     const hasNetworkNameChanged =
       networkData.network !== networkName.networkName;
 
-    await writeNetworks(
+    const updatedNetworkConfig = await mergeNetworkConfig(
       kadenaDir,
+      networkData.network,
       {
         network: networkName.networkName,
         networkId: networkId.networkId,
         networkHost: networkHost.networkHost,
         networkExplorerUrl: networkExplorerUrl.networkExplorerUrl,
       },
-      hasNetworkNameChanged ? networkData.network : undefined,
     );
+
+    await writeNetworks(kadenaDir, updatedNetworkConfig);
 
     if (hasNetworkNameChanged) {
       await removeNetwork(networkData.networkConfig);

--- a/packages/tools/kadena-cli/src/networks/commands/networkManage.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkManage.ts
@@ -45,14 +45,21 @@ export const manageNetworksCommand: (
       networkName,
     });
 
-    await writeNetworks(kadenaDir, {
-      network: networkName.networkName,
-      networkId: networkId.networkId,
-      networkHost: networkHost.networkHost,
-      networkExplorerUrl: networkExplorerUrl.networkExplorerUrl,
-    });
+    const hasNetworkNameChanged =
+      networkData.network !== networkName.networkName;
 
-    if (networkData.network !== networkName.networkName) {
+    await writeNetworks(
+      kadenaDir,
+      {
+        network: networkName.networkName,
+        networkId: networkId.networkId,
+        networkHost: networkHost.networkHost,
+        networkExplorerUrl: networkExplorerUrl.networkExplorerUrl,
+      },
+      hasNetworkNameChanged ? networkData.network : undefined,
+    );
+
+    if (hasNetworkNameChanged) {
       await removeNetwork(networkData.networkConfig);
     }
 

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -11,6 +11,7 @@ import { MAX_CHAIN_VALUE } from '../constants/config.js';
 import type { IPrompt } from '../utils/createOption.js';
 import {
   formatZodError,
+  isValidFilename,
   maskStringPreservingStartAndEnd,
   truncateText,
 } from '../utils/globalHelpers.js';
@@ -40,6 +41,10 @@ export const accountAliasPrompt: IPrompt<string> = async () =>
     validate: function (value: string) {
       if (!value || value.trim().length < 3) {
         return 'Alias must be minimum at least 3 characters long.';
+      }
+
+      if (!isValidFilename(value)) {
+        return `Alias is used as a filename. Do not use these characters: \\ / : * ? " < > |. Please choose a different name without these characters.`;
       }
 
       return true;

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -7,7 +7,10 @@ import {
   parseChainIdRange,
 } from '../account/utils/accountHelpers.js';
 import { CHAIN_ID_RANGE_ERROR_MESSAGE } from '../constants/account.js';
-import { MAX_CHAIN_VALUE } from '../constants/config.js';
+import {
+  INVALID_FILE_NAME_ERROR_MSG,
+  MAX_CHAIN_VALUE,
+} from '../constants/config.js';
 import type { IPrompt } from '../utils/createOption.js';
 import {
   formatZodError,
@@ -44,7 +47,7 @@ export const accountAliasPrompt: IPrompt<string> = async () =>
       }
 
       if (!isValidFilename(value)) {
-        return `Alias is used as a filename. Do not use these characters: \\ / : * ? " < > |. Please choose a different name without these characters.`;
+        return `Alias is used as a filename. ${INVALID_FILE_NAME_ERROR_MSG}`;
       }
 
       return true;

--- a/packages/tools/kadena-cli/src/prompts/network.ts
+++ b/packages/tools/kadena-cli/src/prompts/network.ts
@@ -15,7 +15,7 @@ import { getNetworkDirectory } from '../networks/utils/networkPath.js';
 import { services } from '../services/index.js';
 import { KadenaError } from '../services/service-error.js';
 import type { IPrompt } from '../utils/createOption.js';
-import { isAlphabetic, isNotEmptyString } from '../utils/globalHelpers.js';
+import { isNotEmptyString, isValidFilename } from '../utils/globalHelpers.js';
 import { getExistingNetworks } from '../utils/helpers.js';
 import { input, select } from '../utils/prompts.js';
 import { getInputPrompt } from './generic.js'; // Importing getInputPrompt from another file
@@ -51,8 +51,8 @@ export const networkNamePrompt: IPrompt<string> = async (
     message: 'Enter a network name (e.g. "mainnet")',
     default: defaultValue,
     validate: function (input) {
-      if (!isAlphabetic(input)) {
-        return 'Network names must be alphanumeric! Please enter a valid network name.';
+      if (!isValidFilename(input)) {
+        return 'Name is used as a filename. Do not use these characters: \\ / : * ? " < > |. Please choose a different name without these characters';
       }
       return true;
     },

--- a/packages/tools/kadena-cli/src/prompts/network.ts
+++ b/packages/tools/kadena-cli/src/prompts/network.ts
@@ -1,10 +1,13 @@
 import type { ChainId } from '@kadena/types';
 import { z } from 'zod';
 import { chainIdValidation } from '../account/utils/accountHelpers.js';
-import {  MAX_CHAIN_VALUE } from '../constants/config.js';
 import {
   NO_NETWORKS_FOUND_ERROR_MESSAGE,
 } from '../constants/networks.js';
+import {
+  INVALID_FILE_NAME_ERROR_MSG,
+  MAX_CHAIN_VALUE,
+} from '../constants/config.js';
 import type { ICustomNetworkChoice } from '../networks/utils/networkHelpers.js';
 import {
   ensureNetworksConfiguration,
@@ -51,9 +54,12 @@ export const networkNamePrompt: IPrompt<string> = async (
     message: 'Enter a network name (e.g. "mainnet")',
     default: defaultValue,
     validate: function (input) {
+      if (!isNotEmptyString(input.trim())) return 'Network name is required.';
+
       if (!isValidFilename(input)) {
-        return 'Name is used as a filename. Do not use these characters: \\ / : * ? " < > |. Please choose a different name without these characters';
+        return `Name is used as a filename. ${INVALID_FILE_NAME_ERROR_MSG}`;
       }
+
       return true;
     },
   });

--- a/packages/tools/kadena-cli/src/prompts/wallets.ts
+++ b/packages/tools/kadena-cli/src/prompts/wallets.ts
@@ -1,3 +1,4 @@
+import { INVALID_FILE_NAME_ERROR_MSG } from '../constants/config.js';
 import { services } from '../services/index.js';
 import type { IWallet } from '../services/wallet/wallet.types.js';
 import { CommandError } from '../utils/command.util.js';
@@ -10,7 +11,7 @@ export async function walletNamePrompt(): Promise<string> {
     message: `Enter your wallet name:`,
     validate: function (input) {
       if (!isValidFilename(input)) {
-        return `Name is used as a filename. Do not use these characters: \\ / : * ? " < > |. Please choose a different name without these characters.`;
+        return `Name is used as a filename. ${INVALID_FILE_NAME_ERROR_MSG}`;
       }
       return true;
     },


### PR DESCRIPTION
**Refactor:**
- Currently wallet does validation for the filename contains any special characters like `\ / : * ? " < > |` but network and account not doing the same. For consistency updated it to use the same.
- Network name - only allowing alpha numeric to keep it consistent removed the alpha numeric validation

**Bug:**

`kadena network update` command - added more details in this ticket https://app.asana.com/0/1205969628270714/1207147099820716