### PR TITLE
fix: tx add command prefix alias + index for keys and account

### DIFF
--- a/packages/tools/kadena-cli/src/prompts/tx.ts
+++ b/packages/tools/kadena-cli/src/prompts/tx.ts
@@ -9,6 +9,7 @@ import {
   requestKeyValidation,
 } from '../tx/utils/txHelpers.js';
 
+import { basename } from 'node:path';
 import { getAllAccounts } from '../account/utils/accountHelpers.js';
 import { loadNetworkConfig } from '../networks/utils/networkHelpers.js';
 import { services } from '../services/index.js';
@@ -199,8 +200,9 @@ const promptVariableValue = async (
         ...accounts.map((account) => ({
           value: account.name,
           name: [
-            account.fungible,
+            basename(account.alias, '.yaml'),
             maskStringPreservingStartAndEnd(account.name, 20),
+            account.fungible,
             account.publicKeys
               .map((x) => maskStringPreservingStartAndEnd(x))
               .join(','),
@@ -345,10 +347,14 @@ const promptVariableValue = async (
         // Purposely did not auto-select if 1 key for transparency
         value = await select({
           message: `Select public key from wallet ${wallet.alias}:`,
-          choices: wallet.keys.map((wallet) => ({
-            value: wallet.publicKey,
-            name: wallet.publicKey,
-          })),
+          choices: [
+            ...tableFormatPrompt([
+              ...wallet.keys.map((key) => ({
+                value: key.publicKey,
+                name: [key.index.toString(), key.alias ?? '', key.publicKey],
+              })),
+            ]),
+          ],
         });
       } else if (target === '_plain_') {
         // Purposely did not auto-select if 1 key for transparency
@@ -371,8 +377,9 @@ const promptVariableValue = async (
             ...accounts.map((account) => ({
               value: account.name,
               name: [
-                account.fungible,
+                basename(account.alias, '.yaml'),
                 maskStringPreservingStartAndEnd(account.name, 20),
+                account.fungible,
                 account.publicKeys
                   .map((x) => maskStringPreservingStartAndEnd(x))
                   .join(','),


### PR DESCRIPTION
https://github.com/kadena-community/kadena.js/pull/2020 - another PR to add alias for keys on add-from-wallet subcommand


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207158682603332