### PR TITLE
bugfix(hd-wallet): chainweaver sign did not use the right hash

### DIFF
--- a/.changeset/breezy-oranges-pump.md
+++ b/.changeset/breezy-oranges-pump.md
@@ -1,0 +1,5 @@
+---
+'@kadena/hd-wallet': minor
+---
+
+Fixed bug in chainweaver signing

--- a/packages/libs/hd-wallet/src/chainweaver/compatibility/kadenaSign.ts
+++ b/packages/libs/hd-wallet/src/chainweaver/compatibility/kadenaSign.ts
@@ -9,7 +9,7 @@ export const kadenaSign = async (
 ): Promise<Uint8Array> => {
   return await originalKadenaSign(
     password,
-    message,
+    Buffer.from(message, 'base64'),
     await kadenaDecrypt(password, secretKey),
   );
 };

--- a/packages/libs/hd-wallet/src/chainweaver/compatibility/kadenaSignFromRootKey.ts
+++ b/packages/libs/hd-wallet/src/chainweaver/compatibility/kadenaSignFromRootKey.ts
@@ -19,5 +19,5 @@ export async function kadenaSignFromRootKey(
 ): Promise<Uint8Array> {
   const { secretKey } = await kadenaGenKeypair(password, rootKey, index);
   const secret = await kadenaDecrypt(password, secretKey);
-  return kadenaSign(password, message, secret);
+  return kadenaSign(password, Buffer.from(message, 'base64'), secret);
 }

--- a/packages/libs/hd-wallet/src/chainweaver/tests/chainweaver.test.ts
+++ b/packages/libs/hd-wallet/src/chainweaver/tests/chainweaver.test.ts
@@ -6,6 +6,7 @@ import {
   kadenaGenKeypair,
   kadenaGenMnemonic,
   kadenaMnemonicToRootKeypair,
+  kadenaSign,
   kadenaSignFromRootKey,
 } from '../index.js';
 
@@ -135,7 +136,17 @@ describe('kadenaGenKeypair', () => {
 
     expect(signature).toBeTruthy();
     expect(Buffer.from(signature).toString('hex')).toBe(
-      '4a9a35634ca8b1efd0d84053bf73d78dda4e59223d230869ea7abbee8f923b723538f9a3ed13de31c8d629c97205a3becb15f5fdc71dc1dc4e42596b9a10d906',
+      'e3d3ffe85877a181487ef66acd4e2b5968fa4d055d81efcce812cfcee855d42547a962dc6a28a445f9da696ad2270b046b27a462d1f1ced6c7408b65a1a7fa0c',
+    );
+  });
+  it('should generate a valid signature with keypair', async () => {
+    const rootKey = await kadenaMnemonicToRootKeypair(PASSWORD, MNEMONIC);
+    const keypair = await kadenaGenKeypair(PASSWORD, rootKey, 1);
+    const signature = await kadenaSign(PASSWORD, 'hello', keypair.secretKey);
+
+    expect(signature).toBeTruthy();
+    expect(Buffer.from(signature).toString('hex')).toBe(
+      'e3d3ffe85877a181487ef66acd4e2b5968fa4d055d81efcce812cfcee855d42547a962dc6a28a445f9da696ad2270b046b27a462d1f1ced6c7408b65a1a7fa0c',
     );
   });
 });

--- a/packages/libs/hd-wallet/src/chainweaver/vendor/kadena-crypto.d.cts
+++ b/packages/libs/hd-wallet/src/chainweaver/vendor/kadena-crypto.d.cts
@@ -23,7 +23,7 @@ export declare const kadenaMnemonicToRootKeypair: (
 
 export declare const kadenaSign: (
   password: string | Uint8Array,
-  message: string,
+  message: Uint8Array,
   privateKey: string | Uint8Array,
 ) => Uint8Array;
 


### PR DESCRIPTION
<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->
* Chainweaver sign expects base64 decoded hash as a "message".