### PR TITLE
fix: account fund healthcheck

### DIFF
--- a/packages/tools/kadena-cli/src/account/commands/accountFund.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountFund.ts
@@ -4,7 +4,7 @@ import {
   NO_ACCOUNTS_FOUND_ERROR_MESSAGE,
 } from '../../constants/account.js';
 import { FAUCET_MODULE_NAME } from '../../constants/devnets.js';
-import { networkIsAlive } from '../../devnet/utils/network.js';
+import { checkHealth } from '../../devnet/utils/network.js';
 import { assertCommandError } from '../../utils/command.util.js';
 import { createCommand } from '../../utils/createCommand.js';
 import { notEmpty } from '../../utils/globalHelpers.js';
@@ -75,7 +75,7 @@ export const createAccountFundCommand = createCommand(
     }
 
     if (networkConfig.networkId.includes('development') === true) {
-      if (!(await networkIsAlive(networkConfig.networkHost))) {
+      if (!(await checkHealth(networkConfig.networkHost))) {
         return log.error(
           `Devnet host "${networkConfig.networkHost}" is not running.`,
         );

--- a/packages/tools/kadena-cli/src/account/utils/fundHelpers.ts
+++ b/packages/tools/kadena-cli/src/account/utils/fundHelpers.ts
@@ -138,7 +138,7 @@ export async function findMissingModuleDeployments(
 ): Promise<ChainId[]> {
   const undeployedChainIds: ChainId[] = [];
 
-  for (const chainId of targetChainIds) {
+  await Promise.all(targetChainIds.map(async (chainId) => {
     const moduleDeployed = await describeModule(moduleName, {
       host: network.networkHost,
       defaults: {
@@ -150,7 +150,7 @@ export async function findMissingModuleDeployments(
     if (moduleDeployed === false) {
       undeployedChainIds.push(chainId);
     }
-  }
+  }));
 
   return undeployedChainIds;
 }

--- a/packages/tools/kadena-cli/src/devnet/utils/network.ts
+++ b/packages/tools/kadena-cli/src/devnet/utils/network.ts
@@ -13,3 +13,26 @@ export function networkIsAlive(networkHost: string): Promise<boolean> {
       });
   });
 }
+
+export function checkHealth(networkHost: string): Promise<boolean> {
+  const hostWithSlash = networkHost.endsWith('/')
+    ? networkHost
+    : `${networkHost}/`;
+  const url = `${hostWithSlash}health-check`;
+  return new Promise((resolve) => {
+    http
+      .get(url, (res) => {
+        // Even if we don't need the data, we still need to consume it
+        // to trigger the end and finish the request.
+        // if not the request will hang.
+        res.on('data', () => {});
+        res.on('end', () => {
+          resolve(res.statusCode === 200);
+        });
+      })
+      .on('error', (err) => {
+        log.error(`Error checking network: ${err.message}`);
+        resolve(false);
+      });
+  });
+}


### PR DESCRIPTION
This PR addresses couple of issues

- Use `health-check` end point to check the dev/local server status https://app.asana.com/0/1205969628270714/1207158683269813/f
- In node version `v20.12.1` specifically the account fund command gets hang even after command execution is done 
https://app.asana.com/0/1205969628270714/1206951762878097/f 