### PR TITLE
fix: network update command prefill values from existing config

### DIFF
--- a/packages/tools/kadena-cli/src/networks/commands/networkManage.ts
+++ b/packages/tools/kadena-cli/src/networks/commands/networkManage.ts
@@ -38,9 +38,15 @@ export const manageNetworksCommand: (
 
     const networkData = await option.network();
     const networkName = await option.networkName();
-    const networkId = await option.networkId();
-    const networkHost = await option.networkHost();
-    const networkExplorerUrl = await option.networkExplorerUrl();
+    const networkId = await option.networkId({
+      defaultValue: networkData.networkConfig.networkId,
+    });
+    const networkHost = await option.networkHost({
+      defaultValue: networkData.networkConfig.networkHost,
+    });
+    const networkExplorerUrl = await option.networkExplorerUrl({
+      defaultValue: networkData.networkConfig.networkExplorerUrl,
+    });
 
     log.debug('update-network:action', {
       networkExplorerUrl,

--- a/packages/tools/kadena-cli/src/prompts/network.ts
+++ b/packages/tools/kadena-cli/src/prompts/network.ts
@@ -68,7 +68,8 @@ export const networkIdPrompt: IPrompt<string> = async (
   args,
   isOptional,
 ) => {
-  const defaultValue = args.defaultValue as string;
+  const defaultValue = (args.defaultValue ??
+    previousQuestions.defaultValue) as string;
   const validate = function (input: string): string | boolean {
     if (isOptional) return true;
 
@@ -89,7 +90,8 @@ export const networkHostPrompt: IPrompt<string> = async (
   args,
   isOptional,
 ) => {
-  const defaultValue = args.defaultValue as string;
+  const defaultValue = (args.defaultValue ??
+    previousQuestions.defaultValue) as string;
   const validate = function (input: string): string | boolean {
     if (isOptional && !isNotEmptyString(input.trim())) return true;
 
@@ -113,7 +115,8 @@ export const networkExplorerUrlPrompt: IPrompt<string> = async (
   args,
   isOptional,
 ) => {
-  const defaultValue = args.defaultValue as string;
+  const defaultValue = (args.defaultValue ??
+    previousQuestions.defaultValue) as string;
   return await getInputPrompt(
     'Enter Kadena network explorer URL (e.g. "https://explorer.chainweb.com/mainnet/tx/")',
     defaultValue,


### PR DESCRIPTION
https://app.asana.com/0/0/1207147099820716/1207150008413583/f

Based on the comment from @Ghislain89, I also think this makes sense since we're merging it anyway with the existing network config values but prefilling the values make it more explicit to the user. 

