### PR TITLE
fix: make the icon optional for the textlink component

### DIFF
--- a/.changeset/lovely-trees-flow.md
+++ b/.changeset/lovely-trees-flow.md
@@ -1,0 +1,5 @@
+---
+"@kadena/react-ui": patch
+---
+
+fix: make the icon on the text link component optional

--- a/packages/libs/react-ui/src/components/TextLink/TextLink.stories.tsx
+++ b/packages/libs/react-ui/src/components/TextLink/TextLink.stories.tsx
@@ -38,6 +38,12 @@ const meta: Meta<ITextLinkProps> = {
         type: 'text',
       },
     },
+    withIcon: {
+      description: 'optionally show a link icon',
+      control: {
+        type: 'boolean',
+      },
+    },
   },
 };
 
@@ -61,6 +67,9 @@ export const AllOptions: TextLinkStory = {
       <Stack flexDirection={'column'}>
         <TextLink {...props}>{props.children}</TextLink>{' '}
         <TextLink {...props} isCompact={true}>
+          {props.children}
+        </TextLink>
+        <TextLink {...props} withIcon>
           {props.children}
         </TextLink>
       </Stack>

--- a/packages/libs/react-ui/src/components/TextLink/TextLink.tsx
+++ b/packages/libs/react-ui/src/components/TextLink/TextLink.tsx
@@ -24,6 +24,7 @@ export type ITextLinkProps = Omit<AriaFocusRingProps, 'isTextInput'> &
     title?: string;
     style?: React.CSSProperties;
     children?: string | number;
+    withIcon?: boolean;
   };
 
 /**
@@ -34,11 +35,18 @@ export type ITextLinkProps = Omit<AriaFocusRingProps, 'isTextInput'> &
  * @param className - additional class name
  * @param style - additional style
  * @param title - title to be shown as HTML tooltip
+ * @param withIcon - optionally show an link icon
  */
 
 const TextLink = forwardRef(
   (
-    { isCompact = false, children, className, ...props }: ITextLinkProps,
+    {
+      isCompact = false,
+      children,
+      className,
+      withIcon,
+      ...props
+    }: ITextLinkProps,
     forwardedRef: ForwardedRef<HTMLAnchorElement>,
   ) => {
     props = disableLoadingProps(props);
@@ -77,7 +85,7 @@ const TextLink = forwardRef(
               })}
             >
               {children}
-              <MonoLink />
+              {withIcon && <MonoLink />}
             </span>
           }
         </>


### PR DESCRIPTION
Ticket: https://app.asana.com/0/1206752931509995/1207525414079731

The icon should be optional, this was the intended behaviour by design but implemented incorrect.
This PR will fix that, you can show the icon if you provide the withIcon prop.