### PR TITLE
feat(add-account): rename account type to from option and manual to key value

### DIFF
--- a/.changeset/thick-trees-dance.md
+++ b/.changeset/thick-trees-dance.md
@@ -1,0 +1,7 @@
+---
+"@kadena/kadena-cli": minor
+---
+
+- Renamed `--type` option to `--from` in the `account add` command.
+- Updated `--type=manual` to `--from=key` for specifying account addition via key file or manual entry.
+- Improved descriptions in account from selection prompts for better clarity on available options.

--- a/packages/tools/kadena-cli/src/account/accountAddOptions.ts
+++ b/packages/tools/kadena-cli/src/account/accountAddOptions.ts
@@ -2,7 +2,7 @@ import { globalOptions, securityOptions } from '../utils/globalOptions.js';
 import { accountOptions } from './accountOptions.js';
 
 export const options = [
-  accountOptions.accountTypeSelection({ isOptional: false }),
+  accountOptions.accountFromSelection({ isOptional: false }),
   // common options
   accountOptions.accountAlias(),
   accountOptions.fungible(),

--- a/packages/tools/kadena-cli/src/account/accountOptions.ts
+++ b/packages/tools/kadena-cli/src/account/accountOptions.ts
@@ -19,14 +19,14 @@ import {
 import { isEmpty } from './utils/addHelpers.js';
 
 export const accountOptions = {
-  accountTypeSelection: createOption({
-    key: 'type' as const,
+  accountFromSelection: createOption({
+    key: 'from' as const,
     defaultIsOptional: false,
-    prompt: account.accountTypeSelectionPrompt,
+    prompt: account.accountFromSelectionPrompt,
     validation: z.string(),
     option: new Option(
-      '-t, --type <type>',
-      'Specify the method to add account details: "manual or wallet"',
+      '-f, --from <from>',
+      'Specify the method to add account details: "key or wallet".',
     ),
   }),
   accountAlias: createOption({

--- a/packages/tools/kadena-cli/src/account/commands/accountAdd.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountAdd.ts
@@ -1,22 +1,22 @@
 import { createCommand } from '../../utils/createCommand.js';
 import { options } from '../accountAddOptions.js';
+import { addAccountFromKey } from './accountAddFromKey.js';
 import { addAccountFromWallet } from './accountAddFromWallet.js';
-import { addAccountManual } from './accountAddManual.js';
 
 export const createAddAccountCommand = createCommand(
   'add',
-  'Add an existing account locally to the CLI',
+  'Add an existing account locally to the CLI. Use --from=key to select a key file or enter key details manually. Use --from=wallet to select from available wallets.',
   options,
   async (option) => {
-    const typeSelection = (await option.type()).type;
+    const accountFromSelection = (await option.from()).from;
 
-    if (typeSelection === 'manual') {
-      return addAccountManual(option);
-    } else if (typeSelection === 'wallet') {
+    if (accountFromSelection === 'key') {
+      return addAccountFromKey(option);
+    } else if (accountFromSelection === 'wallet') {
       return addAccountFromWallet(option);
     } else {
       throw new Error(
-        `Invalid account type : ${typeSelection}. Supported types are 'manual' and 'wallet'`,
+        `Invalid account type : ${accountFromSelection}. Supported types are 'key' and 'wallet'`,
       );
     }
   },

--- a/packages/tools/kadena-cli/src/account/commands/accountAdd.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountAdd.ts
@@ -16,7 +16,7 @@ export const createAddAccountCommand = createCommand(
       return addAccountFromWallet(option);
     } else {
       throw new Error(
-        `Invalid account type : ${accountFromSelection}. Supported types are 'key' and 'wallet'`,
+        `Invalid account from value: ${accountFromSelection}. Supported values are "key" and "wallet".`,
       );
     }
   },

--- a/packages/tools/kadena-cli/src/account/commands/accountAddFromKey.ts
+++ b/packages/tools/kadena-cli/src/account/commands/accountAddFromKey.ts
@@ -13,7 +13,7 @@ import { displayAddAccountSuccess } from '../utils/addHelpers.js';
 import { createAccountName } from '../utils/createAccountName.js';
 import { getAccountDetails } from '../utils/getAccountDetails.js';
 
-export const addAccountManual = async (
+export const addAccountFromKey = async (
   option: CommandOption<typeof options>,
 ): Promise<void> => {
   const accountAlias = (await option.accountAlias()).accountAlias;

--- a/packages/tools/kadena-cli/src/account/tests/accountAdd.test.ts
+++ b/packages/tools/kadena-cli/src/account/tests/accountAdd.test.ts
@@ -12,10 +12,7 @@ describe('account add manual type', () => {
   const root = path.join(__dirname, '../../../');
   const configPath = path.join(root, '.kadena');
   const accountPath = path.join(configPath, ACCOUNT_DIR);
-  const accountAliasFile = path.join(
-    accountPath,
-    'account-add-test-manual.yaml',
-  );
+  const accountAliasFile = path.join(accountPath, 'account-add-test.yaml');
   beforeEach(async () => {
     if (await services.filesystem.fileExists(accountAliasFile)) {
       await services.filesystem.deleteFile(accountAliasFile);
@@ -29,12 +26,12 @@ describe('account add manual type', () => {
   it('should add an account alias using manual type without on chain verification', async () => {
     mockPrompts({
       select: {
-        'How would you like to add the account locally?': 'manual',
+        'How would you like to add the account locally?': 'key',
         'Select a keyset predicate:': 'keys-all',
         'Do you want to verify the account on chain?': false,
       },
       input: {
-        'Enter an alias for an account:': 'account-add-test-manual',
+        'Enter an alias for an account:': 'account-add-test',
         'Enter an account name (optional):': 'k:pubkey1',
         'Enter the name of a fungible:': 'coin',
         'Enter one or more public keys (comma separated):': 'pubkey1,pubkey2',
@@ -51,12 +48,12 @@ describe('account add manual type', () => {
   it('should add an account alias using manual type with on chain verification', async () => {
     mockPrompts({
       select: {
-        'How would you like to add the account locally?': 'manual',
+        'How would you like to add the account locally?': 'key',
         'Do you want to verify the account on chain?': true,
         'Select a network:': 'testnet',
       },
       input: {
-        'Enter an alias for an account:': 'account-add-test-manual-chain',
+        'Enter an alias for an account:': 'account-add-test-chain',
         'Enter an account name (optional):': 'k:pubkey1',
         'Enter the name of a fungible:': 'coin',
         'Enter ChainId (0-19):': '1',
@@ -64,10 +61,7 @@ describe('account add manual type', () => {
     });
 
     await runCommand('account add');
-    const aliasFile = path.join(
-      accountPath,
-      'account-add-test-manual-chain.yaml',
-    );
+    const aliasFile = path.join(accountPath, 'account-add-test-chain.yaml');
     expect(await services.filesystem.fileExists(aliasFile)).toBe(true);
     const content = await services.filesystem.readFile(aliasFile);
     expect(jsYaml.load(content!)).toEqual({
@@ -89,12 +83,12 @@ describe('account add manual type', () => {
     );
     mockPrompts({
       select: {
-        'How would you like to add the account locally?': 'manual',
+        'How would you like to add the account locally?': 'key',
         'Select a keyset predicate:': 'keys-all',
         'Do you want to verify the account on chain?': false,
       },
       input: {
-        'Enter an alias for an account:': 'account-add-test-manual',
+        'Enter an alias for an account:': 'account-add-test',
         'Enter an account name (optional):': '',
         'Enter the name of a fungible:': 'coin',
         'Enter one or more public keys (comma separated):': 'pubkey1,pubkey2',
@@ -117,7 +111,7 @@ describe('account add manual type', () => {
 
   it('should add an account alias manual with quiet flag', async () => {
     await runCommand(
-      'account add --type=manual --account-alias=account-add-test-manual --account-name=k:pubkey1 --fungible=coin --verify --network=testnet --chain-id=1',
+      'account add --from=key --account-alias=account-add-test --account-name=k:pubkey1 --fungible=coin --verify --network=testnet --chain-id=1',
     );
     expect(await services.filesystem.fileExists(accountAliasFile)).toBe(true);
     const content = await services.filesystem.readFile(accountAliasFile);
@@ -135,10 +129,7 @@ describe('account add type wallet', () => {
   const configPath = path.join(root, '.kadena');
   const accountPath = path.join(configPath, ACCOUNT_DIR);
   const walletFilePath = path.join(configPath, WALLET_DIR, 'test-wallet.yaml');
-  const accountAliasFile = path.join(
-    accountPath,
-    'account-add-test-manual.yaml',
-  );
+  const accountAliasFile = path.join(accountPath, 'account-add-test.yaml');
   let publicKey: string;
   let generatedKey: string;
   beforeEach(async () => {
@@ -195,7 +186,7 @@ describe('account add type wallet', () => {
         'Select a keyset predicate:': 'keys-all',
       },
       input: {
-        'Enter an alias for an account:': 'account-add-test-manual',
+        'Enter an alias for an account:': 'account-add-test',
         'Enter the name of a fungible:': 'coin',
       },
       checkbox: {
@@ -230,7 +221,7 @@ describe('account add type wallet', () => {
         'Select a keyset predicate:': 'keys-all',
       },
       input: {
-        'Enter an alias for an account:': 'account-add-test-manual',
+        'Enter an alias for an account:': 'account-add-test',
         'Enter the name of a fungible:': 'coin',
       },
       checkbox: {

--- a/packages/tools/kadena-cli/src/account/tests/accountAdd.test.ts
+++ b/packages/tools/kadena-cli/src/account/tests/accountAdd.test.ts
@@ -122,6 +122,16 @@ describe('account add manual type', () => {
       predicate: 'keys-all',
     });
   });
+
+  it('should throw an error when user tries to add an account with unsupported "from" value', async () => {
+    const res = await runCommand(
+      'account add --from=test --account-alias=account-add-test --account-name=k:pubkey1 --fungible=coin --verify --network=testnet --chain-id=1',
+    );
+    expect(res.stderr).toContain(
+      'Invalid account from value: test. Supported values are "key" and "wallet".',
+    );
+    expect(await services.filesystem.fileExists(accountAliasFile)).toBe(false);
+  });
 });
 
 describe('account add type wallet', () => {

--- a/packages/tools/kadena-cli/src/account/tests/accountDelete.test.ts
+++ b/packages/tools/kadena-cli/src/account/tests/accountDelete.test.ts
@@ -18,7 +18,7 @@ describe('account delete', () => {
   beforeEach(async () => {
     // Add account alias file
     await runCommand(
-      'account add --type=manual --account-alias=account-add-test-manual --account-name=accountName --fungible=coin --network=testnet --chain-id=1 --public-keys=publicKey1 --quiet',
+      'account add --from=key --account-alias=account-add-test-manual --account-name=accountName --fungible=coin --network=testnet --chain-id=1 --public-keys=publicKey1 --quiet',
     );
 
     await services.filesystem.fileExists(accountAliasFile);
@@ -77,7 +77,7 @@ describe('account delete', () => {
     // Add one more account alias
     // Add account alias file
     await runCommand(
-      'account add --type=manual --account-alias=another-account-alias --account-name=accountName --fungible=coin --network=testnet --chain-id=1 --public-keys=publicKey1 --quiet',
+      'account add --from=key --account-alias=another-account-alias --account-name=accountName --fungible=coin --network=testnet --chain-id=1 --public-keys=publicKey1 --quiet',
     );
     mockPrompts({
       select: {

--- a/packages/tools/kadena-cli/src/account/tests/accountDetails.test.ts
+++ b/packages/tools/kadena-cli/src/account/tests/accountDetails.test.ts
@@ -27,7 +27,7 @@ describe('account details', () => {
   it('should fetch account details based on the account alias file', async () => {
     // Pre add the account alias file to make sure account alias exists
     await runCommand(
-      'account add --type=manual --account-alias=account-add-test-manual --account-name=accountName --fungible=coin --network=testnet --chain-id=1 --public-keys=publicKey1 --quiet',
+      'account add --from=key --account-alias=account-add-test-manual --account-name=accountName --fungible=coin --network=testnet --chain-id=1 --public-keys=publicKey1 --quiet',
     );
 
     mockPrompts({

--- a/packages/tools/kadena-cli/src/account/tests/accountFund.test.ts
+++ b/packages/tools/kadena-cli/src/account/tests/accountFund.test.ts
@@ -13,7 +13,7 @@ describe('account fund', () => {
   beforeEach(async () => {
     // Pre add the account alias file to make sure account alias exists
     await runCommand(
-      'account add --type=manual --account-alias=account-add-test-manual --account-name=accountName --fungible=coin --network=testnet --chain-id=1 --public-keys=publicKey1 --quiet',
+      'account add --from=key --account-alias=account-add-test-manual --account-name=accountName --fungible=coin --network=testnet --chain-id=1 --public-keys=publicKey1 --quiet',
     );
   });
 
@@ -140,7 +140,7 @@ describe('account fund', () => {
 
   it('should not fund an account when user tries to fund other than coin fungible with quiet flag', async () => {
     await runCommand(
-      'account add --type=manual --account-alias=kdx-account --account-name=accountName --fungible=kdx --network=testnet --chain-id=1 --public-keys=publicKey1 --quiet',
+      'account add --from=key --account-alias=kdx-account --account-name=accountName --fungible=kdx --network=testnet --chain-id=1 --public-keys=publicKey1 --quiet',
     );
     const res = await runCommand(
       'account fund --account=kdx-account --amount=1 --network=testnet --chain-ids=1',

--- a/packages/tools/kadena-cli/src/account/tests/accountList.test.ts
+++ b/packages/tools/kadena-cli/src/account/tests/accountList.test.ts
@@ -9,10 +9,10 @@ describe('account list', () => {
   beforeEach(async () => {
     // Pre add the account alias file to make sure account alias exists
     await runCommand(
-      'account add --type=manual --account-alias=account-one --account-name=k:55e10019549e047e68efaa18489ed785eca271642e2d0ce41d56ced2a30ccb84 --fungible=coin --network=testnet --chain-id=1 --public-keys=55e10019549e047e68efaa18489ed785eca271642e2d0ce41d56ced2a30ccb84 --quiet',
+      'account add --from=key --account-alias=account-one --account-name=k:55e10019549e047e68efaa18489ed785eca271642e2d0ce41d56ced2a30ccb84 --fungible=coin --network=testnet --chain-id=1 --public-keys=55e10019549e047e68efaa18489ed785eca271642e2d0ce41d56ced2a30ccb84 --quiet',
     );
     await runCommand(
-      'account add --type=manual --account-alias=account-two --account-name=w:yCvUbeS6RqdKsY3WBDB3cgK-6q790xkj4Hb-ABpu3gg:keys-all --fungible=coin --network=testnet --chain-id=1 --public-keys=39710afef15243ba36007ae7aa210ab0e09682b2d963928be350e3424b5a420b,0f745a7773cbaffedcc7303b0638ffb34516aa3af98605f39dda3aeb730318c9 --quiet',
+      'account add --from=key --account-alias=account-two --account-name=w:yCvUbeS6RqdKsY3WBDB3cgK-6q790xkj4Hb-ABpu3gg:keys-all --fungible=coin --network=testnet --chain-id=1 --public-keys=39710afef15243ba36007ae7aa210ab0e09682b2d963928be350e3424b5a420b,0f745a7773cbaffedcc7303b0638ffb34516aa3af98605f39dda3aeb730318c9 --quiet',
     );
   });
 

--- a/packages/tools/kadena-cli/src/prompts/account.ts
+++ b/packages/tools/kadena-cli/src/prompts/account.ts
@@ -385,7 +385,7 @@ export const publicKeysForAccountAddPrompt: IPrompt<string> = async (
   args,
   isOptional,
 ) => {
-  if (previousQuestions.type === 'manual') {
+  if (previousQuestions.from === 'key') {
     return addManualPublicKeysPrompt(previousQuestions, args, isOptional);
   }
 
@@ -429,17 +429,17 @@ export const publicKeysForAccountAddPrompt: IPrompt<string> = async (
   return selectedKeys.join(',');
 };
 
-export const accountTypeSelectionPrompt: IPrompt<string> = async () => {
+export const accountFromSelectionPrompt: IPrompt<string> = async () => {
   return await select({
     message: `How would you like to add the account locally?`,
     choices: [
       {
-        value: 'manual',
-        name: 'Manually - Provide public keys to add to account manually',
+        value: 'key',
+        name: 'Key - Add an account by by providing public keys from a key file or entering key details manually',
       },
       {
         value: 'wallet',
-        name: 'Wallet - Provide public keys to add to account by selecting from a wallet',
+        name: 'Wallet - Add an account by by providing public keys from a list of available wallets',
       },
     ],
   });


### PR DESCRIPTION
- Renamed `--type` option to `--from` in the `account add` command.
- Updated `--type=manual` to `--from=key` for specifying account addition via key file or manual entry.
- Improved descriptions in account from selection prompts for better clarity on available options.

<!--
Thanks for contributing to this project!

- Explain why and how for this pull request
- Link to the related issue (if any)
- Add use cases, scenarios, images and screenshots
- Add documentation and tutorials
- Run `pnpm install` and `pnpm test`
- In short: help us help you to get this through!
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207307903477051