### PR TITLE
feat(tx-logs): implement save transactions logs to a file + tx history command to view the logs 

### DIFF
--- a/.changeset/chatty-laws-mate.md
+++ b/.changeset/chatty-laws-mate.md
@@ -4,4 +4,4 @@
 
 - Updated "tx send" command to include transaction logging functionality. Transactions are now saved in a log file, capturing network details, transaction ID, and status.
 
-- Implemented the tx history command to display a formatted transaction history. This command provides a user-friendly way to view detailed transaction logs, including hash, network, network ID, chain ID, status, gas, and transaction ID.
+- Implemented the tx history command to display a formatted transaction history. This command provides a user-friendly way to view detailed transaction logs, including network host, network ID, chain ID, status, and transaction ID.

--- a/.changeset/chatty-laws-mate.md
+++ b/.changeset/chatty-laws-mate.md
@@ -1,0 +1,7 @@
+---
+"@kadena/kadena-cli": minor
+---
+
+- Updated "tx send" command to include transaction logging functionality. Transactions are now saved in a log file, capturing network details, transaction ID, and status.
+
+- Implemented the tx history command to display a formatted transaction history. This command provides a user-friendly way to view detailed transaction logs, including hash, network, network ID, chain ID, status, gas, and transaction ID.

--- a/packages/tools/kadena-cli/src/constants/config.ts
+++ b/packages/tools/kadena-cli/src/constants/config.ts
@@ -28,6 +28,10 @@ export const ACCOUNT_DIR = 'accounts';
 // Default settings path
 export const DEFAULT_SETTINGS_PATH = 'defaults';
 
+// transaction path
+export const TRANSACTIONS_PATH = 'transactions';
+export const TRANSACTIONS_LOG_FILE = 'transactions-log.yaml';
+
 // key extensions
 export const WALLET_EXT = '.wallet';
 export const WALLET_LEGACY_EXT = '.legacy.wallet';

--- a/packages/tools/kadena-cli/src/tx/commands/txHistory.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txHistory.ts
@@ -109,7 +109,10 @@ export const txHistory = async (): Promise<void> => {
       TRANSACTIONS_LOG_FILE,
     );
     let transactionLog = await readTransactionLog(transactionFilePath);
-    if (!transactionLog) throw new Error('No transaction logs available.');
+    if (!transactionLog)
+      throw new Error(
+        'No transaction logs are available. Please ensure that transaction logs are present and try again.',
+      );
 
     const filteredLogs = filterLogsWithoutStatus(transactionLog);
 
@@ -124,7 +127,7 @@ export const txHistory = async (): Promise<void> => {
 
     printTxLogs(transactionLog);
   } catch (error) {
-    log.error(`Failed to read transaction history: ${error.message}`);
+    log.error(`Unable to read transaction history: ${error.message}`);
   }
 };
 

--- a/packages/tools/kadena-cli/src/tx/commands/txHistory.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txHistory.ts
@@ -1,0 +1,67 @@
+import type { Command } from 'commander';
+import path from 'node:path';
+import { TRANSACTIONS_LOG_FILE } from '../../constants/config.js';
+import { KadenaError } from '../../services/service-error.js';
+import { createCommand } from '../../utils/createCommand.js';
+import { notEmpty } from '../../utils/globalHelpers.js';
+import { globalOptions } from '../../utils/globalOptions.js';
+import { log } from '../../utils/logger.js';
+import { createTable } from '../../utils/table.js';
+import {
+  getTransactionDirectory,
+  readTransactionLog,
+} from '../utils/txHelpers.js';
+
+const header: Record<string, string> = {
+  hash: 'Hash',
+  network: 'Network',
+  networkId: 'Network ID',
+  chainId: 'Chain ID',
+  status: 'Status',
+  gas: 'Gas',
+  txId: 'Transaction ID',
+  logs: 'Logs',
+};
+
+export const txHistory = async (): Promise<void> => {
+  try {
+    const transactionDir = getTransactionDirectory();
+    if (!notEmpty(transactionDir)) throw new KadenaError('no_kadena_directory');
+
+    const transactionFilePath = path.join(
+      transactionDir,
+      TRANSACTIONS_LOG_FILE,
+    );
+    const transactionLog = await readTransactionLog(transactionFilePath);
+    if (!transactionLog) throw new Error('no_transaction_data');
+
+    const table = createTable({});
+    Object.entries(transactionLog).forEach(([requestKey, data]) => {
+      table.push([{ colSpan: 2, content: `Request Key: ${requestKey}` }]);
+      Object.entries(data).forEach(([key, value]) => {
+        const headerKey = header[key] || key;
+        table.push({
+          [log.color.green(headerKey)]: value?.toString() ?? 'N/A',
+        });
+      });
+      table.push([{ colSpan: 2, content: '' }]);
+    });
+
+    log.output(table.toString(), transactionLog);
+  } catch (error) {
+    log.error(`Failed to read transaction history: ${error.message}`);
+  }
+};
+
+export const createTxHistoryCommand: (
+  program: Command,
+  version: string,
+) => void = createCommand(
+  'history',
+  'Output a formatted list of transactions with their details, making it easy for users to understand their transaction history.',
+  [globalOptions.directory({ disableQuestion: true })],
+  async () => {
+    log.debug('tx-history:action');
+    await txHistory();
+  },
+);

--- a/packages/tools/kadena-cli/src/tx/commands/txHistory.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txHistory.ts
@@ -23,7 +23,7 @@ const header: Record<string, string> = {
   logs: 'Logs',
 };
 
-export const txHistory = async (): Promise<void> => {
+export const printTxHistory = async (): Promise<void> => {
   try {
     const transactionDir = getTransactionDirectory();
     if (!notEmpty(transactionDir)) throw new KadenaError('no_kadena_directory');
@@ -62,6 +62,6 @@ export const createTxHistoryCommand: (
   [globalOptions.directory({ disableQuestion: true })],
   async () => {
     log.debug('tx-history:action');
-    await txHistory();
+    await printTxHistory();
   },
 );

--- a/packages/tools/kadena-cli/src/tx/commands/txHistory.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txHistory.ts
@@ -1,3 +1,4 @@
+import { createClient } from '@kadena/client';
 import type { Command } from 'commander';
 import path from 'node:path';
 import { TRANSACTIONS_LOG_FILE } from '../../constants/config.js';
@@ -7,9 +8,17 @@ import { notEmpty } from '../../utils/globalHelpers.js';
 import { globalOptions } from '../../utils/globalOptions.js';
 import { log } from '../../utils/logger.js';
 import { createTable } from '../../utils/table.js';
+import type {
+  ITransactionLog,
+  ITransactionLogEntry,
+  IUpdateTransactionsLogPayload,
+} from '../utils/txHelpers.js';
 import {
+  generateClientUrl,
   getTransactionDirectory,
+  mergePayloadsWithTransactionLog,
   readTransactionLog,
+  updateTransactionStatus,
 } from '../utils/txHelpers.js';
 
 const header: Record<string, string> = {
@@ -23,6 +32,76 @@ const header: Record<string, string> = {
   logs: 'Logs',
 };
 
+const filterLogsWithoutSuccess = (log: ITransactionLog): ITransactionLog[] => {
+  return Object.entries(log)
+    .filter(([, logData]) => logData.status !== 'success')
+    .map(([key, value]) => ({ [key]: value }));
+};
+
+const getTransactionStatus = async (
+  requestKey: string,
+  value: ITransactionLogEntry,
+): Promise<IUpdateTransactionsLogPayload | undefined> => {
+  const { getStatus } = createClient(
+    generateClientUrl({
+      networkId: value.networkId,
+      chainId: value.chainId,
+      networkHost: value.networkHost,
+    }),
+  );
+
+  try {
+    const result = await getStatus({
+      requestKey,
+      chainId: value.chainId,
+      networkId: value.networkId,
+    });
+
+    if (result[requestKey] !== undefined) {
+      return {
+        requestKey,
+        status: result[requestKey].result.status,
+        data: result[requestKey],
+      };
+    }
+  } catch (e) {
+    log.error(
+      `Failed to get transaction status for requestKey "${requestKey}": ${e.message}`,
+    );
+  }
+};
+
+const fetchTransactionStatuses = async (
+  logs: ITransactionLog[],
+): Promise<IUpdateTransactionsLogPayload[]> => {
+  return await Promise.all(
+    logs.map(async (logData) => {
+      for (const [requestKey, value] of Object.entries(logData)) {
+        const status = await getTransactionStatus(requestKey, value);
+        if (status) {
+          return status;
+        }
+      }
+    }),
+  ).then((results) => results.filter(notEmpty));
+};
+
+export const printTxLogs = (transactionLog: ITransactionLog): void => {
+  const table = createTable({});
+  Object.entries(transactionLog).forEach(([requestKey, data]) => {
+    table.push([{ colSpan: 2, content: `Request Key: ${requestKey}` }]);
+    Object.entries(data).forEach(([key, value]) => {
+      const headerKey = header[key] || key;
+      table.push({
+        [log.color.green(headerKey)]: value?.toString() ?? 'N/A',
+      });
+    });
+    table.push([{ colSpan: 2, content: '' }]);
+  });
+
+  log.output(table.toString(), transactionLog);
+};
+
 export const printTxHistory = async (): Promise<void> => {
   try {
     const transactionDir = getTransactionDirectory();
@@ -32,22 +111,21 @@ export const printTxHistory = async (): Promise<void> => {
       transactionDir,
       TRANSACTIONS_LOG_FILE,
     );
-    const transactionLog = await readTransactionLog(transactionFilePath);
+    let transactionLog = await readTransactionLog(transactionFilePath);
     if (!transactionLog) throw new Error('no_transaction_data');
 
-    const table = createTable({});
-    Object.entries(transactionLog).forEach(([requestKey, data]) => {
-      table.push([{ colSpan: 2, content: `Request Key: ${requestKey}` }]);
-      Object.entries(data).forEach(([key, value]) => {
-        const headerKey = header[key] || key;
-        table.push({
-          [log.color.green(headerKey)]: value?.toString() ?? 'N/A',
-        });
-      });
-      table.push([{ colSpan: 2, content: '' }]);
-    });
+    const filteredLogs = filterLogsWithoutSuccess(transactionLog);
 
-    log.output(table.toString(), transactionLog);
+    if (filteredLogs.length > 0) {
+      const updatedLogs = await fetchTransactionStatuses(filteredLogs);
+      await updateTransactionStatus(updatedLogs);
+      transactionLog = mergePayloadsWithTransactionLog(
+        transactionLog,
+        updatedLogs,
+      );
+    }
+
+    printTxLogs(transactionLog);
   } catch (error) {
     log.error(`Failed to read transaction history: ${error.message}`);
   }

--- a/packages/tools/kadena-cli/src/tx/commands/txLocal.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txLocal.ts
@@ -73,7 +73,6 @@ export const createTxLocalCommand: (program: Command, version: string) => void =
         generateClientUrl({
           chainId: templateChainId,
           ...network,
-          networkExplorerUrl: network.networkExplorerUrl ?? '',
         }),
       );
 

--- a/packages/tools/kadena-cli/src/tx/commands/txSend.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txSend.ts
@@ -20,12 +20,18 @@ import { log } from '../../utils/logger.js';
 import { txOptions } from '../txOptions.js';
 import { parseTransactionsFromStdin } from '../utils/input.js';
 import { displayTransactionResponse } from '../utils/txDisplayHelper.js';
-import type { INetworkDetails, ISubmitResponse } from '../utils/txHelpers.js';
+import type {
+  INetworkDetails,
+  ISubmitResponse,
+  IUpdateTransactionsLogPayload,
+} from '../utils/txHelpers.js';
 import {
   createTransactionWithDetails,
   getClient,
   getTransactionsFromFile,
   logTransactionDetails,
+  saveTransactionsToFile,
+  updateTransactionStatus,
 } from '../utils/txHelpers.js';
 
 const clientInstances: Map<string, IClient> = new Map();
@@ -66,19 +72,28 @@ export async function pollRequests(
 
   const results = await Promise.allSettled(pollingPromises);
 
+  const txLogsData: IUpdateTransactionsLogPayload[] = [];
   results.forEach((result) => {
     if (result.status === 'fulfilled') {
       const value = result.value;
       const { requestKey, status } = value;
-
       if (status === 'success' && 'data' in value) {
         log.info(`Polling success for requestKey: ${requestKey}`);
         displayTransactionResponse(value.data[requestKey], 2);
+        txLogsData.push({
+          requestKey,
+          status,
+          data: value.data[requestKey],
+        });
       } else if (status === 'error' && 'error' in value) {
         log.error(
           `Polling error for requestKey: ${requestKey}, error:`,
           value.error,
         );
+        txLogsData.push({
+          requestKey,
+          status: 'failure',
+        });
       } else if ('message' in value) {
         log.info(
           `Polling message for requestKey: ${requestKey}: ${value.message}`,
@@ -88,6 +103,7 @@ export async function pollRequests(
       log.error(`Polling failed for a request, error:`, result.reason);
     }
   });
+  await updateTransactionStatus(txLogsData);
 }
 
 export const sendTransactionAction = async ({
@@ -194,6 +210,7 @@ export const createSendTransactionCommand: (
             )
             .join('\n\n'),
         );
+        await saveTransactionsToFile(result.data.transactions);
       }
 
       const txPoll = await option.poll();

--- a/packages/tools/kadena-cli/src/tx/commands/txStatus.ts
+++ b/packages/tools/kadena-cli/src/tx/commands/txStatus.ts
@@ -11,6 +11,7 @@ import { globalOptions } from '../../utils/globalOptions.js';
 import { log } from '../../utils/logger.js';
 import { createTable } from '../../utils/table.js';
 import { txOptions } from '../txOptions.js';
+import { updateTransactionStatus } from '../utils/txHelpers.js';
 
 export const getTxStatus = async ({
   requestKey,
@@ -55,6 +56,15 @@ export const getTxStatus = async ({
         ],
       };
     }
+
+    // To update the log file with the transaction status when requestKey is found
+    await updateTransactionStatus([
+      {
+        requestKey,
+        status: result[trimmedRequestKey].result.status,
+        data: result[trimmedRequestKey],
+      },
+    ]);
 
     return {
       status: 'success',

--- a/packages/tools/kadena-cli/src/tx/index.ts
+++ b/packages/tools/kadena-cli/src/tx/index.ts
@@ -1,4 +1,5 @@
 import { createTransactionCommandNew } from './commands/txCreateTransaction.js';
+import { createTxHistoryCommand } from './commands/txHistory.js';
 import { createTxListCommand } from './commands/txList.js';
 import { createTxLocalCommand } from './commands/txLocal.js';
 import { createSendTransactionCommand } from './commands/txSend.js';
@@ -22,4 +23,5 @@ export function txCommandFactory(program: Command, version: string): void {
   createTxStatusCommand(txProgram, version);
   createTxListCommand(txProgram, version);
   createTxLocalCommand(txProgram, version);
+  createTxHistoryCommand(txProgram, version);
 }

--- a/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
+++ b/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
@@ -900,7 +900,8 @@ export const updateTransactionStatus = async (
       TRANSACTIONS_LOG_FILE,
     );
     const currentTransactionLog = await readTransactionLog(transactionFilePath);
-    if (!currentTransactionLog) throw new Error('no_transaction_data');
+    if (!currentTransactionLog)
+      throw new Error('No transaction logs available.');
 
     const updatedTransactionLog = mergePayloadsWithTransactionLog(
       currentTransactionLog,

--- a/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
+++ b/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
@@ -803,9 +803,7 @@ export interface IUpdateTransactionsLogPayload {
 interface ITransactionLogDetails
   extends Partial<Pick<ICommandResult, 'txId' | 'logs' | 'gas'>> {
   chainId: ChainId;
-  network: string;
   networkId: string;
-  hash: string;
   status?: 'success' | 'failure';
 }
 
@@ -849,20 +847,12 @@ export const saveTransactionsToFile = async (
     const transactionLog =
       (await readTransactionLog(transactionFilePath)) || {};
 
-    transactions.forEach(
-      ({
-        transaction,
-        requestKey,
-        details: { networkId, network, chainId },
-      }) => {
-        transactionLog[requestKey] = {
-          hash: transaction.hash,
-          networkId,
-          network,
-          chainId,
-        };
-      },
-    );
+    transactions.forEach(({ requestKey, details: { networkId, chainId } }) => {
+      transactionLog[requestKey] = {
+        networkId,
+        chainId,
+      };
+    });
 
     await writeTransactionLog(transactionFilePath, transactionLog);
   } catch (error) {
@@ -889,9 +879,7 @@ export const updateTransactionStatus = async (
         transactionLog[requestKey] = {
           ...transactionLog[requestKey],
           status,
-          gas: data.gas,
           txId: notEmpty(data.txId) ? data.txId : null,
-          logs: notEmpty(data.logs) ? data.logs : null,
         };
       } else {
         log.error(`No transaction found for request key: ${requestKey}`);

--- a/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
+++ b/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
@@ -26,18 +26,24 @@ import type {
   INetworkCreateOptions,
 } from '../../networks/utils/networkHelpers.js';
 
+import jsYaml from 'js-yaml';
 import path, { isAbsolute, join } from 'node:path';
 import { z } from 'zod';
-import { TX_TEMPLATE_FOLDER } from '../../constants/config.js';
+import {
+  TRANSACTIONS_LOG_FILE,
+  TRANSACTIONS_PATH,
+  TX_TEMPLATE_FOLDER,
+} from '../../constants/config.js';
 import { ICommandSchema } from '../../prompts/tx.js';
 import { services } from '../../services/index.js';
+import { KadenaError } from '../../services/service-error.js';
 import type {
   IWallet,
   IWalletKey,
   IWalletKeyPair,
 } from '../../services/wallet/wallet.types.js';
 import type { CommandResult } from '../../utils/command.util.js';
-import { notEmpty } from '../../utils/globalHelpers.js';
+import { isNotEmptyObject, notEmpty } from '../../utils/globalHelpers.js';
 import { log } from '../../utils/logger.js';
 import { createTable } from '../../utils/table.js';
 import type { ISavedTransaction } from './storage.js';
@@ -779,4 +785,121 @@ export const createTransactionWithDetails = async (
     }
   }
   return transactionsWithDetails;
+};
+
+export const getTransactionDirectory = (): string | null => {
+  const kadenaDirectory = services.config.getDirectory();
+  return notEmpty(kadenaDirectory)
+    ? path.join(kadenaDirectory, TRANSACTIONS_PATH)
+    : null;
+};
+
+export interface IUpdateTransactionsLogPayload {
+  requestKey: string;
+  status: 'success' | 'failure';
+  data?: Partial<ICommandResult>;
+}
+
+interface ITransactionLogDetails
+  extends Partial<Pick<ICommandResult, 'txId' | 'logs' | 'gas'>> {
+  chainId: ChainId;
+  network: string;
+  networkId: string;
+  hash: string;
+  status?: 'success' | 'failure';
+}
+
+interface ITransactionLog {
+  [key: string]: ITransactionLogDetails;
+}
+
+export const readTransactionLog = async (
+  filePath: string,
+): Promise<ITransactionLog | null> => {
+  const fileContent = await services.filesystem.readFile(filePath);
+  return notEmpty(fileContent)
+    ? (jsYaml.load(fileContent) as ITransactionLog)
+    : null;
+};
+
+const writeTransactionLog = async (
+  filePath: string,
+  data: ITransactionLog,
+): Promise<void> => {
+  try {
+    await services.filesystem.writeFile(filePath, jsYaml.dump(data));
+  } catch (error) {
+    log.error(`Failed to write transaction log: ${error.message}`);
+  }
+};
+
+export const saveTransactionsToFile = async (
+  transactions: ISubmitResponse[],
+): Promise<void> => {
+  try {
+    const transactionDir = getTransactionDirectory();
+    if (!notEmpty(transactionDir)) throw new KadenaError('no_kadena_directory');
+
+    await services.filesystem.ensureDirectoryExists(transactionDir);
+    const transactionFilePath = path.join(
+      transactionDir,
+      TRANSACTIONS_LOG_FILE,
+    );
+
+    const transactionLog =
+      (await readTransactionLog(transactionFilePath)) || {};
+
+    transactions.forEach(
+      ({
+        transaction,
+        requestKey,
+        details: { networkId, network, chainId },
+      }) => {
+        transactionLog[requestKey] = {
+          hash: transaction.hash,
+          networkId,
+          network,
+          chainId,
+        };
+      },
+    );
+
+    await writeTransactionLog(transactionFilePath, transactionLog);
+  } catch (error) {
+    log.error(`Failed to save transactions: ${error.message}`);
+  }
+};
+
+export const updateTransactionStatus = async (
+  payloads: IUpdateTransactionsLogPayload[],
+): Promise<void> => {
+  try {
+    const transactionDir = getTransactionDirectory();
+    if (!notEmpty(transactionDir)) throw new KadenaError('no_kadena_directory');
+
+    const transactionFilePath = path.join(
+      transactionDir,
+      TRANSACTIONS_LOG_FILE,
+    );
+    const transactionLog = await readTransactionLog(transactionFilePath);
+    if (!transactionLog) throw new Error('no_transaction_data');
+
+    payloads.forEach(({ requestKey, status, data = {} }) => {
+      if (isNotEmptyObject(transactionLog[requestKey])) {
+        transactionLog[requestKey] = {
+          ...transactionLog[requestKey],
+          status,
+          gas: data.gas,
+          txId: notEmpty(data.txId) ? data.txId : null,
+          logs: notEmpty(data.logs) ? data.logs : null,
+        };
+      } else {
+        log.error(`No transaction found for request key: ${requestKey}`);
+      }
+    });
+
+    await writeTransactionLog(transactionFilePath, transactionLog);
+  } catch (error) {
+    log.error(`Failed to update transaction status: ${error.message}`);
+  }
 };

--- a/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
+++ b/packages/tools/kadena-cli/src/tx/utils/txHelpers.ts
@@ -901,7 +901,9 @@ export const updateTransactionStatus = async (
     );
     const currentTransactionLog = await readTransactionLog(transactionFilePath);
     if (!currentTransactionLog)
-      throw new Error('No transaction logs available.');
+      throw new Error(
+        'No transaction logs are available. Please ensure that transaction logs are present and try again.',
+      );
 
     const updatedTransactionLog = mergePayloadsWithTransactionLog(
       currentTransactionLog,


### PR DESCRIPTION
- Store all transactions in a single file
- Storing networkId, chainId, networkHost, status and transactionId. `networkHost` is required to fetch status when running a `tx history` command
- `tx send` - only write the tx details (networkId, chainId, networkHost)
- `tx send --poll` will update the status and transaction Id. once polling is successfully completed 
- `tx status` - will update the status and transaction id only when the requestKey is available in the log file

I tried to add few other data like `blockHeight`, `logs` and `blockHash` - but I'm not sure how much value this can add as part of log, but with current implementation we can add them easily so open for feedback

#### Empty state
<img width="1283" alt="image" src="https://github.com/kadena-community/kadena.js/assets/7163943/6f38b55c-3ba8-478c-ae7e-f6cd979849bd">


#### tx history command without status(get status will not poll - so if you try to check tx history right after submitting a transaction it will not show the `status`)
<img width="1145" alt="image" src="https://github.com/kadena-community/kadena.js/assets/7163943/f1c8d89b-ceb4-4047-a0a4-870b9ad49869">

#### tx history with status and transaction id
<img width="1135" alt="image" src="https://github.com/kadena-community/kadena.js/assets/7163943/5b807118-4465-40c8-b462-41d5e4979f4e">

#### tx history with json flag
<img width="1130" alt="image" src="https://github.com/kadena-community/kadena.js/assets/7163943/f6359bd2-a243-4d0b-9670-ec38d628fa15">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207316295957454