### PR TITLE
fix(kadena-cli): add warning message for not deploying faucet + update test case descriptions

### DIFF
--- a/.changeset/polite-suns-dress.md
+++ b/.changeset/polite-suns-dress.md
@@ -1,0 +1,5 @@
+---
+"@kadena/kadena-cli": minor
+---
+
+Add warning log message when user selects "no" for deploying the faucet.

--- a/packages/tools/kadena-cli/src/account/commands/accountFund.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountFund.ts
@@ -97,7 +97,9 @@ export const createAccountFundCommand = createCommand(
         const { deployFaucet } = await option.deployFaucet();
 
         if (deployFaucet === false) {
-          return;
+          return log.warning(
+            `To fund your account on chain "${undeployedChainIdsStr}" in the "${networkConfig.network}" network, deploy the faucet using the --deploy-faucet option.`,
+          );
         }
 
         const loader = ora(

--- a/packages/tools/kadena-cli/src/account/tests/accountFund.test.ts
+++ b/packages/tools/kadena-cli/src/account/tests/accountFund.test.ts
@@ -174,7 +174,7 @@ describe('account fund', () => {
     mockCheckHealth.mockRestore();
   });
 
-  it('should exit and not fund when user select no for deploy faucet prompt', async () => {
+  it('should exit without funding when user select "no" for deploy faucet prompt', async () => {
     mockPrompts({
       select: {
         'Do you wish to deploy faucet module?': 'no',
@@ -197,6 +197,9 @@ describe('account fund', () => {
       'Faucet module unavailable on chain "1" in the "devnet" network.',
     );
     expect(mockdeployFaucetsToChains).not.toHaveBeenCalled();
+    expect(res.stderr).toContain(
+      'To fund your account on chain "1" in the "devnet" network, deploy the faucet using the --deploy-faucet option.',
+    );
     expect(res.stderr).not.toContain(
       'Account "accountName" funded with 5 coin(s) on Chain ID(s) "1" in development network.',
     );
@@ -205,7 +208,7 @@ describe('account fund', () => {
     mockdeployFaucetsToChains.mockRestore();
   });
 
-  it('should deploy faucets when user select yes to deploy faucet', async () => {
+  it('should deploy faucet and fund account when user select "yes" to deploy faucet', async () => {
     mockPrompts({
       select: {
         'Do you wish to deploy faucet module?': 'yes',


### PR DESCRIPTION
- Add warning log message when user selects "no" for deploying the faucet.
- Improve clarity of unit test descriptions.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207343169763167