### PR TITLE
fix(kadena-cli): add empty log message for networks + empty state level to warning

### DIFF
--- a/.changeset/five-pans-reply.md
+++ b/.changeset/five-pans-reply.md
@@ -1,0 +1,6 @@
+---
+"@kadena/kadena-cli": minor
+---
+
+Add empty state warning message for network list command
+All empty state log level to warning for consistency

--- a/packages/tools/kadena-cli/src/account/commands/accountList.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountList.ts
@@ -64,7 +64,7 @@ export const createAccountListCommand: (
     const isAccountAliasesExist = await ensureAccountAliasFilesExists();
 
     if (!isAccountAliasesExist) {
-      return log.error(NO_ACCOUNTS_FOUND_ERROR_MESSAGE);
+      return log.warning(NO_ACCOUNTS_FOUND_ERROR_MESSAGE);
     }
 
     const { accountAlias } = await option.accountAlias();

--- a/packages/tools/kadena-cli/src/keys/utils/keysDisplay.ts
+++ b/packages/tools/kadena-cli/src/keys/utils/keysDisplay.ts
@@ -13,9 +13,9 @@ export async function printPlainKeys(plainKeys: IPlainKey[]): Promise<void> {
   });
 
   if (plainKeys.length === 0) {
-    log.info('There are no key files in your working directory.');
-    log.info('You can add one using:\n');
-    log.info('  kadena key generate');
+    log.warning('There are no key files in your working directory.');
+    log.warning('You can add one using:\n');
+    log.warning('  kadena key generate');
     return;
   }
   for (const key of plainKeys) {

--- a/packages/tools/kadena-cli/src/networks/tests/networkList.test.ts
+++ b/packages/tools/kadena-cli/src/networks/tests/networkList.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { CWD_KADENA_DIR } from '../../constants/config.js';
+import { NO_NETWORKS_FOUND_ERROR_MESSAGE } from '../../constants/networks.js';
 import { services } from '../../services/index.js';
 import { runCommand, runCommandJson } from '../../utils/test.util.js';
 
@@ -10,8 +11,8 @@ describe('network list command', () => {
     }
   });
   it('should return empty networks list', async () => {
-    const res = await runCommandJson('network list');
-    expect(res.networks).toEqual([]);
+    const res = await runCommand('network list');
+    expect(res.stderr).toContain(NO_NETWORKS_FOUND_ERROR_MESSAGE);
   });
 
   it('should return networks list', async () => {

--- a/packages/tools/kadena-cli/src/networks/utils/networkDisplay.ts
+++ b/packages/tools/kadena-cli/src/networks/utils/networkDisplay.ts
@@ -1,4 +1,7 @@
-import { networkDefaults } from '../../constants/networks.js';
+import {
+  NO_NETWORKS_FOUND_ERROR_MESSAGE,
+  networkDefaults,
+} from '../../constants/networks.js';
 
 import { log } from '../../utils/logger.js';
 
@@ -36,6 +39,10 @@ export async function displayNetworksConfig(): Promise<void> {
 
   const defaultNetworkName = await getDefaultNetworkName();
   const existingNetworks: ICustomNetworkChoice[] = await getExistingNetworks();
+
+  if (existingNetworks.length === 0) {
+    return log.warning(NO_NETWORKS_FOUND_ERROR_MESSAGE);
+  }
 
   const networks = await Promise.all(
     existingNetworks.map(async (network) => {

--- a/packages/tools/kadena-cli/src/wallets/commands/walletList.ts
+++ b/packages/tools/kadena-cli/src/wallets/commands/walletList.ts
@@ -21,8 +21,8 @@ export const createListWalletsCommand: (
       return log.error(`Selected wallet not found.`);
     } else if (Array.isArray(config.walletNameConfig)) {
       if (config.walletNameConfig.length === 0) {
-        log.info('There are no wallets created. You can add one with:\n');
-        log.info('  kadena wallet add');
+        log.warning('There are no wallets created. You can add one with:\n');
+        log.warning('  kadena wallet add');
       }
       for (const wallet of config.walletNameConfig) {
         await printWalletKeys(wallet);


### PR DESCRIPTION


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207343169763162