### PR TITLE
fix: temp workaround for apt-get update failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install rust dependencies
         run: |
-          sudo apt-get update
+          sudo apt-get update || true
           sudo apt-get install libgtk-3-dev libsoup2.4-dev javascriptcoregtk-4.1
 
       - name: Lint monorepo root


### PR DESCRIPTION
Do not fail on apt-update temporary workaround for [#9773](https://github.com/actions/runner-images/issues/9733) and  [#130](https://github.com/microsoft/linux-package-repositories/issues/130)