### PR TITLE
fix: react-ui dialog opacity

### DIFF
--- a/packages/apps/docs/src/components/SearchDialog/styles.css.ts
+++ b/packages/apps/docs/src/components/SearchDialog/styles.css.ts
@@ -5,7 +5,7 @@ export const dialogClass = style([
   responsiveStyle({
     xs: {
       height: '100svh',
-      width: '100vw',
+      width: '100vw !important',
     },
     md: {
       height: '75vh',

--- a/packages/libs/react-ui/src/components/Modal/Modal.css.ts
+++ b/packages/libs/react-ui/src/components/Modal/Modal.css.ts
@@ -8,9 +8,9 @@ export const underlayClass = style([
     justifyContent: 'center',
     position: 'fixed',
     inset: 0,
-    backgroundColor: 'base.default',
   }),
   {
-    backdropFilter: 'blur(12px)',
+    // TODO: Update to use token: please check docs search dialog to align
+    backgroundColor: 'rgba(34, 33, 33, 0.8)',
   },
 ]);


### PR DESCRIPTION
i guess with solid background-color and backdrop filter seems doesn't work. so, i just making it to fix for docs based on the background base default `#222121` version to rgba. Maybe we can revisit fixing it better. 

it's breaking the docs for now. so creating a PR as short term fix