### PR TITLE
fix: add account alias prompt for init + wallet add command

### DIFF
--- a/packages/tools/kadena-cli/README.md
+++ b/packages/tools/kadena-cli/README.md
@@ -227,6 +227,7 @@ kadena config init [options]
 | --wallet-name    | Name for the new wallet                                                                            |              |
 | --password-file  | Path to a file containing the wallet's password, alternatively, passwords can be passed via stdin. |              |
 | --create-account | Enable the creation of an account using the first wallet key.                                      |              |
+| --account-alias  | Alias to store your account details            |              |
 
 ---
 
@@ -235,7 +236,7 @@ Examples
 Setup in a Specific Directory with a New Wallet and Account:
 
 ```
-kadena config init --location="/my-app/.kadena" --create-wallet="true" --wallet-name="my_first_wallet" --create-account="true"
+kadena config init --location="/my-app/.kadena" --create-wallet="true" --wallet-name="my_first_wallet" --create-account="true" --account-alias="dev_account"
 ```
 
 Setup Without Creating a Wallet or Account:
@@ -362,19 +363,22 @@ kadena wallet add [options]
 | **Options**                | **Description**                                | **Required** |
 | -------------------------- | ---------------------------------------------- | ------------ |
 | --wallet-name              | Set the name of the wallet                     |              |
-| --security-password        | Set the password for the wallet                |              |
-| --security-verify-password | Set the password for the wallet (verification) |              |
+| --password-file            | File path to the password file                 |              |
 | --legacy                   | Generate legacy wallet                         |              |
+| --create-account           | Create an account using the first wallet key   |              |
+| --account-alias            | Alias to store your account details            |              |
 
 example:
 
 ```
-kadena wallet add --wallet-name="kadenawallet" --security-password=1245678 --security-verify-password=1245678
+kadena wallet add --wallet-name="kadena_wallet" --password-file="./kadenawallet-pw.txt"
 ```
 
-password will be hidden after entry: --security-password=\*
-\--security-verify-password=\*
+example using wallet with account creation:
 
+```
+kadena wallet add --wallet-name="kadena_wallet" --password-file="./kadenawallet-pw.txt" --create-account=true --account-alias="dev_account"
+```
 ---
 
 ```

--- a/packages/tools/kadena-cli/src/config/commands/configInit.ts
+++ b/packages/tools/kadena-cli/src/config/commands/configInit.ts
@@ -95,8 +95,12 @@ export const createConfigInitCommand: (
     logWalletInfo(created.words, wallet.filepath, key.publicKey);
 
     if (createAccount === 'true') {
+      // when --quiet is passed and account alias is not provided
+      // we will not create an account
       if (!notEmpty(accountAlias)) {
-        log.error('Account alias is required when creating an account');
+        log.error(
+          'Account alias is required when creating an account: -l, --account-alias <accountAlias>',
+        );
         return;
       }
 

--- a/packages/tools/kadena-cli/src/config/commands/configInit.ts
+++ b/packages/tools/kadena-cli/src/config/commands/configInit.ts
@@ -97,7 +97,7 @@ export const createConfigInitCommand: (
     if (createAccount === 'true') {
       // when --quiet is passed and account alias is not provided
       // we will not create an account
-      if (!notEmpty(accountAlias)) {
+      if (!notEmpty(accountAlias) || accountAlias.trim().length === 0) {
         log.warning(
           'Account alias is required when creating an account: -l, --account-alias <accountAlias>',
         );

--- a/packages/tools/kadena-cli/src/config/commands/configInit.ts
+++ b/packages/tools/kadena-cli/src/config/commands/configInit.ts
@@ -1,11 +1,13 @@
 import type { Command } from 'commander';
 import path from 'path';
+import { accountOptions } from '../../account/accountOptions.js';
 import { ACCOUNT_DIR } from '../../constants/config.js';
 import { getNetworkFiles } from '../../constants/networks.js';
 import { ensureNetworksConfiguration } from '../../networks/utils/networkHelpers.js';
 import { Services } from '../../services/index.js';
 import { KadenaError } from '../../services/service-error.js';
 import { createCommand } from '../../utils/createCommand.js';
+import { notEmpty } from '../../utils/globalHelpers.js';
 import { globalOptions, securityOptions } from '../../utils/globalOptions.js';
 import { log } from '../../utils/logger.js';
 import {
@@ -32,6 +34,7 @@ export const createConfigInitCommand: (
     }),
     globalOptions.legacy({ isOptional: true, disableQuestion: true }),
     walletOptions.createAccount(),
+    accountOptions.accountAlias({ isOptional: true }),
   ],
   async (option) => {
     const { location } = await option.location();
@@ -69,6 +72,11 @@ export const createConfigInitCommand: (
     const { legacy } = await option.legacy();
     const { createAccount } = await option.createAccount();
 
+    let accountAlias = null;
+    if (createAccount === 'true') {
+      accountAlias = (await option.accountAlias()).accountAlias;
+    }
+
     const created = await services.wallet.create({
       alias: walletName,
       legacy: legacy,
@@ -87,6 +95,11 @@ export const createConfigInitCommand: (
     logWalletInfo(created.words, wallet.filepath, key.publicKey);
 
     if (createAccount === 'true') {
+      if (!notEmpty(accountAlias)) {
+        log.error('Account alias is required when creating an account');
+        return;
+      }
+
       const directory = services.config.getDirectory();
       if (directory === null) {
         throw new KadenaError('no_kadena_directory');
@@ -95,7 +108,7 @@ export const createConfigInitCommand: (
       const accountDir = path.join(directory, ACCOUNT_DIR);
       const { accountName, accountFilepath } =
         await createAccountAliasByPublicKey(
-          wallet.alias,
+          accountAlias,
           wallet.keys[0].publicKey,
           accountDir,
         );

--- a/packages/tools/kadena-cli/src/config/commands/configInit.ts
+++ b/packages/tools/kadena-cli/src/config/commands/configInit.ts
@@ -98,7 +98,7 @@ export const createConfigInitCommand: (
       // when --quiet is passed and account alias is not provided
       // we will not create an account
       if (!notEmpty(accountAlias)) {
-        log.error(
+        log.warning(
           'Account alias is required when creating an account: -l, --account-alias <accountAlias>',
         );
         return;

--- a/packages/tools/kadena-cli/src/wallets/commands/walletAdd.ts
+++ b/packages/tools/kadena-cli/src/wallets/commands/walletAdd.ts
@@ -1,9 +1,11 @@
 import type { Command } from 'commander';
 import { services } from '../../services/index.js';
 
+import { accountOptions } from '../../account/accountOptions.js';
 import { getAccountDirectory } from '../../account/utils/accountHelpers.js';
 import { KadenaError } from '../../services/service-error.js';
 import { createCommand } from '../../utils/createCommand.js';
+import { notEmpty } from '../../utils/globalHelpers.js';
 import { globalOptions, securityOptions } from '../../utils/globalOptions.js';
 import { handleNoKadenaDirectory } from '../../utils/helpers.js';
 import { log } from '../../utils/logger.js';
@@ -34,14 +36,32 @@ export const createGenerateWalletCommand: (
     }),
     globalOptions.legacy({ isOptional: true, disableQuestion: true }),
     walletOptions.createAccount(),
+    accountOptions.accountAlias({ isOptional: true }),
   ],
-  async (option, { collect }) => {
+  async (option) => {
     const accountDir = getAccountDirectory();
     if (accountDir === null) {
       throw new KadenaError('no_kadena_directory');
     }
 
-    const config = await collect(option);
+    const walletName = await option.walletName();
+    const passwordFile = await option.passwordFile();
+    const legacy = await option.legacy();
+    const createAccount = await option.createAccount();
+
+    let accountAlias = null;
+    if (createAccount.createAccount === 'true') {
+      accountAlias = await option.accountAlias();
+    }
+
+    const config = {
+      walletName: walletName.walletName,
+      passwordFile: passwordFile.passwordFile,
+      legacy: legacy.legacy,
+      createAccount: createAccount.createAccount,
+      accountAlias: accountAlias?.accountAlias,
+    };
+
     log.debug('create-wallet:action', config);
 
     try {
@@ -63,9 +83,14 @@ export const createGenerateWalletCommand: (
 
       log.info();
       if (config.createAccount === 'true') {
+        if (!notEmpty(config.accountAlias)) {
+          log.error('Account alias is required when creating an account');
+          return;
+        }
+
         const { accountName, accountFilepath } =
           await createAccountAliasByPublicKey(
-            wallet.alias,
+            config.accountAlias,
             wallet.keys[0].publicKey,
             accountDir,
           );

--- a/packages/tools/kadena-cli/src/wallets/commands/walletAdd.ts
+++ b/packages/tools/kadena-cli/src/wallets/commands/walletAdd.ts
@@ -83,8 +83,12 @@ export const createGenerateWalletCommand: (
 
       log.info();
       if (config.createAccount === 'true') {
+        // when --quiet is passed and account alias is not provided
+        // we will not create an account
         if (!notEmpty(config.accountAlias)) {
-          log.error('Account alias is required when creating an account');
+          log.error(
+            'Account alias is required when creating an account: -l, --account-alias <accountAlias>',
+          );
           return;
         }
 

--- a/packages/tools/kadena-cli/src/wallets/commands/walletAdd.ts
+++ b/packages/tools/kadena-cli/src/wallets/commands/walletAdd.ts
@@ -100,7 +100,7 @@ export const createGenerateWalletCommand: (
           );
         logAccountCreation(accountName, accountFilepath);
         log.info(`\nTo fund the account, use the following command:`);
-        log.info(`kadena account fund --account ${accountName}`);
+        log.info(`kadena account fund --account ${config.accountAlias}`);
       }
 
       log.output(null, {


### PR DESCRIPTION
account alias option is an optional field because it's required only when create account is passed as true

So, incase when `--quiet` flag is used with `--create-account=true` but `account-alias` is **not** passed. it still create the wallet but doesn't create a account alias fails with error 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207158682603351