### PR TITLE
Fix: Increase timeout for starting the graph server

### DIFF
--- a/packages/e2e/e2e-graph/playwright.config.ts
+++ b/packages/e2e/e2e-graph/playwright.config.ts
@@ -4,6 +4,7 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   ...baseConfig,
   webServer: {
+    timeout: 90000,
     command: `pnpm --filter @kadena/graph start:generate`,
     url: 'http://localhost:4000/graphql',
     reuseExistingServer: process.env.CI === undefined,


### PR DESCRIPTION
This PR bumps the timeout for the graph server slightly to give graph a bit more time to start up in CI
