### PR TITLE
fix(account): remove network and chain prompts for account add manual/from-wallet commands

### DIFF
--- a/packages/tools/kadena-cli/README.md
+++ b/packages/tools/kadena-cli/README.md
@@ -606,18 +606,16 @@ kadena account add-manual [options]
 
 | **Options**     | **Description**                              | **Required** |
 | --------------- | -------------------------------------------- | ------------ |
-| --account-alias | Set alias for account                        |              |
-| --account-name  | Set account name                             |              |
+| --account-alias | Provide alias for account                    |              |
+| --account-name  | Provide account name                         |              |
 | --fungible      | Fungible module name (default: coin)         |              |
-| --network       | Name of the network to be used               |              |
-| --chain-id      | Chain to be used                             |              |
 | --public-keys   | Comma separated list of public keys          |              |
 | --predicate     | keys-all, keys-any, keys-2, Custom predicate |              |
 
 example:
 
 ```
-kadena account add-manual --account-alias="myalias" --account-name="myaccountname" --fungible="coin" --network="mainnet" --chain-id="1" --public-keys="mypublickey" --predicate="keys-all"
+kadena account add-manual --account-alias="myalias" --account-name="myaccountname" --fungible="coin" --public-keys="mypublickey" --predicate="keys-all"
 ```
 
 ---
@@ -628,18 +626,17 @@ kadena account add-from-wallet [options]
 
 | **Options**     | **Description**                              | **Required** |
 | --------------- | -------------------------------------------- | ------------ |
-| --account-alias | Set alias for account                        |              |
+| --account-alias | Provide alias for account                    |              |
+| --account-name  | Provide account name                         |              |
 | --wallet-name   | Provide the name of the wallet               |              |
 | --fungible      | Fungible module name (default: coin)         |              |
-| --network       | Name of the network to be used               |              |
-| --chain-id      | Chain to be used                             |              |
 | --public-keys   | Comma separated list of public keys          |              |
 | --predicate     | keys-all, keys-any, keys-2, Custom predicate |              |
 
 example:
 
 ```
-kadena account add-from-wallet --account-alias="myalias" --wallet-name="mywallet" --fungible="coin" --network="mainnet" --chain-id="1" --public-keys="publickey" --predicate="keys-all"
+kadena account add-from-wallet --account-alias="myalias" --account-name="k:account" --wallet-name="mywallet" --fungible="coin" --public-keys="publickey" --predicate="keys-all"
 ```
 
 ---

--- a/packages/tools/kadena-cli/README.md
+++ b/packages/tools/kadena-cli/README.md
@@ -604,18 +604,27 @@ Tool to manage / fund accounts of fungibles (e.g. coin')
 kadena account add-manual [options]
 ```
 
-| **Options**     | **Description**                              | **Required** |
-| --------------- | -------------------------------------------- | ------------ |
-| --account-alias | Provide alias for account                    |              |
-| --account-name  | Provide account name                         |              |
-| --fungible      | Fungible module name (default: coin)         |              |
-| --public-keys   | Comma separated list of public keys          |              |
-| --predicate     | keys-all, keys-any, keys-2, Custom predicate |              |
+| **Options**               | **Description**                              | **Required** |
+| --------------------------| -------------------------------------------- | ------------ |
+| --account-alias           | Alias for the account                        |              |
+| --account-name            | Name of the account                          |              |
+| --fungible                | Fungible module name (default: coin)         |              |
+| --public-keys             | Comma separated list of public keys          |              |
+| --public-key-directory    | Path of the kadena config directory          |              |
+| --predicate               | keys-all, keys-any, keys-2, Custom predicate |              |
 
 example:
 
 ```
 kadena account add-manual --account-alias="myalias" --account-name="myaccountname" --fungible="coin" --public-keys="mypublickey" --predicate="keys-all"
+```
+
+**Using custom public key directory:**
+
+If you need to fetch public keys from a specific directory other than the current working directory, you can specify it using --public-key-directory. For instance, if the Kadena configuration is located at `/user/dev/.kadena`
+
+```
+kadena account add-manual --account-alias="myalias" --account-name="myaccountname" --fungible="coin" --public-keys="mypublickey" --predicate="keys-all" --public-key-directory=/user/dev/.kadena
 ```
 
 ---
@@ -626,9 +635,9 @@ kadena account add-from-wallet [options]
 
 | **Options**     | **Description**                              | **Required** |
 | --------------- | -------------------------------------------- | ------------ |
-| --account-alias | Provide alias for account                    |              |
-| --account-name  | Provide account name                         |              |
-| --wallet-name   | Provide the name of the wallet               |              |
+| --account-alias | Alias for the account                        |              |
+| --account-name  | Name of the account                          |              |
+| --wallet-name   | Name of the wallet                           |              |
 | --fungible      | Fungible module name (default: coin)         |              |
 | --public-keys   | Comma separated list of public keys          |              |
 | --predicate     | keys-all, keys-any, keys-2, Custom predicate |              |
@@ -656,8 +665,8 @@ kadena account create [options]
 
 | **Options**    | **Description**                              | **Required** |
 | -------------- | -------------------------------------------- | ------------ |
-| --account-name | Provide an account name                      | No           |
-| --fungible     | Fungible e.g coin                            | No           |
+| --account-name | Name of the account                          | No           |
+| --fungible     | Fungible module name (default: coin)         | No           |
 | --chain-id     | Chain to be used                             |              |
 | --public-keys  | Comma separated list of public keys          |              |
 | --predicate    | keys-all, keys-any, keys-2, Custom predicate |              |

--- a/packages/tools/kadena-cli/src/account/accountOptions.ts
+++ b/packages/tools/kadena-cli/src/account/accountOptions.ts
@@ -213,4 +213,13 @@ export const accountOptions = {
         .filter((key) => !!key);
     },
   }),
+  publicKeyDirectory: createOption({
+    key: 'publicKeyDirectory' as const,
+    prompt: () => null,
+    validation: z.string().optional(),
+    option: new Option(
+      '-d, --public-key-directory <publicKeyDirectory>',
+      'Public key directory',
+    ),
+  }),
 };

--- a/packages/tools/kadena-cli/src/account/accountOptions.ts
+++ b/packages/tools/kadena-cli/src/account/accountOptions.ts
@@ -198,4 +198,19 @@ export const accountOptions = {
       'Deploy faucet on devnet if not available on chain.',
     ),
   }),
+  publicKeysWithManual: createOption({
+    key: 'publicKeys' as const,
+    prompt: account.publicKeysSelectWithManualPrompt,
+    validation: z.string(),
+    option: new Option(
+      '-k, --public-keys <publicKeys>',
+      'Public keys (comma separated for multiple keys)',
+    ),
+    expand: async (publicKeys: string) => {
+      return publicKeys
+        ?.split(',')
+        .map((value) => value.trim())
+        .filter((key) => !!key);
+    },
+  }),
 };

--- a/packages/tools/kadena-cli/src/account/commands/accountAddManual.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountAddManual.ts
@@ -14,7 +14,7 @@ export const createAddAccountManualCommand = createCommand(
     accountOptions.accountAlias(),
     accountOptions.accountName({ isOptional: false }),
     accountOptions.fungible(),
-    accountOptions.publicKeys({ isOptional: false }),
+    accountOptions.publicKeysWithManual({ isOptional: false }),
     accountOptions.predicate(),
   ],
 

--- a/packages/tools/kadena-cli/src/account/commands/accountAddManual.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountAddManual.ts
@@ -16,6 +16,7 @@ export const createAddAccountManualCommand = createCommand(
     accountOptions.fungible(),
     accountOptions.publicKeysWithManual({ isOptional: false }),
     accountOptions.predicate(),
+    accountOptions.publicKeyDirectory({ disableQuestion: true }),
   ],
 
   async (option) => {
@@ -25,8 +26,10 @@ export const createAddAccountManualCommand = createCommand(
 
     let predicate = 'keys-all';
     let isKeysAllPredicate = false;
-
-    const publicKeysPrompt = await option.publicKeys();
+    const { publicKeyDirectory } = await option.publicKeyDirectory();
+    const publicKeysPrompt = await option.publicKeys({
+      directory: publicKeyDirectory,
+    });
     isKeysAllPredicate = isValidForOnlyKeysAllPredicate(
       accountName,
       publicKeysPrompt.publicKeysConfig,

--- a/packages/tools/kadena-cli/src/account/commands/accountAddManual.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountAddManual.ts
@@ -1,26 +1,20 @@
 import { KEYS_ALL_PRED_ERROR_MESSAGE } from '../../constants/account.js';
 import { assertCommandError } from '../../utils/command.util.js';
 import { createCommand } from '../../utils/createCommand.js';
-import { globalOptions } from '../../utils/globalOptions.js';
 import { log } from '../../utils/logger.js';
 import { accountOptions } from '../accountOptions.js';
 import { isValidForOnlyKeysAllPredicate } from '../utils/accountHelpers.js';
 import { addAccount } from '../utils/addAccount.js';
 import { displayAddAccountSuccess } from '../utils/addHelpers.js';
-import { getAccountDetails } from '../utils/getAccountDetails.js';
-import { validateAndRetrieveAccountDetails } from '../utils/validateAndRetrieveAccountDetails.js';
 
 export const createAddAccountManualCommand = createCommand(
   'add-manual',
   'Add an existing account locally to the CLI',
   [
     accountOptions.accountAlias(),
-    accountOptions.accountName(),
+    accountOptions.accountName({ isOptional: false }),
     accountOptions.fungible(),
-    globalOptions.networkSelect(),
-    globalOptions.chainId(),
-    accountOptions.accountOverwrite(),
-    accountOptions.publicKeys(),
+    accountOptions.publicKeys({ isOptional: false }),
     accountOptions.predicate(),
   ],
 
@@ -29,57 +23,24 @@ export const createAddAccountManualCommand = createCommand(
     const accountName = (await option.accountName()).accountName;
     const fungible = (await option.fungible()).fungible || 'coin';
 
-    const { network, networkConfig } = await option.network();
-
-    const chainId = (await option.chainId()).chainId;
-
-    const accountDetailsFromChain = accountName
-      ? await getAccountDetails({
-          accountName,
-          networkId: networkConfig.networkId,
-          chainId,
-          networkHost: networkConfig.networkHost,
-          fungible,
-        })
-      : undefined;
-
-    const hasAccountDetails =
-      !!accountDetailsFromChain &&
-      accountDetailsFromChain.guard.keys.length > 0;
-
-    let accountOverwrite = hasAccountDetails
-      ? (await option.accountOverwrite()).accountOverwrite
-      : false;
-
-    let publicKeysPrompt;
     let predicate = 'keys-all';
     let isKeysAllPredicate = false;
 
-    // If the user choose not to overwrite the account, we need to ask for the public keys and predicate
-    if (!accountOverwrite) {
-      publicKeysPrompt = await option.publicKeys();
-      isKeysAllPredicate = isValidForOnlyKeysAllPredicate(
-        accountName,
-        publicKeysPrompt.publicKeysConfig,
-      );
-      const allowedPredicates = isKeysAllPredicate ? ['keys-all'] : undefined;
-      predicate =
-        (
-          await option.predicate({
-            allowedPredicates,
-          })
-        ).predicate || 'keys-all';
-    }
+    const publicKeysPrompt = await option.publicKeys();
+    isKeysAllPredicate = isValidForOnlyKeysAllPredicate(
+      accountName,
+      publicKeysPrompt.publicKeysConfig,
+    );
+
+    const allowedPredicates = isKeysAllPredicate ? ['keys-all'] : undefined;
+    predicate =
+      (
+        await option.predicate({
+          allowedPredicates,
+        })
+      ).predicate || 'keys-all';
 
     const { publicKeys, publicKeysConfig = [] } = publicKeysPrompt ?? {};
-
-    // when --quiet is passed and account details are not in chain
-    // public keys are required to add account
-    if (!hasAccountDetails && !publicKeysConfig.length) {
-      throw new Error(
-        'Missing required argument PublicKeys: "-k, --public-keys <publicKeys>"',
-      );
-    }
 
     if (isKeysAllPredicate && predicate !== 'keys-all') {
       throw new Error(KEYS_ALL_PRED_ERROR_MESSAGE);
@@ -87,47 +48,20 @@ export const createAddAccountManualCommand = createCommand(
 
     const validPublicKeys = publicKeysConfig.filter((key) => !!key);
 
-    const config = {
+    const aliasConfig = {
       accountAlias,
-      accountDetailsFromChain,
       accountName,
-      accountOverwrite,
-      chainId,
       fungible,
-      network,
-      networkConfig,
       predicate,
-      publicKeys,
       publicKeysConfig: validPublicKeys,
     };
 
-    let newConfig = { ...config };
+    log.debug('create-account-add-manual:action', {
+      ...aliasConfig,
+      publicKeys,
+    });
 
-    // If the account name is not provided, we need to create account name,
-    // get account details from chain and
-    // compare config and account details from chain are same
-    if (!accountName) {
-      const {
-        accountName: accountNameFromChain,
-        accountDetails,
-        isConfigAreSame,
-      } = await validateAndRetrieveAccountDetails(config);
-
-      if (!isConfigAreSame) {
-        accountOverwrite = (await option.accountOverwrite()).accountOverwrite;
-      }
-
-      newConfig = {
-        ...newConfig,
-        accountName: accountNameFromChain,
-        accountDetailsFromChain: accountDetails,
-        accountOverwrite,
-      };
-    }
-
-    log.debug('create-account-add-manual:action', newConfig);
-
-    const result = await addAccount(newConfig);
+    const result = await addAccount(aliasConfig);
 
     assertCommandError(result);
 

--- a/packages/tools/kadena-cli/src/account/types.ts
+++ b/packages/tools/kadena-cli/src/account/types.ts
@@ -1,21 +1,14 @@
-import type { ChainId } from '@kadena/types';
-import type { INetworkCreateOptions } from '../networks/utils/networkHelpers.js';
-
 export type Predicate = 'keys-all' | 'keys-2' | 'keys-any';
 
-export interface IAddAccountConfig {
-  accountAlias: string;
-  fungible: string;
-  predicate: string;
-  network: string;
-  chainId: ChainId;
-  networkConfig: INetworkCreateOptions;
-  quiet?: boolean;
-  publicKeys?: string;
-  publicKeysConfig: string[];
-  accountOverwrite: boolean;
-  accountDetailsFromChain?: IAccountDetailsResult;
+export interface IAccountAliasFileConfig {
   accountName: string;
+  fungible: string;
+  publicKeysConfig: Array<string>;
+  predicate: string;
+}
+
+export interface IAddAccountConfig extends IAccountAliasFileConfig {
+  accountAlias: string;
 }
 
 export interface IValidateAccountDetailsConfig

--- a/packages/tools/kadena-cli/src/account/types.ts
+++ b/packages/tools/kadena-cli/src/account/types.ts
@@ -1,3 +1,6 @@
+import type { ChainId } from '@kadena/types';
+import type { INetworkCreateOptions } from '../networks/utils/networkHelpers.js';
+
 export type Predicate = 'keys-all' | 'keys-2' | 'keys-any';
 
 export interface IAccountAliasFileConfig {
@@ -14,6 +17,8 @@ export interface IAddAccountConfig extends IAccountAliasFileConfig {
 export interface IValidateAccountDetailsConfig
   extends Omit<IAddAccountConfig, 'accountName'> {
   accountName?: string;
+  chainId: ChainId;
+  networkConfig: INetworkCreateOptions;
 }
 
 export interface IGuard {

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/addAccount.test.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/addAccount.test.ts
@@ -1,5 +1,4 @@
 /// <reference lib="dom" />
-import yaml from 'js-yaml';
 import { afterEach, assert, describe, expect, it } from 'vitest';
 
 import { server } from '../../../mocks/server.js';
@@ -23,73 +22,12 @@ describe('addAccount', () => {
       ...defaultConfigMock,
       publicKeys: 'publicKey1,publicKey2',
       publicKeysConfig: ['publicKey1', 'publicKey2'],
-      accountDetailsFromChain: {
-        guard: {
-          keys: ['publicKey1', 'publicKey2'],
-          pred: 'keys-all',
-        },
-        account: 'accountName',
-        balance: 0,
-      },
     };
     const filePath = getAccountFilePath(defaultConfigMock.accountAlias);
     const result = await addAccount(config);
 
     assert(result.status === 'success');
     expect(result.data).toEqual(filePath);
-    expect(result.warnings).toEqual([]);
-  });
-
-  it('should write user config to file when account details are undefined', async () => {
-    const config = {
-      ...defaultConfigMock,
-      accountName: 'k:3645365457567ghghdghf6534673',
-      publicKeys: 'publicKey1,publicKey2',
-      publicKeysConfig: ['publicKey1', 'publicKey2'],
-      accountDetailsFromChain: undefined,
-    };
-    const filePath = getAccountFilePath(defaultConfigMock.accountAlias);
-    const result = await addAccount(config);
-
-    assert(result.status === 'success');
-    expect(result.data).toEqual(filePath);
-    expect(result.warnings).toEqual([
-      'The account "k:3645365457567ghghdghf6534673" is not on chain yet. To create it on-chain, transfer funds to it from testnet and use "kadena account fund" command.',
-    ]);
-  });
-
-  it('should write config with account details from chain when accountOverwrite is true', async () => {
-    const config = {
-      ...defaultConfigMock,
-      accountName: 'accountName',
-      publicKeys: 'publicKey1,publicKey2',
-      publicKeysConfig: ['publicKey1', 'publicKey2'],
-      accountDetailsFromChain: {
-        guard: {
-          keys: ['publicKey1'],
-          pred: 'keys-any',
-        },
-        account: 'accountName',
-        balance: 0,
-      },
-      accountOverwrite: true,
-    };
-    const filePath = getAccountFilePath(defaultConfigMock.accountAlias);
-    const result = await addAccount(config);
-
-    const fileContent = await services.filesystem.readFile(filePath);
-
-    assert(result.status === 'success');
-    expect(result.data).toEqual(filePath);
-    expect(fileContent).toBe(
-      yaml.dump({
-        name: 'accountName',
-        fungible: 'coin',
-        publicKeys: ['publicKey1'],
-        predicate: 'keys-any',
-      }),
-    );
-    expect(result.warnings).toEqual([]);
   });
 
   it('should return error when file already exists', async () => {

--- a/packages/tools/kadena-cli/src/account/utils/__tests__/mocks.ts
+++ b/packages/tools/kadena-cli/src/account/utils/__tests__/mocks.ts
@@ -1,5 +1,5 @@
+import type { ChainId } from '@kadena/types';
 import type { INetworkCreateOptions } from '../../../networks/utils/networkHelpers.js';
-import type { IAddAccountConfig } from '../../types.js';
 
 export const testNetworkConfigMock: INetworkCreateOptions = {
   networkHost: 'https://api.testnet.chainweb.com',
@@ -15,14 +15,14 @@ export const devNetConfigMock: INetworkCreateOptions = {
   network: 'devnet',
 };
 
-export const defaultConfigMock: IAddAccountConfig = {
+export const defaultConfigMock = {
   accountAlias: 'accountAlias',
   accountName: 'accountName',
   fungible: 'coin',
   publicKeysConfig: [],
   publicKeys: '',
   predicate: 'keys-all',
-  chainId: '1',
+  chainId: '1' as ChainId,
   ...testNetworkConfigMock,
   networkConfig: testNetworkConfigMock,
   accountOverwrite: false,

--- a/packages/tools/kadena-cli/src/account/utils/addAccount.ts
+++ b/packages/tools/kadena-cli/src/account/utils/addAccount.ts
@@ -1,31 +1,19 @@
 import type { CommandResult } from '../../utils/command.util.js';
 import type { IAddAccountConfig } from '../types.js';
-import { getAccountFilePath, getUpdatedConfig } from './addHelpers.js';
+import { getAccountFilePath } from './addHelpers.js';
 import { createAccountConfigFile } from './createAccountConfigFile.js';
 
 export async function addAccount(
   config: IAddAccountConfig,
 ): Promise<CommandResult<string>> {
   try {
-    const filePath = getAccountFilePath(config.accountAlias);
-    const updatedConfig =
-      config.accountDetailsFromChain === undefined
-        ? config
-        : getUpdatedConfig(
-            config,
-            config.accountDetailsFromChain,
-            config.accountOverwrite,
-          );
+    const { accountAlias, ...rest } = config;
+    const filePath = getAccountFilePath(accountAlias);
 
-    const result = await createAccountConfigFile(filePath, updatedConfig);
+    const result = await createAccountConfigFile(filePath, rest);
     return {
       status: 'success',
       data: result,
-      warnings: !config.accountDetailsFromChain
-        ? [
-            `The account "${config.accountName}" is not on chain yet. To create it on-chain, transfer funds to it from ${config.networkConfig.network} and use "kadena account fund" command.`,
-          ]
-        : [],
     };
   } catch (error) {
     return {

--- a/packages/tools/kadena-cli/src/account/utils/createAccountConfigFile.ts
+++ b/packages/tools/kadena-cli/src/account/utils/createAccountConfigFile.ts
@@ -1,34 +1,10 @@
 import yaml from 'js-yaml';
 import { services } from '../../services/index.js';
-import type { IAddAccountConfig } from '../types.js';
+import type { IAccountAliasFileConfig } from '../types.js';
 import { accountAliasFileSchema, formatZodErrors } from './accountHelpers.js';
 
 export async function writeAccountAlias(
-  config: IAddAccountConfig,
-  filePath: string,
-): Promise<void> {
-  const { publicKeysConfig, predicate, accountName, fungible } = config;
-  await services.filesystem.ensureDirectoryExists(filePath);
-  try {
-    const aliasData = {
-      name: accountName,
-      fungible,
-      publicKeys: publicKeysConfig,
-      predicate,
-    };
-    accountAliasFileSchema.parse(aliasData);
-    await services.filesystem.writeFile(filePath, yaml.dump(aliasData));
-  } catch (error) {
-    const errorMessage = formatZodErrors(error);
-    throw new Error(`Error writing alias file: ${filePath}\n ${errorMessage}`);
-  }
-}
-
-export async function writeAccountAliasMinimal(
-  config: Pick<
-    IAddAccountConfig,
-    'publicKeysConfig' | 'predicate' | 'accountName' | 'fungible'
-  >,
+  config: IAccountAliasFileConfig,
   filePath: string,
 ): Promise<void> {
   const { publicKeysConfig, predicate, accountName, fungible } = config;
@@ -50,7 +26,7 @@ export async function writeAccountAliasMinimal(
 
 export async function createAccountConfigFile(
   filePath: string,
-  config: IAddAccountConfig,
+  config: IAccountAliasFileConfig,
 ): Promise<string> {
   if (await services.filesystem.fileExists(filePath)) {
     throw new Error(`The account configuration "${filePath}" already exists.`);

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -359,8 +359,14 @@ function walletKeysToPromptChoices(wallets: IWallet[]): {
   );
 }
 
-export const publicKeysSelectWithManualPrompt = async (): Promise<string> => {
-  const allWallets = await services.wallet.list();
+export const publicKeysSelectWithManualPrompt: IPrompt<string> = async (
+  previousQuestions,
+  args,
+  isOptional,
+) => {
+  const allWallets = await services.config.getWallets(
+    previousQuestions.directory as string,
+  );
 
   const publicKeysChoices = walletKeysToPromptChoices(allWallets);
 

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -345,9 +345,9 @@ function walletKeysToPromptChoices(wallets: IWallet[]): {
       const publicKeyStr = maskStringPreservingStartAndEnd(publicKey, 24);
       let name = '';
       if (hasAlias) {
-        name = `idx ${indexString} - ${paddedAlias} - ${publicKeyStr}`;
+        name = `  ${indexString} - ${paddedAlias} - ${publicKeyStr}`;
       } else {
-        name = `idx ${indexString} - ${publicKeyStr}`;
+        name = `  ${indexString} - ${publicKeyStr}`;
       }
       acc.push({
         name,

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -54,9 +54,24 @@ export const accountAliasPrompt: IPrompt<string> = async () =>
     },
   });
 
-export const accountNamePrompt: IPrompt<string> = async () =>
+export const accountNamePrompt: IPrompt<string> = async (
+  previousQuestions,
+  args,
+  isOptional,
+) =>
   await input({
-    message: 'Enter an account name (optional):',
+    message: isOptional
+      ? 'Enter an account name (optional):'
+      : 'Enter an account name:',
+    validate: function (value: string) {
+      if (isOptional && (!value || value.trim.length === 0)) return true;
+
+      if (!value || value.trim().length < 3) {
+        return 'Account name must be minimum at least 3 characters long.';
+      }
+
+      return true;
+    },
   });
 
 export const accountKdnAddressPrompt: IPrompt<string> = async () =>
@@ -261,8 +276,8 @@ export const accountDeleteConfirmationPrompt: IPrompt<boolean> = async (
     previousQuestions.accountAlias === 'all'
       ? 'all the accounts'
       : selectedAccountsLength > 1
-        ? 'all the selected aliases accounts'
-        : `the ${selectedAccounts} alias account`;
+      ? 'all the selected aliases accounts'
+      : `the ${selectedAccounts} alias account`;
 
   return await select({
     message: `Are you sure you want to delete ${selectedAccountMessage}?`,

--- a/packages/tools/kadena-cli/src/services/config/config.service.ts
+++ b/packages/tools/kadena-cli/src/services/config/config.service.ts
@@ -55,7 +55,7 @@ export interface IConfigService {
   // wallet
   getWallet: (filepath: string) => Promise<IWallet | null>;
   setWallet: (wallet: IWalletCreate, update?: boolean) => Promise<string>;
-  getWallets: () => Promise<IWallet[]>;
+  getWallets: (directory?: string) => Promise<IWallet[]>;
   deleteWallet: (filepath: string) => Promise<void>;
 }
 
@@ -211,10 +211,12 @@ export class ConfigService implements IConfigService {
     return filepath;
   }
 
-  public async getWallets(): ReturnType<IConfigService['getWallets']> {
-    const directory = await this.getDirectory();
-    if (directory === null) throw new KadenaError('no_kadena_directory');
-    const walletPath = path.join(directory, WALLET_DIR);
+  public async getWallets(
+    directory?: string,
+  ): ReturnType<IConfigService['getWallets']> {
+    const dir = directory ?? this.getDirectory();
+    if (dir === null) throw new KadenaError('no_kadena_directory');
+    const walletPath = path.join(dir, WALLET_DIR);
     if (!(await this.services.filesystem.directoryExists(walletPath))) {
       return [];
     }

--- a/packages/tools/kadena-cli/src/utils/globalHelpers.ts
+++ b/packages/tools/kadena-cli/src/utils/globalHelpers.ts
@@ -245,3 +245,9 @@ export function getPubKeyFromAccount(account: string): string {
   const pubKey = account.toLowerCase().slice(2);
   return pubKey;
 }
+
+export function isAlphanumeric(str: string): boolean {
+  // Regular expression that matches only alphanumeric characters
+  const alphanumericRegex = /^[a-z0-9]+$/i;
+  return alphanumericRegex.test(str);
+}

--- a/packages/tools/kadena-cli/src/wallets/utils/walletHelpers.ts
+++ b/packages/tools/kadena-cli/src/wallets/utils/walletHelpers.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { writeAccountAliasMinimal } from '../../account/utils/createAccountConfigFile.js';
+import { writeAccountAlias } from '../../account/utils/createAccountConfigFile.js';
 import { log } from '../../utils/logger.js';
 import { relativeToCwd } from '../../utils/path.util.js';
 
@@ -41,7 +41,7 @@ export const createAccountAliasByPublicKey = async (
 }> => {
   const accountName = `k:${publicKey}`;
   const accountFilepath = path.join(directory, `${alias}.yaml`);
-  await writeAccountAliasMinimal(
+  await writeAccountAlias(
     {
       accountName,
       fungible: 'coin',


### PR DESCRIPTION
Summarising the discussion on the ticket
- Remove network and chain id prompts from the account add-manual and add-from-wallet sub commands
- As part of `account add-manual` command public keys prompt list public keys from all wallets 
- If user wants to pass a different directory to fetch public keys from wallet can able to pass it in through cli option

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207178351013591