### PR TITLE
fix(kadena-cli): Improved account list display formatting in account list command

### DIFF
--- a/.changeset/brown-toys-divide.md
+++ b/.changeset/brown-toys-divide.md
@@ -1,0 +1,5 @@
+---
+"@kadena/kadena-cli": minor
+---
+
+Updated table generation and json output format to improve account information display

--- a/packages/tools/kadena-cli/src/account/tests/accountList.test.ts
+++ b/packages/tools/kadena-cli/src/account/tests/accountList.test.ts
@@ -49,7 +49,7 @@ describe('account list', () => {
     );
   });
 
-  it('should display only selected account information', async () => {
+  it('should display information for the specified account only', async () => {
     mockPrompts({
       select: {
         'Select an account (alias - account name):': 'account-one',
@@ -58,41 +58,37 @@ describe('account list', () => {
 
     const res = await runCommandJson('account list');
     expect(res).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          alias: 'account-one.yaml',
-          fungible: 'coin',
-          name: 'k:55e10019549e047e68efaa18489ed785eca271642e2d0ce41d56ced2a30ccb84',
-          predicate: 'keys-all',
-          publicKeys: [
-            '55e10019549e047e68efaa18489ed785eca271642e2d0ce41d56ced2a30ccb84',
-          ],
-        }),
-      ]),
+      expect.objectContaining({
+        alias: 'account-one.yaml',
+        fungible: 'coin',
+        name: 'k:55e10019549e047e68efaa18489ed785eca271642e2d0ce41d56ced2a30ccb84',
+        predicate: 'keys-all',
+        publicKeys: [
+          '55e10019549e047e68efaa18489ed785eca271642e2d0ce41d56ced2a30ccb84',
+        ],
+      }),
     );
   });
 
-  it('should display only passed account information through cli', async () => {
+  it('should display only the specified account information via CL', async () => {
     const res = await runCommandJson(
-      'account list --account-alias=account-two',
+      'account list --account-alias=account-two --quiet',
     );
     expect(res).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          alias: 'account-two.yaml',
-          fungible: 'coin',
-          name: 'w:yCvUbeS6RqdKsY3WBDB3cgK-6q790xkj4Hb-ABpu3gg:keys-all',
-          predicate: 'keys-all',
-          publicKeys: [
-            '39710afef15243ba36007ae7aa210ab0e09682b2d963928be350e3424b5a420b',
-            '0f745a7773cbaffedcc7303b0638ffb34516aa3af98605f39dda3aeb730318c9',
-          ],
-        }),
-      ]),
+      expect.objectContaining({
+        alias: 'account-two.yaml',
+        fungible: 'coin',
+        name: 'w:yCvUbeS6RqdKsY3WBDB3cgK-6q790xkj4Hb-ABpu3gg:keys-all',
+        predicate: 'keys-all',
+        publicKeys: [
+          '39710afef15243ba36007ae7aa210ab0e09682b2d963928be350e3424b5a420b',
+          '0f745a7773cbaffedcc7303b0638ffb34516aa3af98605f39dda3aeb730318c9',
+        ],
+      }),
     );
   });
 
-  it('should return account alias not found when user passes any random account alias', async () => {
+  it('should return "account alias not found" when a random account alias is provided', async () => {
     const res = await runCommand(
       'account list --account-alias=some-random-account-alias',
     );

--- a/packages/tools/kadena-cli/src/account/tests/accountList.test.ts
+++ b/packages/tools/kadena-cli/src/account/tests/accountList.test.ts
@@ -70,7 +70,7 @@ describe('account list', () => {
     );
   });
 
-  it('should display only the specified account information via CL', async () => {
+  it('should display only the specified account information via CLI', async () => {
     const res = await runCommandJson(
       'account list --account-alias=account-two --quiet',
     );


### PR DESCRIPTION
### Account listing by all accounts table display 
<img width="1190" alt="image" src="https://github.com/kadena-community/kadena.js/assets/7163943/7783201f-be03-4ba4-a78a-023e72f6e1ce">

### account listing by all account with `--json` format
<img width="1144" alt="image" src="https://github.com/kadena-community/kadena.js/assets/7163943/40015517-ddfd-426b-a11e-72f195cd7663">

### Account listing by specific account with `--json` format
<img width="1154" alt="image" src="https://github.com/kadena-community/kadena.js/assets/7163943/7baee484-2b5f-4e66-ba7e-341f134ef31b">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207275180683040