### PR TITLE
chore: add marmalade team as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,11 +8,12 @@
 /packages/apps/proof-of-us                      @sstraatemans @realdreamer @ghislain89
 /packages/apps/graph                            @alber70g @MRVDH @nil-amrutlal-dept
 /packages/apps/graph-client                     @alber70g @MRVDH @nil-amrutlal-dept
+/packages/apps/marmalade-marketplace            @wooglie @jermaine150 @ggobugi27
 /packages/apps/tools                            @sanderlooijenga
 /packages/libs/bootstrap-lib                    @alber70g
 /packages/libs/chainweb-stream-client           @Takadenoshi
 /packages/libs/client                           @alber70g @javadkh2 @nillo
-/packages/libs/client-utils                     @alber70g @javadkh2 @jessevanmuijden
+/packages/libs/client-utils                     @alber70g @javadkh2 @jessevanmuijden @wooglie @jermaine150 @ggobugi27
 /packages/libs/kadena.js                        @alber70g
 /packages/libs/pactjs-generator                 @alber70g @javadkh2
 /packages/libs/react-ui                         @eileenmguo @sstraatemans @r-mulder


### PR DESCRIPTION
Adding Marmalade team as codeowners to marmalade marketplace app and client-utils