### PR TITLE
FIX: add Turbo config to Marmalade Marketplace

### DIFF
--- a/packages/apps/marmalade-marketplace/turbo.json
+++ b/packages/apps/marmalade-marketplace/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**", "./src/graphql/generated/**"],
+      "outputMode": "new-only"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds missing turbo config to the marmalade marketplace