### PR TITLE
chore: client-utils marmalade.js point release update

### DIFF
--- a/packages/libs/client-utils/src/integration-tests/marmalade-conventional-auction.int.test.ts
+++ b/packages/libs/client-utils/src/integration-tests/marmalade-conventional-auction.int.test.ts
@@ -444,7 +444,7 @@ describe('updateAuction', () => {
           if (prResult.result.status === 'failure') {
             expect(prResult.result.status).toBe('success');
           } else {
-            expect(prResult.result.data).toBe('Write succeeded');
+            expect(prResult.result.data).toBe(true);
           }
         }),
       )
@@ -464,13 +464,13 @@ describe('updateAuction', () => {
           if (sbResult.result.status === 'failure') {
             expect(sbResult.result.status).toBe('success');
           } else {
-            expect(sbResult.result.data).toBe('Write succeeded');
+            expect(sbResult.result.data).toBe(true);
           }
         }),
       )
       .execute();
 
-    expect(result).toBe('Write succeeded');
+    expect(result).toBe(true);
   });
 });
 

--- a/packages/libs/client-utils/src/integration-tests/marmalade-dutch-auction.int.test.ts
+++ b/packages/libs/client-utils/src/integration-tests/marmalade-dutch-auction.int.test.ts
@@ -442,7 +442,7 @@ describe('updateAuction', () => {
           if (prResult.result.status === 'failure') {
             expect(prResult.result.status).toBe('success');
           } else {
-            expect(prResult.result.data).toBe('Write succeeded');
+            expect(prResult.result.data).toBe(true);
           }
         }),
       )
@@ -462,13 +462,13 @@ describe('updateAuction', () => {
           if (sbResult.result.status === 'failure') {
             expect(sbResult.result.status).toBe('success');
           } else {
-            expect(sbResult.result.data).toBe('Write succeeded');
+            expect(sbResult.result.data).toBe(true);
           }
         }),
       )
       .execute();
 
-    expect(result).toBe('Write succeeded');
+    expect(result).toBe(true);
   });
 });
 

--- a/packages/libs/client-utils/src/integration-tests/utils.int.test.ts
+++ b/packages/libs/client-utils/src/integration-tests/utils.int.test.ts
@@ -43,7 +43,7 @@ describe('estimateGas', () => {
       'http://127.0.0.1:8080',
     );
 
-    expect(gasEstimation).toEqual({ gasLimit: 707, gasPrice: 1e-8 });
+    expect(gasEstimation).toEqual({ gasLimit: 709, gasPrice: 1e-8 });
 
     // check if the gas estimation is correct
     const transferResult = await transferCreate(inputs, {

--- a/packages/libs/client-utils/src/integration-tests/utils.int.test.ts
+++ b/packages/libs/client-utils/src/integration-tests/utils.int.test.ts
@@ -43,7 +43,7 @@ describe('estimateGas', () => {
       'http://127.0.0.1:8080',
     );
 
-    expect(gasEstimation).toEqual({ gasLimit: 709, gasPrice: 1e-8 });
+    expect(gasEstimation).toEqual({ gasLimit: 707, gasPrice: 1e-8 });
 
     // check if the gas estimation is correct
     const transferResult = await transferCreate(inputs, {

--- a/packages/libs/client-utils/src/marmalade/create-token.ts
+++ b/packages/libs/client-utils/src/marmalade/create-token.ts
@@ -190,7 +190,7 @@ const createTokenCommand = <C extends ICreateTokenPolicyConfig>({
     addKeyset('creation-guard', creator.keyset.pred, ...creator.keyset.keys),
     addSigner(creator.keyset.keys, (signFor) => [
       signFor('coin.GAS'),
-      signFor('marmalade-v2.ledger.CREATE-TOKEN', tokenId),
+      signFor('marmalade-v2.ledger.CREATE-TOKEN', tokenId, creator.keyset),
 
       ...generatePolicyCapabilities(
         policyConfig as ICreateTokenPolicyConfig,


### PR DESCRIPTION
Adding back guard to `marmalade-v2.ledger.CREATE-TOKEN` to adopt the Point Release 1.1.0 update