### PR TITLE
fix: remove max height from global image and svg selector to prevent …

### DIFF
--- a/.changeset/metal-ladybugs-obey.md
+++ b/.changeset/metal-ladybugs-obey.md
@@ -1,0 +1,5 @@
+---
+"@kadena/react-ui": patch
+---
+
+fix: prevent icons from scaling down in size when their parent container shrinks in size

--- a/packages/libs/react-ui/src/styles/global.css.ts
+++ b/packages/libs/react-ui/src/styles/global.css.ts
@@ -87,7 +87,6 @@ globalStyle('body', {
 */
 globalStyle('img, picture, video, canvas, svg', {
   display: 'block',
-  maxWidth: '100%',
 });
 
 /*

--- a/packages/libs/react-ui/src/styles/global.css.ts
+++ b/packages/libs/react-ui/src/styles/global.css.ts
@@ -89,6 +89,10 @@ globalStyle('img, picture, video, canvas, svg', {
   display: 'block',
 });
 
+globalStyle('img, picture, video, canvas', {
+  maxWidth: '100%',
+});
+
 /*
     7. Remove built-in form typography styles
 */


### PR DESCRIPTION
Ticket: https://app.asana.com/0/1206752931509995/1207470017609457

There was an issue with the icons, when their parent container gets scaled down due to a smaller viewport the icons were also reducing in size. This was because a global selector was set to provide a maxheight of 100% on all images & svgs.

**How to test:**
Open the notification story in storybook and reduce the viewport. When the viewport gets really small the icon reduces in size on production. After removing this line the icons keep their size. 

**Note:** I haven't tested other application so see and know what the impact is. I assume there wont be an issue but you never know.