### PR TITLE
Feat/dev wallet/write down recovery key

### DIFF
--- a/packages/apps/dev-wallet/src/Components/AuthCard/AuthCard.tsx
+++ b/packages/apps/dev-wallet/src/Components/AuthCard/AuthCard.tsx
@@ -15,7 +15,7 @@ export const AuthCard: FC<IProps> = ({ children }) => {
       <Stack paddingBlockEnd="md">
         <Button
           variant="transparent"
-          onClick={() => navigate(-1)}
+          onPress={() => navigate(-1)}
           className={backButtonClass}
         >
           <Stack alignItems="center" gap="xs">

--- a/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/backup-recovery-phrase.tsx
+++ b/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/backup-recovery-phrase.tsx
@@ -1,29 +1,27 @@
 import { AuthCard } from '@/Components/AuthCard/AuthCard';
-import { useWallet } from '@/modules/wallet/wallet.hook';
-import { Button, Heading, MaskedValue, Stack, Text } from '@kadena/react-ui';
-import { Link, useParams } from 'react-router-dom';
-
-declare const PasswordCredential: {
-  new (passwordCredentialInit: { id: string; password: string }): Credential;
-};
+import {
+  Text,
+  Button,
+  Heading,
+  Notification,
+  NotificationFooter,
+  NotificationHeading,
+  Stack,
+  Dialog
+} from '@kadena/react-ui';
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 
 export function BackupRecoveryPhrase() {
-  const supportPasswordCredential = 'PasswordCredential' in window;
-  const wallet = useWallet();
   const { keySourceId } = useParams();
-  const storeRecoveryPhrase: React.MouseEventHandler<HTMLAnchorElement> = (
-    e,
-  ) => {
-    e.preventDefault();
-    if (supportPasswordCredential) {
-      const passwordCredential = new PasswordCredential({
-        id: `${wallet.profile}-dev-wallet-secret`,
-        password: 'my recovery phrase',
-      });
+  const navigate = useNavigate();
 
-      navigator.credentials.store(passwordCredential);
-    }
-  };
+  const [modalOpen, setModalOpen] = useState(false);
+  const acceptWarning = (): void => {
+    setModalOpen(false);
+    navigate(`/backup-recovery-phrase/${keySourceId}/write-down`);
+  }
+
   return (
     <>
       <AuthCard backButtonLink="/create-profile">
@@ -34,36 +32,63 @@ export function BackupRecoveryPhrase() {
           your assets if this wallet is deleted.
         </Text>
         <Heading as="h6">Recovery phrase</Heading>
-        <Link to={`/backup-recovery-phrase/${keySourceId}/write-down`}>
-          Write down the phrase
-        </Link>
-        <br />
-        <Link to={`/backup-recovery-phrase/${keySourceId}/export-encrypted`}>
-          Export encrypted phrase
-        </Link>
-        <br />
-        {supportPasswordCredential && (
-          <>
-            <a onClick={storeRecoveryPhrase} href="#">
-              Store encrypted in password storage
-            </a>
-            <br />
-          </>
-        )}
-        <MaskedValue
-          maskCharacter="*"
-          maskLength={5}
-          title="1"
-          value="wordfd"
-          startUnmaskedValues={0}
-          endUnmaskedValues={0}
-        />
+        <Stack gap="md" flexWrap="wrap">
+          {[...Array(12)].map((e, index) => {
+            return (
+              <span key={index}>
+                {index + 1} *****
+              </span>
+            )
+          })}
+        </Stack>
         <Stack flexDirection="column" gap="md">
-          <Button variant="outlined">Export encrypted file</Button>
-          <Button variant="primary">Write it down</Button>
+          <Button
+            variant="outlined"
+            onPress={() => navigate(`/backup-recovery-phrase/${keySourceId}/write-down`)}
+          >
+            Export encrypted file
+          </Button>
+          <Button
+            variant="primary"
+            onPress={() => setModalOpen(true)}
+          >
+            Write it down
+          </Button>
         </Stack>
       </AuthCard>
       <Link to="/">Skip step</Link>
+
+      <Dialog
+        onOpenChange={() => setModalOpen(false)}
+        isOpen={modalOpen}
+        size="sm"
+        className="dialog-warning"
+      >
+        <Notification
+          intent="warning"
+          // isDismissable
+          // onDismiss={() => {}}
+          role="alert"
+          type="inlineStacked"
+        >
+          <NotificationHeading>
+            Warning
+          </NotificationHeading>
+          <Text>
+            Your Secret Recovery Phrase provides full access to your wallet and funds. 
+            Please be aware that malicious softwares can monitor the clipboard, 
+            your keyboard or record the screen.
+          </Text>
+          <NotificationFooter>
+            <Button
+              variant="warning"
+              onPress={() => acceptWarning()}
+            >
+              Understood
+            </Button>
+          </NotificationFooter> 
+        </Notification>
+      </Dialog>
     </>
   );
 }

--- a/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/backup-recovery-phrase.tsx
+++ b/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/backup-recovery-phrase.tsx
@@ -10,13 +10,15 @@ import {
   Dialog
 } from '@kadena/react-ui';
 import { useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { warningDialog } from './styles.css.ts';
 
 export function BackupRecoveryPhrase() {
   const { keySourceId } = useParams();
   const navigate = useNavigate();
 
   const [modalOpen, setModalOpen] = useState(false);
+  const location = useLocation();
   const acceptWarning = (): void => {
     setModalOpen(false);
     navigate(`/backup-recovery-phrase/${keySourceId}/write-down`);
@@ -24,7 +26,7 @@ export function BackupRecoveryPhrase() {
 
   return (
     <>
-      <AuthCard backButtonLink="/create-profile">
+      <AuthCard>
         <Heading variant="h5">Save your recovery key</Heading>
         <Text>
           Secure your assets by writing down or exporting 
@@ -62,12 +64,10 @@ export function BackupRecoveryPhrase() {
         onOpenChange={() => setModalOpen(false)}
         isOpen={modalOpen}
         size="sm"
-        className="dialog-warning"
+        className={warningDialog}
       >
         <Notification
           intent="warning"
-          // isDismissable
-          // onDismiss={() => {}}
           role="alert"
           type="inlineStacked"
         >
@@ -82,6 +82,7 @@ export function BackupRecoveryPhrase() {
           <NotificationFooter>
             <Button
               variant="warning"
+              className="acceptWarningButton"
               onPress={() => acceptWarning()}
             >
               Understood

--- a/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/backup-recovery-phrase.tsx
+++ b/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/backup-recovery-phrase.tsx
@@ -1,5 +1,6 @@
+import { AuthCard } from '@/Components/AuthCard/AuthCard';
 import { useWallet } from '@/modules/wallet/wallet.hook';
-import { Box, Heading, Text } from '@kadena/react-ui';
+import { Button, Heading, MaskedValue, Stack, Text } from '@kadena/react-ui';
 import { Link, useParams } from 'react-router-dom';
 
 declare const PasswordCredential: {
@@ -25,13 +26,14 @@ export function BackupRecoveryPhrase() {
   };
   return (
     <>
-      <Box margin="md">
-        <Heading variant="h5">Backup the recovery phrase</Heading>
+      <AuthCard backButtonLink="/create-profile">
+        <Heading variant="h5">Save your recovery key</Heading>
         <Text>
-          With recovery phrase you can recover your wallet; you should consider
-          everyone with the phrase have access to your assets
+          Secure your assets by writing down or exporting 
+          your recovery phrase. Otherwise you will lose 
+          your assets if this wallet is deleted.
         </Text>
-        <Heading variant="h5">Choose a method</Heading>
+        <Heading as="h6">Recovery phrase</Heading>
         <Link to={`/backup-recovery-phrase/${keySourceId}/write-down`}>
           Write down the phrase
         </Link>
@@ -48,8 +50,20 @@ export function BackupRecoveryPhrase() {
             <br />
           </>
         )}
-        <Link to="/">Skip for now</Link>
-      </Box>
+        <MaskedValue
+          maskCharacter="*"
+          maskLength={5}
+          title="1"
+          value="wordfd"
+          startUnmaskedValues={0}
+          endUnmaskedValues={0}
+        />
+        <Stack flexDirection="column" gap="md">
+          <Button variant="outlined">Export encrypted file</Button>
+          <Button variant="primary">Write it down</Button>
+        </Stack>
+      </AuthCard>
+      <Link to="/">Skip step</Link>
     </>
   );
 }

--- a/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/styles.css.ts
+++ b/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/styles.css.ts
@@ -1,0 +1,17 @@
+import { style } from '@vanilla-extract/css';
+
+export const warningDialog = style([
+  {
+    padding: '0',
+    border: 'none',
+    maxWidth: '460px',
+  },
+]);
+
+export const acceptWarningButton = style([
+  {
+    padding: '0',
+    border: 'none',
+    maxWidth: '460px',
+  },
+]);

--- a/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/write-down/write-down-recovery-phrase.tsx
+++ b/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/write-down/write-down-recovery-phrase.tsx
@@ -1,20 +1,27 @@
 import { HDWalletKeySource } from '@/modules/key-source/key-source.repository';
 import { useWallet } from '@/modules/wallet/wallet.hook';
 import { KeySourceType } from '@/modules/wallet/wallet.repository';
-import { Box, Button, Heading, Text, TextField } from '@kadena/react-ui';
+import { Button, Heading, Stack, Text, TextField } from '@kadena/react-ui';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ConfirmRecoveryPhrase } from './confirm-recovery-phrase';
+import { AuthCard } from '@/Components/AuthCard/AuthCard';
+import { MonoContentCopy } from '@kadena/react-icons/system';
 
 export function WriteDownRecoveryPhrase() {
   const { register, handleSubmit } = useForm<{ password: string }>();
   const { keySources, decryptSecret } = useWallet();
   const { keySourceId } = useParams();
   const [mnemonic, setMnemonic] = useState('');
+  const [codeVisible, setCodeVisible] = useState(false);
   const [error, setError] = useState('');
   const [readyForConfirmation, setReadyForConfirmation] = useState(false);
   const navigate = useNavigate();
+  const maskedValue = (): string => {
+    const maskedSymbol = "*";
+    return maskedSymbol.repeat(5);
+  }
   async function decryptMnemonic({ password }: { password: string }) {
     setError('');
     try {
@@ -32,7 +39,7 @@ export function WriteDownRecoveryPhrase() {
       }
       const secretId = (keySource as HDWalletKeySource).secretId;
       if (!secretId) {
-        throw new Error('No mnemonic found');
+        throw new Error('Mnemonic is not found');
       }
       const mnemonic = await decryptSecret(password, secretId);
       setMnemonic(mnemonic);
@@ -53,33 +60,64 @@ export function WriteDownRecoveryPhrase() {
   }
   return (
     <>
-      <Box margin="md">
-        <Heading variant="h5">Write your recovery phrase down</Heading>
+      <AuthCard backButtonLink="/backup-recovery-phrase">
+        <Heading variant="h5">Write down your phrase</Heading>
         <Text>
-          Make sure no one is watching you; consider some malware might take
-          screenshot of your screen
+          Secure your assets by writing down or exporting your recovery phrase. 
+          Otherwise you will lose your assets if this wallet is deleted.
         </Text>
-        <Text>
-          you should consider everyone with the phrase have access to your
-          assets
-        </Text>
-        <Heading variant="h5">Enter your password to show the phrase</Heading>
+        {/* todo: check if password needed */}
         <form onSubmit={handleSubmit(decryptMnemonic)}>
           <label htmlFor="password">Password</label>
           <TextField id="password" type="password" {...register('password')} />
           <Button type="submit">Show Phrase</Button>
         </form>
         {error && <Text>{error}</Text>}
-        <Text size="small">{mnemonic}</Text>
-        <Button
-          type="submit"
-          onPress={() => {
-            setReadyForConfirmation(true);
-          }}
-        >
-          Confirm
-        </Button>
-      </Box>
+        {mnemonic && (
+          <>
+            <Stack
+              alignItems="center"
+              flexDirection="row"
+              gap="md"
+              justifyContent="space-between"
+            >
+              <Heading as="h6">Recovery phrase</Heading>
+              <Button
+                variant="transparent"
+                endVisual={<MonoContentCopy />}
+                isCompact
+                onPress={() => navigator.clipboard.writeText(mnemonic)}
+              >
+                Copy
+              </Button>
+            </Stack>
+            <Stack gap="md" flexWrap="wrap">
+              {mnemonic.split(' ').map((word, index) => {
+                return (
+                  <span key={index}>
+                    {index + 1} {codeVisible ? word : maskedValue()}
+                  </span>
+                )
+              })}
+            </Stack>
+          </>
+        )}
+        <Stack flexDirection="column" gap="md">
+          <Button
+            variant="outlined"
+            onPress={() => setCodeVisible(!codeVisible)}
+          >
+            {codeVisible ? 'Hide code' : 'Show code'}
+          </Button>
+          <Button
+            variant="primary"
+            type="submit"
+            onPress={() => setReadyForConfirmation(true)}
+          >
+            Continue
+          </Button>
+        </Stack>
+      </AuthCard>
     </>
   );
 }

--- a/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/write-down/write-down-recovery-phrase.tsx
+++ b/packages/apps/dev-wallet/src/pages/backup-recovery-phrase/write-down/write-down-recovery-phrase.tsx
@@ -60,13 +60,12 @@ export function WriteDownRecoveryPhrase() {
   }
   return (
     <>
-      <AuthCard backButtonLink="/backup-recovery-phrase">
+      <AuthCard>
         <Heading variant="h5">Write down your phrase</Heading>
         <Text>
           Secure your assets by writing down or exporting your recovery phrase. 
           Otherwise you will lose your assets if this wallet is deleted.
         </Text>
-        {/* todo: check if password needed */}
         <form onSubmit={handleSubmit(decryptMnemonic)}>
           <label htmlFor="password">Password</label>
           <TextField id="password" type="password" {...register('password')} />

--- a/packages/apps/dev-wallet/src/pages/create-profile/create-profile.tsx
+++ b/packages/apps/dev-wallet/src/pages/create-profile/create-profile.tsx
@@ -55,7 +55,6 @@ export function CreateProfile() {
     password: string;
     accentColor?: string;
   }) {
-    console.log(password, profileName, accentColor);
     if (!activeNetwork) {
       return;
     }
@@ -148,7 +147,7 @@ export function CreateProfile() {
                     {!isShortFlow && (
                       <Button
                         type="button"
-                        onClick={() => navigate('personalize-profile')}
+                        onPress={() => navigate('personalize-profile')}
                         isDisabled={Boolean(
                           errors.confirmation?.message ||
                             errors.password?.message ||


### PR DESCRIPTION
Add functionality for Backup recovery key - writing down

Related Issue/Asana ticket: https://app.asana.com/0/1205838799963624/1206840333553537/f

Steps to improve this PR:
- move NavigationDialog to a separate component
- move recovery phrase view to a separate component
- remove password input on writing down recovery phrase page 