### PR TITLE
Tools dApp: Module explorer - Add network info to modules

### DIFF
--- a/packages/apps/tools/src/components/Global/ModuleExplorer/SidePanel/index.tsx
+++ b/packages/apps/tools/src/components/Global/ModuleExplorer/SidePanel/index.tsx
@@ -1,3 +1,4 @@
+import { useWalletConnectClient } from '@/context/connect-wallet-context';
 import { Text, TextField } from '@kadena/react-ui';
 import useTranslation from 'next-translate/useTranslation';
 import React, { useState, useTransition } from 'react';
@@ -33,6 +34,7 @@ const SidePanel = ({
   const [searchQuery, setSearchQuery] = useState<string>();
   const [isPending, startTransition] = useTransition();
   const { t } = useTranslation('common');
+  const { selectedNetwork } = useWalletConnectClient();
 
   const onChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
     setText(e.target.value);
@@ -54,6 +56,7 @@ const SidePanel = ({
       </div>
       {isPending && <Text>Loading...</Text>}
       <Results
+        key={`results-${selectedNetwork}`}
         data={results}
         filter={searchQuery}
         onItemClick={onResultClick}

--- a/packages/apps/tools/src/components/Global/ModuleExplorer/SidePanel/outline.tsx
+++ b/packages/apps/tools/src/components/Global/ModuleExplorer/SidePanel/outline.tsx
@@ -13,7 +13,8 @@ export interface IOutlineProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const Outline = (props: IOutlineProps): React.JSX.Element => {
-  const { selectedModule, onInterfaceClick, onInterfacesExpand } = props;
+  const { selectedModule, onInterfaceClick, onInterfacesExpand, className } =
+    props;
   const { t } = useTranslation('common');
 
   let parsedContract: Contract;
@@ -23,7 +24,7 @@ const Outline = (props: IOutlineProps): React.JSX.Element => {
   }
 
   return (
-    <div {...props}>
+    <div className={className}>
       <Heading as="h4">
         Outline
         {selectedModule

--- a/packages/apps/tools/src/components/Global/ModuleExplorer/SidePanel/results.tsx
+++ b/packages/apps/tools/src/components/Global/ModuleExplorer/SidePanel/results.tsx
@@ -37,10 +37,10 @@ const resultsMapToTreeItems = (
     ),
     onOpen: () =>
       onModuleExpand({ moduleName, chains: chainsInfo.map((x) => x.chainId) }),
-    items: chainsInfo.map(({ chainId, hash, code }) => ({
+    items: chainsInfo.map(({ chainId, hash, code, network }) => ({
       title: (
         <Button
-          onPress={() => onItemClick({ chainId, moduleName, code })}
+          onPress={() => onItemClick({ chainId, moduleName, code, network })}
           isCompact
           endVisual={<MonoExitToApp />}
           title={chainId + (hash ? ` - ${hash}` : '')}

--- a/packages/apps/tools/src/components/Global/ModuleExplorer/SidePanel/results.tsx
+++ b/packages/apps/tools/src/components/Global/ModuleExplorer/SidePanel/results.tsx
@@ -60,7 +60,7 @@ const Results = ({
   onItemClick,
   onModuleExpand,
   filter,
-  ...rest
+  className,
 }: IResultsProps): React.JSX.Element => {
   const items = useMemo(() => {
     let filteredData = data;
@@ -75,7 +75,7 @@ const Results = ({
   }, [data, filter, onItemClick, onModuleExpand]);
 
   return (
-    <div {...rest}>
+    <div className={className}>
       <Tree items={items} isOpen />
     </div>
   );

--- a/packages/apps/tools/src/components/Global/ModuleExplorer/SidePanel/utils.tsx
+++ b/packages/apps/tools/src/components/Global/ModuleExplorer/SidePanel/utils.tsx
@@ -23,7 +23,11 @@ export const contractToTreeItems = (
       onOpen: () => {
         onInterfacesExpand(
           interfaces.map((i) => {
-            return { chainId: module!.chainId, moduleName: i.name };
+            return {
+              chainId: module!.chainId,
+              moduleName: i.name,
+              network: module!.network,
+            };
           }),
         );
       },
@@ -31,7 +35,11 @@ export const contractToTreeItems = (
         title: (
           <Button
             onPress={() =>
-              onInterfaceClick({ chainId: module!.chainId, moduleName: i.name })
+              onInterfaceClick({
+                chainId: module!.chainId,
+                moduleName: i.name,
+                network: module!.network,
+              })
             }
             isCompact
             endVisual={<MonoExitToApp />}

--- a/packages/apps/tools/src/components/Global/ModuleExplorer/editor.tsx
+++ b/packages/apps/tools/src/components/Global/ModuleExplorer/editor.tsx
@@ -35,8 +35,12 @@ export interface IEditorProps {
   activeModule?: IChainModule;
 }
 
-const moduleToTabId = ({ moduleName, chainId }: IChainModule): string => {
-  return `${moduleName}-${chainId}`;
+const moduleToTabId = ({
+  moduleName,
+  chainId,
+  network,
+}: IChainModule): string => {
+  return `${moduleName}-${chainId}-${network}`;
 };
 
 const Editor = ({
@@ -131,11 +135,11 @@ const Editor = ({
         }}
       >
         {openedModules.map((module) => {
-          const { moduleName, chainId, code } = module;
+          const { moduleName, chainId, code, network } = module;
           return (
             <TabItem
               title={`${moduleName} @ ${chainId}`}
-              key={moduleToTabId({ moduleName, chainId })}
+              key={moduleToTabId({ moduleName, chainId, network })}
             >
               <Button
                 onPress={() => {

--- a/packages/apps/tools/src/components/Global/ModuleExplorer/index.tsx
+++ b/packages/apps/tools/src/components/Global/ModuleExplorer/index.tsx
@@ -39,7 +39,8 @@ const ModuleExplorer = ({
         const alreadyOpened = prev.find((openedModule) => {
           return (
             openedModule.moduleName === result.moduleName &&
-            openedModule.chainId === result.chainId
+            openedModule.chainId === result.chainId &&
+            openedModule.network === result.network
           );
         });
 
@@ -95,8 +96,8 @@ const ModuleExplorer = ({
           setOpenedModules(
             openedModules.filter((openedModule) => {
               return (
-                `${openedModule.moduleName}-${openedModule.chainId}` !==
-                `${module.moduleName}-${module.chainId}`
+                `${openedModule.moduleName}-${openedModule.chainId}-${openedModule.network}` !==
+                `${module.moduleName}-${module.chainId}-${module.network}`
               );
             }),
           );

--- a/packages/apps/tools/src/components/Global/ModuleExplorer/types.ts
+++ b/packages/apps/tools/src/components/Global/ModuleExplorer/types.ts
@@ -1,3 +1,4 @@
+import type { Network } from '@/constants/kadena';
 import type { ChainwebChainId } from '@kadena/chainweb-node-client';
 
 export interface IChainModule {
@@ -5,6 +6,7 @@ export interface IChainModule {
   chainId: ChainwebChainId;
   moduleName: string;
   hash?: string;
+  network: Network;
 }
 
 export interface IModule {

--- a/packages/apps/tools/src/components/Global/ModuleExplorer/utils.ts
+++ b/packages/apps/tools/src/components/Global/ModuleExplorer/utils.ts
@@ -1,3 +1,4 @@
+import type { Network } from '@/constants/kadena';
 import type { ChainwebChainId } from '@kadena/chainweb-node-client';
 import type { IChainModule } from './types';
 
@@ -5,22 +6,42 @@ export const getModulesMap = (
   modules: IChainModule[],
 ): Map<
   string,
-  Array<{ chainId: ChainwebChainId; hash?: string; code?: string }>
+  Array<{
+    chainId: ChainwebChainId;
+    hash?: string;
+    code?: string;
+    network: Network;
+  }>
 > => {
   const modulesMap = new Map<
     string,
-    Array<{ chainId: ChainwebChainId; hash?: string; code?: string }>
+    Array<{
+      chainId: ChainwebChainId;
+      hash?: string;
+      code?: string;
+      network: Network;
+    }>
   >();
 
   modules.forEach((module) => {
     if (modulesMap.has(module.moduleName)) {
       modulesMap.set(module.moduleName, [
         ...modulesMap.get(module.moduleName)!,
-        { chainId: module.chainId, hash: module.hash, code: module.code },
+        {
+          chainId: module.chainId,
+          hash: module.hash,
+          code: module.code,
+          network: module.network,
+        },
       ]);
     } else {
       modulesMap.set(module.moduleName, [
-        { chainId: module.chainId, hash: module.hash, code: module.code },
+        {
+          chainId: module.chainId,
+          hash: module.hash,
+          code: module.code,
+          network: module.network,
+        },
       ]);
     }
   });

--- a/packages/apps/tools/src/pages/modules/explorer/index.tsx
+++ b/packages/apps/tools/src/pages/modules/explorer/index.tsx
@@ -210,11 +210,12 @@ export const getServerSideProps: GetServerSideProps<{
     context.query,
     (value) => CHAINS.includes(value),
   );
-  if (moduleQueryValue && chainQueryValue) {
+  const networkQueryValue = getQueryValue(QueryParams.NETWORK, context.query);
+  if (moduleQueryValue && chainQueryValue && networkQueryValue) {
     const moduleResponse = (await describeModule(
       moduleQueryValue,
       chainQueryValue as ChainwebChainId,
-      network,
+      networkQueryValue,
       networksData,
       kadenaConstants.DEFAULT_SENDER,
       kadenaConstants.GAS_PRICE,
@@ -226,7 +227,7 @@ export const getServerSideProps: GetServerSideProps<{
         code: (moduleResponse.result.data as unknown as { code: string }).code,
         moduleName: moduleQueryValue,
         chainId: chainQueryValue as ChainwebChainId,
-        network,
+        network: networkQueryValue,
       });
     }
   }

--- a/packages/apps/tools/src/pages/modules/explorer/index.tsx
+++ b/packages/apps/tools/src/pages/modules/explorer/index.tsx
@@ -102,6 +102,7 @@ export const getCompleteModule = async (
     moduleName,
     chainId,
     hash,
+    network,
   };
 };
 
@@ -138,7 +139,7 @@ export const enrichModule = async (
 ) => {
   const promises = module.chains.map((chain) => {
     return getCompleteModule(
-      { moduleName: module.moduleName, chainId: chain },
+      { moduleName: module.moduleName, chainId: chain, network },
       network,
       networksData,
     );
@@ -166,7 +167,7 @@ export const enrichModules = async (
     module.chains.forEach((chain) => {
       acc.push(
         getCompleteModule(
-          { moduleName: module.moduleName, chainId: chain },
+          { moduleName: module.moduleName, chainId: chain, network },
           network,
           networksData,
         ),
@@ -224,6 +225,7 @@ export const getServerSideProps: GetServerSideProps<{
         code: (moduleResponse.result.data as unknown as { code: string }).code,
         moduleName: moduleQueryValue,
         chainId: chainQueryValue as ChainwebChainId,
+        network,
       });
     }
   }

--- a/packages/apps/tools/src/pages/modules/explorer/index.tsx
+++ b/packages/apps/tools/src/pages/modules/explorer/index.tsx
@@ -40,6 +40,7 @@ import { getCookieValue, getQueryValue } from './utils';
 const QueryParams = {
   MODULE: 'module',
   CHAIN: 'chain',
+  NETWORK: 'network',
 };
 
 export const getModules = async (
@@ -253,7 +254,7 @@ const ModuleExplorerPage = (
   const setDeepLink = useCallback(
     (module: IChainModule) => {
       void router.replace(
-        `?${QueryParams.MODULE}=${module.moduleName}&${QueryParams.CHAIN}=${module.chainId}&network=${module.network}`,
+        `?${QueryParams.MODULE}=${module.moduleName}&${QueryParams.CHAIN}=${module.chainId}&${QueryParams.NETWORK}=${module.network}`,
         undefined,
         { shallow: true },
       );

--- a/packages/apps/tools/src/pages/modules/explorer/index.tsx
+++ b/packages/apps/tools/src/pages/modules/explorer/index.tsx
@@ -253,7 +253,7 @@ const ModuleExplorerPage = (
   const setDeepLink = useCallback(
     (module: IChainModule) => {
       void router.replace(
-        `?${QueryParams.MODULE}=${module.moduleName}&${QueryParams.CHAIN}=${module.chainId}`,
+        `?${QueryParams.MODULE}=${module.moduleName}&${QueryParams.CHAIN}=${module.chainId}&network=${module.network}`,
         undefined,
         { shallow: true },
       );

--- a/packages/apps/tools/src/services/modules/list-module.ts
+++ b/packages/apps/tools/src/services/modules/list-module.ts
@@ -12,6 +12,7 @@ export interface IModulesResult {
   status?: string;
   data?: string[];
   chainId: ChainwebChainId;
+  network: Network;
 }
 
 export const listModules = async (
@@ -60,5 +61,6 @@ export const listModules = async (
     status: result.status,
     data: 'data' in result ? (result.data as string[]) : [],
     chainId,
+    network,
   };
 };

--- a/packages/apps/tools/src/services/utils/transform.ts
+++ b/packages/apps/tools/src/services/utils/transform.ts
@@ -11,5 +11,6 @@ export const transformModulesRequest = (
   return modulesRequest.data.map((moduleName) => ({
     chainId: modulesRequest.chainId,
     moduleName,
+    network: modulesRequest.network,
   }));
 };


### PR DESCRIPTION
This PR makes it possible to switch networks while having opened modules in the editor section. E.g.; you can now open the same module on the same chain on different networks in different tabs, this wasn't possible before. The network of the opened module is now also stored as part of the URL for deep linking purposes