### PR TITLE
Adjust reconcile view amount fields to decimals

### DIFF
--- a/.changeset/dry-trees-begin.md
+++ b/.changeset/dry-trees-begin.md
@@ -1,0 +1,5 @@
+---
+'@kadena/graph': patch
+---
+
+Alter reconcile view amount fields to decimals

--- a/packages/apps/graph/cwd-extra-migrations/2.3.0.0.6_replace_reconcile_view.sql
+++ b/packages/apps/graph/cwd-extra-migrations/2.3.0.0.6_replace_reconcile_view.sql
@@ -1,0 +1,25 @@
+DROP VIEW IF EXISTS reconcile;
+
+CREATE VIEW reconcile AS
+SELECT params ->> 0 AS token
+     , (params ->> 1) :: DECIMAL AS amount
+     , params -> 2 ->> 'account' AS sender
+     , (params -> 2 ->> 'current') :: DECIMAL AS sender_current
+     , (params -> 2 ->> 'previous') :: DECIMAL AS sender_previous
+     , params -> 3 ->> 'account' AS receiver
+     , (params -> 3 ->> 'current') :: DECIMAL  AS receiver_current
+     , (params -> 3 ->> 'previous') :: DECIMAL  AS receiver_previous
+     , chainid
+     , height
+     , requestkey
+     , idx
+     , block
+     , id
+     , CASE
+         WHEN module = 'marmalade.ledger' THEN 'v1'
+         WHEN module = 'marmalade-v2.ledger' THEN 'v2'
+       END AS version
+FROM events
+WHERE ( module = 'marmalade.ledger' OR module = 'marmalade-v2.ledger' )
+  AND name = 'RECONCILE'
+;

--- a/packages/apps/graph/package.json
+++ b/packages/apps/graph/package.json
@@ -17,7 +17,7 @@
     "kadena-graph": "./dist/index.js"
   },
   "scripts": {
-    "build": "pnpm run pactjs:generate:contract:coin && pnpm run pactjs:generate:contract:marmalade && pnpm run pactjs:generate:contract:marmalade-v2 && pnpm prisma:generate && tsc",
+    "build": "pnpm run pactjs:generate:contracts && pnpm prisma:generate && tsc",
     "deploy:marmalade": "ts-node -T src/devnet/deployment/index.ts deploy:marmalade",
     "devnet": "docker volume create kadena_devnet; docker run --rm -it -p 8080:8080 -p 5432:5432 -p 9999:9999 -p 1789:1789 -v kadena_devnet:/data -v ./cwd-extra-migrations:/cwd-extra-migrations:ro --name devnet kadena/devnet",
     "devnet:update": "docker pull kadena/devnet",
@@ -33,6 +33,7 @@
     "pactjs:generate:contract:faucet": "pactjs contract-generate --contract user.coin-faucet --api https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/0/pact;",
     "pactjs:generate:contract:marmalade": "pactjs contract-generate --contract marmalade.ledger --api https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/1/pact;",
     "pactjs:generate:contract:marmalade-v2": "pactjs contract-generate --contract marmalade-v2.ledger --api https://api.testnet.chainweb.com/chainweb/0.0/testnet04/chain/1/pact;",
+    "pactjs:generate:contracts": "npm run pactjs:generate:contract:coin & npm run pactjs:generate:contract:marmalade & npm run pactjs:generate:contract:marmalade-v2",
     "prisma:generate": "prisma generate",
     "prisma:pull": "prisma db pull",
     "prisma:studio": "prisma studio",

--- a/packages/apps/graph/prisma/schema.prisma
+++ b/packages/apps/graph/prisma/schema.prisma
@@ -162,19 +162,19 @@ model schema_migrations {
 /// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
 view reconcile {
   token                  String?
-  amount                 Int?
-  senderAccount          String? @map("sender")
-  senderCurrentAmount    Int?    @map("sender_current")
-  senderPreviousAmount   Int?    @map("sender_previous")
-  receiverAccount        String? @map("receiver")
-  receiverCurrentAmount  Int?    @map("receiver_current")
-  receiverPreviousAmount Int?    @map("receiver_previous")
-  chainId                BigInt? @map("chainid")
+  amount                 Decimal?
+  senderAccount          String?  @map("sender")
+  senderCurrentAmount    Decimal? @map("sender_current")
+  senderPreviousAmount   Decimal? @map("sender_previous")
+  receiverAccount        String?  @map("receiver")
+  receiverCurrentAmount  Decimal? @map("receiver_current")
+  receiverPreviousAmount Decimal? @map("receiver_previous")
+  chainId                BigInt?  @map("chainid")
   height                 BigInt?
-  requestKey             String  @map("requestkey") @db.VarChar
-  orderIndex             BigInt  @map("idx")
-  blockHash              String  @map("block") @db.VarChar
-  eventId                Int?    @map("id")
+  requestKey             String   @map("requestkey") @db.VarChar
+  orderIndex             BigInt   @map("idx")
+  blockHash              String   @map("block") @db.VarChar
+  eventId                Int?     @map("id")
   version                String?
 
   @@id([blockHash, orderIndex, requestKey])

--- a/packages/apps/graph/src/services/token-service.ts
+++ b/packages/apps/graph/src/services/token-service.ts
@@ -67,7 +67,7 @@ export async function getTokenDetails(
 
       result.push({
         __typename: NonFungibleTokenBalanceName,
-        balance,
+        balance: Number(balance),
         accountName,
         tokenId: event.token,
         chainId: finalChainId,


### PR DESCRIPTION
In Marmalade, non fungible token balances can be decimal. Due to the view having these fields as integer. To correct this, I am adding a migration to drop the view and recreate it with a decimal column type

<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207100487482658