### PR TITLE
Feat(react UI)/new select component

### DIFF
--- a/.changeset/ten-dots-prove.md
+++ b/.changeset/ten-dots-prove.md
@@ -1,0 +1,6 @@
+---
+"@kadena/dev-wallet": patch
+"@kadena/react-ui": patch
+---
+
+feat: updated the select component with the new styling updates. These include new size variants, font variants and consistent states like the other form elements. Breaking change: startIcon has been renamed to startVisual to be consistent with other components.

--- a/packages/apps/dev-wallet/src/App/layout.tsx
+++ b/packages/apps/dev-wallet/src/App/layout.tsx
@@ -43,7 +43,7 @@ export const Layout: FC = () => {
           aria-label="Select Network"
           selectedKey={activeNetwork?.networkId}
           onSelectionChange={(value) => handleNetworkUpdate(value as string)}
-          startIcon={<MonoPublic />}
+          startVisual={<MonoPublic />}
         >
           {networks.map((network) => (
             <SelectItem key={network.networkId} textValue={network.name}>

--- a/packages/apps/tools/src/components/Common/Layout/partials/Header/Header.tsx
+++ b/packages/apps/tools/src/components/Common/Layout/partials/Header/Header.tsx
@@ -120,7 +120,7 @@ const Header: FC<IHeaderProps> = () => {
             aria-label={t('Select Network')}
             selectedKey={selectedNetwork as string}
             onSelectionChange={(value) => handleOnChange(value as Network)}
-            startIcon={<MonoPublic />}
+            startVisual={<MonoPublic />}
           >
             {[
               ...networksData.map((network: INetworkData) => (

--- a/packages/apps/tools/src/components/Global/ChainSelect/index.tsx
+++ b/packages/apps/tools/src/components/Global/ChainSelect/index.tsx
@@ -44,7 +44,7 @@ const ChainSelect: FC<ChainSelectProps> = ({
       label="Chain ID"
       id={id ?? ELEMENT_ID}
       onSelectionChange={onSelectChange}
-      startIcon={<MonoLink />}
+      startVisual={<MonoLink />}
       aria-label="Select Chain ID"
     >
       {CHAINS.map((chainId, index) => (

--- a/packages/libs/react-ui/src/components/Form/Form.css.ts
+++ b/packages/libs/react-ui/src/components/Form/Form.css.ts
@@ -29,7 +29,7 @@ export const outlineColor = createVar();
 export const iconFill = fallbackVar(token('color.icon.base.@init'));
 const textColor = fallbackVar(token('color.text.base.@init'));
 
-const outlineStyles = {
+export const outlineStyles = {
   outlineStyle: `solid`,
   outlineWidth: '2px',
   outlineOffset: '2px',
@@ -48,10 +48,20 @@ export const baseContainerClass = recipe({
     {
       transition: 'outline-color 0.2s ease-in-out',
       outlineColor: 'transparent',
+      minWidth: '150px',
+      '@media': {
+        [breakpoints.sm]: {
+          maxWidth: '100%',
+        },
+        [breakpoints.md]: {
+          maxWidth: '40rem',
+        },
+      },
       selectors: {
         // outline should not be shown if there is a button which is focused
         '&:focus-within:has(button:not(button:focus))': outlineStyles,
         '&:focus-within:not(&:has(button))': outlineStyles,
+        [`&:focus-within:has(button#select-button)`]: outlineStyles,
       },
     },
   ],
@@ -186,6 +196,72 @@ globalStyle(`${endAddonStyles.fullHeight} button`, {
   borderRadius: '0',
 });
 
+export const inputSizeVariants = {
+  size: {
+    sm: atoms({ paddingBlock: 'n2' }),
+    md: atoms({ paddingBlock: 'n3' }),
+    lg: atoms({ paddingBlock: 'n4' }),
+  },
+} as const;
+
+export const inputFontTypeVariants = {
+  fontType: {
+    ui: uiSmallRegular,
+    code: monospaceSmallRegular,
+  },
+} as const;
+
+export const inputSizeCompoundVariants: {
+  variants: {
+    fontType: keyof (typeof inputFontTypeVariants)['fontType'];
+    size: keyof (typeof inputSizeVariants)['size'];
+  };
+  style: string;
+}[] = [
+  {
+    variants: {
+      size: 'sm',
+      fontType: 'ui',
+    },
+    style: uiSmallestRegular,
+  },
+  {
+    variants: {
+      size: 'md',
+      fontType: 'ui',
+    },
+    style: uiSmallRegular,
+  },
+  {
+    variants: {
+      size: 'lg',
+      fontType: 'ui',
+    },
+    style: uiBaseRegular,
+  },
+  {
+    variants: {
+      size: 'sm',
+      fontType: 'code',
+    },
+    style: monospaceSmallestRegular,
+  },
+  {
+    variants: {
+      size: 'md',
+      fontType: 'code',
+    },
+    style: monospaceSmallRegular,
+  },
+  {
+    variants: {
+      size: 'lg',
+      fontType: 'code',
+    },
+    style: monospaceBaseRegular,
+  },
+];
+
 export const input = recipe({
   base: [
     atoms({
@@ -201,15 +277,6 @@ export const input = recipe({
       transition: 'box-shadow, background-color 0.2s ease-in-out',
       '::placeholder': {
         color: textColor,
-      },
-      minWidth: '150px',
-      '@media': {
-        [breakpoints.sm]: {
-          maxWidth: '100%',
-        },
-        [breakpoints.md]: {
-          maxWidth: '40rem',
-        },
       },
       selectors: {
         '&[data-focused]': {
@@ -242,15 +309,6 @@ export const input = recipe({
     },
   ],
   variants: {
-    size: {
-      sm: atoms({ paddingBlock: 'n2' }),
-      md: atoms({ paddingBlock: 'n3' }),
-      lg: atoms({ paddingBlock: 'n4' }),
-    },
-    fontType: {
-      ui: uiSmallRegular,
-      code: monospaceSmallRegular,
-    },
     variant: {
       default: {
         boxShadow: `0 -1px 0 0 ${token('color.border.base.default')} inset`,
@@ -300,49 +358,8 @@ export const input = recipe({
         },
       },
     },
+    ...inputSizeVariants,
+    ...inputFontTypeVariants,
   },
-  compoundVariants: [
-    {
-      variants: {
-        size: 'sm',
-        fontType: 'ui',
-      },
-      style: uiSmallestRegular,
-    },
-    {
-      variants: {
-        size: 'md',
-        fontType: 'ui',
-      },
-      style: uiSmallRegular,
-    },
-    {
-      variants: {
-        size: 'lg',
-        fontType: 'ui',
-      },
-      style: uiBaseRegular,
-    },
-    {
-      variants: {
-        size: 'sm',
-        fontType: 'code',
-      },
-      style: monospaceSmallestRegular,
-    },
-    {
-      variants: {
-        size: 'md',
-        fontType: 'code',
-      },
-      style: monospaceSmallRegular,
-    },
-    {
-      variants: {
-        size: 'lg',
-        fontType: 'code',
-      },
-      style: monospaceBaseRegular,
-    },
-  ],
+  compoundVariants: inputSizeCompoundVariants,
 });

--- a/packages/libs/react-ui/src/components/Form/Form.css.ts
+++ b/packages/libs/react-ui/src/components/Form/Form.css.ts
@@ -130,6 +130,7 @@ const startAddonBase = style([
   }),
   {
     insetInlineStart: token('spacing.n3'),
+    zIndex: 10,
     color: iconFill,
   },
 ]);

--- a/packages/libs/react-ui/src/components/Form/Form.css.ts
+++ b/packages/libs/react-ui/src/components/Form/Form.css.ts
@@ -9,10 +9,10 @@ import type { RecipeVariants } from '@vanilla-extract/recipes';
 import { recipe } from '@vanilla-extract/recipes';
 import {
   atoms,
-  breakpoints,
   monospaceBaseRegular,
   monospaceSmallRegular,
   monospaceSmallestRegular,
+  responsiveStyle,
   token,
   uiBaseRegular,
   uiSmallRegular,
@@ -49,19 +49,19 @@ export const baseContainerClass = recipe({
       transition: 'outline-color 0.2s ease-in-out',
       outlineColor: 'transparent',
       minWidth: '150px',
-      '@media': {
-        [breakpoints.sm]: {
+      ...responsiveStyle({
+        sm: {
           maxWidth: '100%',
         },
-        [breakpoints.md]: {
+        md: {
           maxWidth: '40rem',
         },
-      },
+      }),
       selectors: {
         // outline should not be shown if there is a button which is focused
         '&:focus-within:has(button:not(button:focus))': outlineStyles,
         '&:focus-within:not(&:has(button))': outlineStyles,
-        [`&:focus-within:has(button#select-button)`]: outlineStyles,
+        [`&:focus-within:has([data-role="select-button"])`]: outlineStyles,
       },
     },
   ],

--- a/packages/libs/react-ui/src/components/Form/NumberField/NumberField.tsx
+++ b/packages/libs/react-ui/src/components/Form/NumberField/NumberField.tsx
@@ -137,6 +137,7 @@ export function NumberFieldBase(
         data-invalid={props.isInvalid || undefined}
         data-positive={props.isPositive || undefined}
         data-has-start-addon={!!props.startVisual || undefined}
+        data-has-end-addon
       />
     </Field>
   );

--- a/packages/libs/react-ui/src/components/Form/NumberField/NumberField.tsx
+++ b/packages/libs/react-ui/src/components/Form/NumberField/NumberField.tsx
@@ -12,9 +12,9 @@ import React, { forwardRef, useCallback } from 'react';
 import type { AriaNumberFieldProps } from 'react-aria';
 import { useFocusRing, useHover, useLocale, useNumberField } from 'react-aria';
 import { useNumberFieldState } from 'react-stately';
-import { NumberFieldActions } from '../ActionButtons/NumberFieldActions';
 import { Field } from '../Field/Field';
 import { input } from '../Form.css';
+import { NumberFieldActions } from './NumberFieldActions';
 
 type Variants = NonNullable<RecipeVariants<typeof input>>;
 

--- a/packages/libs/react-ui/src/components/Form/NumberField/NumberFieldActions.tsx
+++ b/packages/libs/react-ui/src/components/Form/NumberField/NumberFieldActions.tsx
@@ -2,8 +2,8 @@ import { MonoAdd, MonoRemove } from '@kadena/react-icons/system';
 import React from 'react';
 import { Button } from '../../Button/Button';
 
-import type { INumberFieldProps } from '../NumberField';
-import { iconSize } from '../NumberField/NumberField.css';
+import type { INumberFieldProps } from '.';
+import { iconSize } from './NumberField.css';
 
 interface INumberFieldActionsProps {
   isDisabled?: boolean;

--- a/packages/libs/react-ui/src/components/Form/Select/Select.css.ts
+++ b/packages/libs/react-ui/src/components/Form/Select/Select.css.ts
@@ -1,46 +1,39 @@
-import { style } from '@vanilla-extract/css';
-import { atoms, bodyBaseRegular, ellipsis, token } from '../../../styles';
+import { globalStyle, style, styleVariants } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+import { atoms, ellipsis, token } from '../../../styles';
+import { inputFontTypeVariants, inputSizeCompoundVariants } from '../Form.css';
+
+export const selectButtonValue = atoms({
+  display: 'flex',
+  flex: 1,
+});
 
 export const selectButtonClass = style([
-  bodyBaseRegular,
   atoms({
     display: 'flex',
-    alignItems: 'center',
-    borderRadius: 'sm',
     backgroundColor: 'input.default',
-    border: 'none',
+    justifyContent: 'space-between',
     color: 'text.base.default',
-    outline: 'none',
     flex: 1,
     overflow: 'hidden',
+    position: 'relative',
+    alignItems: 'center',
   }),
   {
+    paddingBlock: '0',
     paddingInlineStart: token('spacing.md'),
-    paddingInlineEnd: token('spacing.md'),
-    paddingBlock: token('spacing.sm'),
-    boxShadow: `0px 1px 0 0 ${token('color.border.base.default')}`,
-    outlineOffset: '2px',
+    paddingInlineEnd: '0',
     selectors: {
       '&[data-hovered]': {
         cursor: 'pointer',
       },
-      '&[data-positive]': {
-        outline: `2px solid ${token('color.border.semantic.positive.@focus')}`,
-      },
-      '&[data-disabled]': {
-        pointerEvents: 'none',
-        backgroundColor: token('color.background.input.inverse.default'),
-        color: token('color.text.base.inverse.@disabled'),
-      },
-      '&[data-focused]': {
-        outline: `2px solid ${token('color.border.semantic.info.@focus')}`,
-      },
-      '&[data-invalid]': {
-        outline: `2px solid ${token('color.border.semantic.negative.@focus')}`,
-      },
     },
   },
 ]);
+
+globalStyle(`${selectButtonClass} > span`, {
+  fontFamily: 'unset',
+});
 
 // applied on a span
 export const selectValueClass = style([
@@ -55,3 +48,29 @@ export const selectValueClass = style([
     },
   },
 ]);
+
+export const selectIconWrapper = style([
+  atoms({
+    backgroundColor: 'surface.default',
+    padding: 'n2',
+  }),
+]);
+
+export const selectIconClass = styleVariants({
+  sm: { height: token('icon.size.xs') },
+  md: { height: token('icon.size.base') },
+  lg: { height: token('icon.size.lg') },
+});
+
+export const selectItemClass = recipe({
+  base: [atoms({ paddingInlineStart: 'md' })],
+  variants: {
+    size: {
+      sm: [],
+      md: [],
+      lg: [],
+    },
+    ...inputFontTypeVariants,
+  },
+  compoundVariants: inputSizeCompoundVariants,
+});

--- a/packages/libs/react-ui/src/components/Form/Select/Select.stories.tsx
+++ b/packages/libs/react-ui/src/components/Form/Select/Select.stories.tsx
@@ -1,19 +1,26 @@
 import { MonoAccountCircle, MonoAdd } from '@kadena/react-icons/system';
 import type { Meta, StoryObj } from '@storybook/react';
 import React, { useState } from 'react';
-import { onLayer2, withContentWidth } from '../../../storyDecorators';
+import {
+  getVariants,
+  onLayer3,
+  withContentWidth,
+} from '../../../storyDecorators';
 import { atoms } from '../../../styles';
 import { getArrayOf } from '../../../utils';
 import { Button } from '../../Button';
 import { Box } from '../../Layout';
 import { Form } from '../Form';
+import { input } from '../Form.css';
 import type { ISelectProps } from './Select';
 import { Select, SelectItem } from './Select';
+
+const { size, variant, fontType } = getVariants(input);
 
 const meta: Meta<ISelectProps> = {
   title: 'Form/Select',
   component: Select,
-  decorators: [withContentWidth, onLayer2],
+  decorators: [withContentWidth, onLayer3],
   parameters: {
     status: { type: 'releaseCandidate' },
     docs: {
@@ -24,6 +31,34 @@ const meta: Meta<ISelectProps> = {
     },
   },
   argTypes: {
+    variant: {
+      description: 'Variant of the input.',
+      control: {
+        type: 'select',
+      },
+      options: variant,
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'default' },
+      },
+    },
+    size: {
+      description: 'Size of the input.',
+      control: {
+        type: 'radio',
+      },
+      options: size,
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'md' },
+      },
+    },
+    fontType: {
+      description: 'Font type of the input.',
+      control: { type: 'radio' },
+      options: fontType,
+      table: { type: { summary: 'string' }, defaultValue: { summary: 'ui' } },
+    },
     description: {
       description: 'Helper text to display below the input.',
       control: {
@@ -51,7 +86,6 @@ const meta: Meta<ISelectProps> = {
         type: { summary: 'string' },
       },
     },
-
     placeholder: {
       description: 'Placeholder text to display in the input.',
       control: {
@@ -61,7 +95,6 @@ const meta: Meta<ISelectProps> = {
         type: { summary: 'string' },
       },
     },
-
     errorMessage: {
       description: 'Error message to display below the input.',
       control: {
@@ -71,17 +104,6 @@ const meta: Meta<ISelectProps> = {
         type: { summary: 'string' },
       },
     },
-    isPositive: {
-      description: 'Applies positive visual styling.',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        type: { summary: 'boolean' },
-        defaultValue: { summary: 'false' },
-      },
-    },
-
     isInvalid: {
       description: 'Marks the input as invalid and applies visual styling.',
       control: {
@@ -92,7 +114,6 @@ const meta: Meta<ISelectProps> = {
         defaultValue: { summary: 'false' },
       },
     },
-
     isDisabled: {
       description: 'Disables the input and applies visual styling.',
       control: {
@@ -120,15 +141,6 @@ export default meta;
 type Story = StoryObj<ISelectProps>;
 
 export const Default: Story = {
-  args: {
-    isDisabled: false,
-    isInvalid: false,
-    isRequired: false,
-    isPositive: false,
-    description: 'Some description',
-    label: 'Select something',
-    placeholder: 'Select an option',
-  },
   render: (args) => {
     return (
       <Select {...args}>
@@ -153,7 +165,7 @@ export const WithIcon: Story = {
   },
   render: (args) => {
     return (
-      <Select {...args} startIcon={<MonoAccountCircle />}>
+      <Select {...args} startVisual={<MonoAccountCircle />}>
         <SelectItem key="option1">Option 1</SelectItem>
         <SelectItem key="option2">Option 2</SelectItem>
         <SelectItem key="option3">Option 3</SelectItem>
@@ -252,4 +264,19 @@ export const NativeValidation: Story = {
       </Form>
     );
   },
+};
+
+export const WithAddons = () => {
+  const items = getArrayOf(
+    (index) => ({
+      label: `Option ${index}`,
+      key: `option${index}`,
+    }),
+    100,
+  );
+  return (
+    <Select label="Select an option" items={items} startVisual={<MonoAdd />}>
+      {(item) => <SelectItem key={item.key}>{item.label}</SelectItem>}
+    </Select>
+  );
 };

--- a/packages/libs/react-ui/src/components/Form/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Form/Select/Select.tsx
@@ -78,6 +78,7 @@ function SelectBase<T extends object>(
       tag={tag}
       info={info}
       ref={ref}
+      startVisual={startVisual}
       isInvalid={fieldProps.isInvalid}
     >
       <HiddenSelect
@@ -98,10 +99,11 @@ function SelectBase<T extends object>(
           className,
         )}
         size={size}
-        startIcon={startVisual}
         ref={ref}
         state={state}
         data-disabled={isDisabled || undefined}
+        data-has-end-addon
+        data-has-start-addon={!!startVisual || undefined}
         autoFocus={props.autoFocus}
         isInvalid={fieldProps.isInvalid}
         isPositive={props.isPositive}

--- a/packages/libs/react-ui/src/components/Form/Select/Select.tsx
+++ b/packages/libs/react-ui/src/components/Form/Select/Select.tsx
@@ -101,6 +101,7 @@ function SelectBase<T extends object>(
         size={size}
         ref={ref}
         state={state}
+        isDisabled={isDisabled}
         data-disabled={isDisabled || undefined}
         data-has-end-addon
         data-has-start-addon={!!startVisual || undefined}

--- a/packages/libs/react-ui/src/components/Form/Select/SelectButton.tsx
+++ b/packages/libs/react-ui/src/components/Form/Select/SelectButton.tsx
@@ -43,7 +43,7 @@ function SelectButtonBase<T extends object>(
   return (
     <button
       {...mergeProps(buttonProps, dataProps, hoverProps)}
-      id="select-button"
+      data-role="select-button"
       className={classNames(selectButtonClass, props.className)}
       ref={ref}
     >

--- a/packages/libs/react-ui/src/components/Form/Select/SelectButton.tsx
+++ b/packages/libs/react-ui/src/components/Form/Select/SelectButton.tsx
@@ -7,7 +7,11 @@ import type { AriaButtonProps } from 'react-aria';
 import { useButton, useHover } from 'react-aria';
 import type { SelectState } from 'react-stately';
 import { atoms, rotate180Transition } from '../../../styles';
-import { selectButtonClass } from './Select.css';
+import {
+  selectButtonClass,
+  selectIconClass,
+  selectIconWrapper,
+} from './Select.css';
 
 export interface ISelectButtonProps<T extends object> extends AriaButtonProps {
   state: SelectState<T>;
@@ -16,6 +20,7 @@ export interface ISelectButtonProps<T extends object> extends AriaButtonProps {
   isInvalid?: boolean;
   isPositive?: boolean;
   startIcon?: ReactNode;
+  size: 'sm' | 'md' | 'lg';
 }
 function SelectButtonBase<T extends object>(
   props: ISelectButtonProps<T>,
@@ -38,6 +43,7 @@ function SelectButtonBase<T extends object>(
   return (
     <button
       {...mergeProps(buttonProps, dataProps, hoverProps)}
+      id="select-button"
       className={classNames(selectButtonClass, props.className)}
       ref={ref}
     >
@@ -47,10 +53,13 @@ function SelectButtonBase<T extends object>(
         </span>
       )}
       {props.children}
-      <span className={atoms({ marginInlineStart: 'sm' })}>
+      <span className={selectIconWrapper}>
         <MonoExpandMore
           data-open={props.state.isOpen}
-          className={rotate180Transition}
+          className={classNames(
+            rotate180Transition,
+            selectIconClass[props.size],
+          )}
         />
       </span>
     </button>

--- a/packages/libs/react-ui/src/components/ListBox/ListBox.css.ts
+++ b/packages/libs/react-ui/src/components/ListBox/ListBox.css.ts
@@ -48,12 +48,8 @@ export const listItemClass = style([
   }),
   {
     transition: 'background 0.2s',
-    ':hover': {
-      color: token('color.text.base.default'),
-      backgroundColor: token('color.background.input.@hover'),
-    },
     ':focus': {
-      outlineColor: 'none',
+      outline: 'none',
     },
     ':focus-visible': {
       outline: 'none',
@@ -69,7 +65,7 @@ export const listItemClass = style([
       },
       '&[data-focused="true"]': {
         color: token('color.text.semantic.info.@focus'),
-        backgroundColor: token('color.background.semantic.info.@focus'),
+        backgroundColor: token('color.background.input.@focus'),
       },
       '&[data-selected="true"]': {
         backgroundColor: token(

--- a/packages/libs/react-ui/src/components/ListBox/ListBox.css.ts
+++ b/packages/libs/react-ui/src/components/ListBox/ListBox.css.ts
@@ -1,5 +1,5 @@
 import { style } from '@vanilla-extract/css';
-import { atoms, bodyBaseRegular, token } from '../../styles';
+import { atoms, token } from '../../styles';
 
 // applied on ul
 export const listBoxClass = style([
@@ -7,22 +7,14 @@ export const listBoxClass = style([
     width: '100%',
     display: 'flex',
     flexDirection: 'column',
-    backgroundColor: 'surface.default',
+    backgroundColor: 'input.default',
     margin: 'no',
     padding: 'no',
     listStyleType: 'none',
-    paddingBlock: 'sm',
-    borderRadius: 'sm',
     overflowX: 'hidden',
   }),
   {
     boxShadow: `0px 1px 0 0 ${token('color.border.base.default')}`,
-    ':focus': {
-      outline: 'none',
-    },
-    ':focus-visible': {
-      outline: 'none',
-    },
     selectors: {
       "&[data-scrollable='true']": {
         maxHeight: '500px',
@@ -33,13 +25,18 @@ export const listBoxClass = style([
         borderRadius: '0',
         boxShadow: 'none',
       },
+      '&[data-focus-visible="true"]': {
+        outlineColor: token('color.border.tint.outline'),
+      },
+      '&[data-focused="true"]': {
+        outlineColor: token('color.border.tint.outline'),
+      },
     },
   },
 ]);
 
 // applied on li
 export const listItemClass = style([
-  bodyBaseRegular,
   atoms({
     display: 'flex',
     alignItems: 'center',
@@ -47,23 +44,25 @@ export const listItemClass = style([
     listStyleType: 'none',
     paddingBlock: 'sm',
     paddingInline: 'sm',
-    marginInline: 'xs',
     color: 'text.base.default',
     cursor: 'pointer',
-    borderRadius: 'sm',
   }),
   {
     transition: 'background 0.2s',
+    ':hover': {
+      color: token('color.text.base.default'),
+      backgroundColor: token('color.background.input.@hover'),
+    },
     ':focus': {
-      outline: 'none',
+      outlineColor: 'none',
     },
     ':focus-visible': {
       outline: 'none',
     },
     selectors: {
       '&[data-hovered="true"]': {
-        color: token('color.text.semantic.info.@hover'),
-        backgroundColor: token('color.background.semantic.info.@hover'),
+        color: token('color.text.base.default'),
+        backgroundColor: token('color.background.input.@hover'),
       },
       '&[data-disabled="true"]': {
         color: token('color.text.base.@disabled'),
@@ -74,7 +73,10 @@ export const listItemClass = style([
         backgroundColor: token('color.background.semantic.info.@focus'),
       },
       '&[data-selected="true"]': {
-        color: token('color.text.semantic.info.default'),
+        backgroundColor: token(
+          'color.background.accent.primary.inverse.default',
+        ),
+        color: token('color.text.base.inverse.default'),
         fontWeight: token('typography.weight.secondaryFont.bold'),
       },
       '&[data-has-children="true"]': {

--- a/packages/libs/react-ui/src/components/ListBox/ListBox.css.ts
+++ b/packages/libs/react-ui/src/components/ListBox/ListBox.css.ts
@@ -7,7 +7,6 @@ export const listBoxClass = style([
     width: '100%',
     display: 'flex',
     flexDirection: 'column',
-    backgroundColor: 'input.default',
     margin: 'no',
     padding: 'no',
     listStyleType: 'none',

--- a/packages/libs/react-ui/src/components/ListBox/ListBox.tsx
+++ b/packages/libs/react-ui/src/components/ListBox/ListBox.tsx
@@ -1,4 +1,5 @@
 import { useObjectRef } from '@react-aria/utils';
+import classNames from 'classnames';
 import type { ForwardedRef, ReactNode, Ref } from 'react';
 import React, { forwardRef } from 'react';
 import type { AriaListBoxOptions } from 'react-aria';
@@ -10,6 +11,8 @@ import { ListBoxOption } from './ListBoxOption';
 interface IListBoxProps<T extends object> extends AriaListBoxOptions<T> {
   state: ListState<T>;
   label?: ReactNode;
+  listClassName?: string;
+  itemClassName?: string;
 }
 
 function ListBoxBase<T extends object>(
@@ -17,7 +20,7 @@ function ListBoxBase<T extends object>(
   forwardedRef: ForwardedRef<HTMLUListElement>,
 ) {
   const ref = useObjectRef(forwardedRef);
-  const { state } = props;
+  const { state, listClassName, itemClassName } = props;
   const { listBoxProps, labelProps } = useListBox(props, state, ref);
 
   return (
@@ -27,10 +30,15 @@ function ListBoxBase<T extends object>(
         {...listBoxProps}
         ref={ref}
         data-scrollable="true"
-        className={listBoxClass}
+        className={classNames(listBoxClass, listClassName)}
       >
         {[...state.collection].map((item) => (
-          <ListBoxOption key={item.key} item={item} state={state} />
+          <ListBoxOption
+            key={item.key}
+            item={item}
+            state={state}
+            className={itemClassName}
+          />
         ))}
       </ul>
     </>

--- a/packages/libs/react-ui/src/components/ListBox/ListBoxOption.tsx
+++ b/packages/libs/react-ui/src/components/ListBox/ListBoxOption.tsx
@@ -18,8 +18,14 @@ function ListBoxOptionBase<T extends object>(
   forwardedRef: ForwardedRef<HTMLLIElement>,
 ) {
   const ref = useObjectRef(forwardedRef);
-  const { optionProps, isSelected, isDisabled, isFocusVisible, isPressed } =
-    useOption({ key: item.key }, state, ref);
+  const {
+    optionProps,
+    isSelected,
+    isDisabled,
+    isFocusVisible,
+    isFocused,
+    isPressed,
+  } = useOption({ key: item.key }, state, ref);
   const { hoverProps, isHovered } = useHover({
     isDisabled,
   });
@@ -29,6 +35,7 @@ function ListBoxOptionBase<T extends object>(
       {...mergeProps(optionProps, hoverProps)}
       ref={ref}
       data-selected={isSelected || undefined}
+      data-focused={isFocused}
       data-focused-visible={isFocusVisible || undefined}
       data-pressed={isPressed}
       data-disabled={isDisabled}

--- a/packages/libs/react-ui/src/components/ListBox/ListBoxOption.tsx
+++ b/packages/libs/react-ui/src/components/ListBox/ListBoxOption.tsx
@@ -1,4 +1,5 @@
 import { mergeProps, useObjectRef } from '@react-aria/utils';
+import classNames from 'classnames';
 import type { ForwardedRef, Ref } from 'react';
 import React, { forwardRef } from 'react';
 import { useHover, useOption } from 'react-aria';
@@ -9,35 +10,30 @@ import { listItemClass } from './ListBox.css';
 interface IListBoxOptionProps<T> {
   item: Node<T>;
   state: ListState<T>;
+  className?: string;
 }
 
 function ListBoxOptionBase<T extends object>(
-  { item, state }: IListBoxOptionProps<T>,
+  { item, state, className }: IListBoxOptionProps<T>,
   forwardedRef: ForwardedRef<HTMLLIElement>,
 ) {
   const ref = useObjectRef(forwardedRef);
-  const {
-    optionProps,
-    isSelected,
-    isFocused,
-    isDisabled,
-    isFocusVisible,
-    isPressed,
-  } = useOption({ key: item.key }, state, ref);
+  const { optionProps, isSelected, isDisabled, isFocusVisible, isPressed } =
+    useOption({ key: item.key }, state, ref);
   const { hoverProps, isHovered } = useHover({
     isDisabled,
   });
+
   return (
     <li
       {...mergeProps(optionProps, hoverProps)}
       ref={ref}
-      data-selected={isSelected}
-      data-focused={isFocused}
-      data-focused-visible={isFocusVisible}
+      data-selected={isSelected || undefined}
+      data-focused-visible={isFocusVisible || undefined}
       data-pressed={isPressed}
       data-disabled={isDisabled}
-      data-hovered={isHovered}
-      className={listItemClass}
+      data-hovered={isHovered || undefined}
+      className={classNames(listItemClass, className)}
     >
       <span className={ellipsis}>{item.rendered}</span>
     </li>

--- a/packages/libs/react-ui/src/components/Popover/Popover.css.ts
+++ b/packages/libs/react-ui/src/components/Popover/Popover.css.ts
@@ -9,12 +9,13 @@ export const underlayClass = style({
 
 export const popoverClass = style([
   atoms({
-    backgroundColor: 'base.default',
-    borderRadius: 'sm',
+    backgroundColor: 'input.default',
     overflow: 'auto',
   }),
   {
+    backdropFilter: 'blur(64px)',
     maxHeight: '100%',
+    boxShadow: `0 1px 0 0 ${token('color.border.base.default')}`,
   },
 ]);
 
@@ -25,7 +26,7 @@ export const arrowClass = style({
   selectors: {
     "&[data-placement='top']": {
       top: '100%',
-      transform: ' translate(-50%)',
+      transform: 'translate(-50%)',
     },
     "&[data-placement='bottom']": {
       bottom: '100%',

--- a/packages/libs/react-ui/src/components/Popover/Popover.css.ts
+++ b/packages/libs/react-ui/src/components/Popover/Popover.css.ts
@@ -13,7 +13,7 @@ export const popoverClass = style([
     overflow: 'auto',
   }),
   {
-    backdropFilter: 'blur(64px)',
+    backdropFilter: 'blur(32px)',
     maxHeight: '100%',
     boxShadow: `0 1px 0 0 ${token('color.border.base.default')}`,
   },

--- a/packages/libs/react-ui/src/components/Popover/Popover.tsx
+++ b/packages/libs/react-ui/src/components/Popover/Popover.tsx
@@ -76,7 +76,7 @@ function PopoverBase(
   );
 }
 
-interface PopoverInnerProps extends AriaPopoverProps, IPopoverProps {
+interface IPopoverInnerProps extends AriaPopoverProps, IPopoverProps {
   state: OverlayTriggerState;
 }
 
@@ -86,7 +86,7 @@ function PopoverInner({
   portalContainer,
   resizeToTrigger = true,
   ...props
-}: PopoverInnerProps) {
+}: IPopoverInnerProps) {
   const { popoverProps, underlayProps, arrowProps, placement } = usePopover(
     {
       ...props,

--- a/packages/libs/react-ui/src/styles/global.css.ts
+++ b/packages/libs/react-ui/src/styles/global.css.ts
@@ -100,7 +100,7 @@ globalStyle('button, input, select, textarea, label', {
 /*
     8. Avoid text overflows
 */
-globalStyle('p, h1, h2, h3, h4, h5, h6, span', {
+globalStyle('p, h1, h2, h3, h4, h5, h6, span, li', {
   overflowWrap: 'break-word',
   fontFamily: vars.fonts.$main,
 });

--- a/packages/libs/react-ui/src/styles/utils.css.ts
+++ b/packages/libs/react-ui/src/styles/utils.css.ts
@@ -19,7 +19,7 @@ export const ellipsis = style({
 
 export const rotate180Transition = style({
   transitionProperty: 'transform',
-  transitionDuration: '100ms',
+  transitionDuration: '400ms',
   transitionTimingFunction: 'ease-in-out',
   transform: 'rotate(0deg)',
 

--- a/packages/libs/react-ui/src/styles/utils.css.ts
+++ b/packages/libs/react-ui/src/styles/utils.css.ts
@@ -1,6 +1,7 @@
 import { style } from '@vanilla-extract/css';
 
 export const ellipsis = style({
+  fontFamily: 'unset',
   display: 'inline-block',
   overflow: 'hidden',
   textOverflow: 'ellipsis',


### PR DESCRIPTION
### Changes:
updated the select component with the new styling updates. These include new size variants, font variants and consistent states like the other form elements. Internally the component uses the new Field component to abstract the formfield logic and simplify the select component.

### Breaking changes:
- startIcon has been renamed to startVisual to be consistent with other rebranded components.

