### PR TITLE
fix: validate alias and wallet name exists on input prompt

### DIFF
--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -1,5 +1,5 @@
 import type { ChainId } from '@kadena/types';
-import { parse } from 'node:path';
+import { basename, parse } from 'node:path';
 import {
   chainIdRangeValidation,
   fundAmountValidation,
@@ -45,13 +45,21 @@ export const publicKeysPrompt: IPrompt<string> = async (
 export const accountAliasPrompt: IPrompt<string> = async () =>
   await input({
     message: 'Enter an alias for an account:',
-    validate: function (value: string) {
+    validate: async function (value: string) {
       if (!value || value.trim().length < 3) {
         return 'Alias must be minimum at least 3 characters long.';
       }
 
       if (!isValidFilename(value)) {
         return `Alias is used as a filename. ${INVALID_FILE_NAME_ERROR_MSG}`;
+      }
+
+      const allAccountAliases = (await getAllAccountNames()).map((account) =>
+        basename(account.alias, '.yaml'),
+      );
+
+      if (allAccountAliases.includes(value)) {
+        return `Alias "${value}" already exists. Please enter a different alias.`;
       }
 
       return true;

--- a/packages/tools/kadena-cli/src/prompts/wallets.ts
+++ b/packages/tools/kadena-cli/src/prompts/wallets.ts
@@ -9,10 +9,19 @@ import { input, select } from '../utils/prompts.js';
 export async function walletNamePrompt(): Promise<string> {
   return await input({
     message: `Enter your wallet name:`,
-    validate: function (input) {
+    validate: async function (input) {
       if (!isValidFilename(input)) {
         return `Name is used as a filename. ${INVALID_FILE_NAME_ERROR_MSG}`;
       }
+
+      const allWalletNames = (await services.config.getWallets()).map(
+        (wallet) => wallet.alias,
+      );
+
+      if (allWalletNames.includes(input)) {
+        return `Wallet name "${input}" already exists. Please enter a different wallet name.`;
+      }
+
       return true;
     },
   });

--- a/packages/tools/kadena-cli/src/wallets/tests/walletDelete.test.ts
+++ b/packages/tools/kadena-cli/src/wallets/tests/walletDelete.test.ts
@@ -36,7 +36,9 @@ describe('delete wallet', () => {
     mockPrompts({
       select: {
         'Select a wallet': 'test',
-        'Are you sure': true,
+      },
+      input: {
+        'Are you sure you want to delete the wallet:': 'yes',
       },
     });
 


### PR DESCRIPTION
Currently for wallet and account add commands if alias and wallet already exists on the same name we thrown an error at the end. It might be improved when we validate whether file exists or not at the time of user input. 


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207265443085992