### PR TITLE
[Docs] Change --type manual to --from key and add tx subcommands local and h…

### DIFF
--- a/packages/apps/docs/src/docs/build/dev-with-cli.md
+++ b/packages/apps/docs/src/docs/build/dev-with-cli.md
@@ -516,7 +516,7 @@ To add a new local account:
    
    
    Executed:
-   kadena account add --type="wallet" --wallet-name="pistolas" --account-alias="pistolas-local" --fungible="coin" --public-keys="ad833b6bbfc72fb7d18b88cd5b4349f82b2f015be8e4b5e7ad28f3249fd5e105" --predicate="keys-all" 
+   kadena account add --from="wallet" --wallet-name="pistolas" --account-alias="pistolas-local" --fungible="coin" --public-keys="ad833b6bbfc72fb7d18b88cd5b4349f82b2f015be8e4b5e7ad28f3249fd5e105" --predicate="keys-all" 
    ```
 
 You now have one onchain account and one local account.

--- a/packages/apps/docs/src/docs/reference/cli/cli-account.md
+++ b/packages/apps/docs/src/docs/reference/cli/cli-account.md
@@ -50,25 +50,25 @@ You can use the following optional flags with `kadena account` commands.
 ## kadena account add
 
 Use `kadena account add` to add a new local account manually from existing keys or from a wallet.
-The parameters required depend on the type of account you specify using the `--type` command-line option. 
-Use `--type manual` to add an account manually from existing local keys.
-Use `--type wallet` to add an account to an existing wallet.
+The parameters required depend on the type of account you specify using the `--from` command-line option. 
+Use `--from key` to add an account manually from existing local keys.
+Use `--from wallet` to add an account to an existing wallet.
 
 ### Basic usage
 
 The basic syntax for the `kadena account add` command is:
 
 ```bash
-kadena account add --type manual | wallet [arguments] [flags]
+kadena account add --from key | wallet [arguments] [flags]
 ```
 
-### Arguments for manual
+### Arguments for using a local key
 
-You can use the following command-line arguments with the `kadena account add --type manual` command:
+You can use the following command-line arguments with the `kadena account add --from key` command:
 
 | Use this argument | To do this                                 | 
 | ----------------- | ------------------------------------------ | 
-| -t, --type _manual_ | Specify the type of account to add. Use`manual` to add an account manually from existing keys. |
+| -f --from _key_ | Specify the type of account to add. Use `--from key` to add an account manually from existing keys. |
 | -l, --account-alias _aliasName_ | Specify an alias for the account. | 
 | -f, --fungible _fungible_ | Specify the fungible module name. The default is `coin`. |
 | -p, --predicate _predicate_ | Specify the predicate to use for the account. You can specify on the the `keys-all`, `keys-any`, or `keys-2` built-in predicates or a custom predicate. |
@@ -80,13 +80,13 @@ You can use the following command-line arguments with the `kadena account add --
 
 If you want to verify the account details on the blockchain, you must provide the network name and chain identifier.
 
-### Arguments for wallet
+### Arguments for using a wallet
 
-You can use the following command-line arguments with the `kadena account add --type wallet` command:
+You can use the following command-line arguments with the `kadena account add --from wallet` command:
 
 | Use this argument | To do this                                 |
 | ----------------- | ------------------------------------------ |
-| -t, --type _wallet_ | Specify the type of account to add. Use `wallet` to add a wallet account. | 
+| -f, --from _wallet_ | Specify the type of account to add. Use `--from wallet` to add a wallet account. | 
 | -l, --account-alias _aliasName_ | Specify an alias for the account. |
 | -a, --account-name _accountName_ | Provide an account name. |
 | -f, --fungible _fungible_ | Specify the fungible module name. The default is `coin`.|
@@ -110,7 +110,7 @@ If you have other public keys that you want to use, you can add an account by en
 To add an account locally from an account that exists on the Kadena test network and chain identifier 1, run a command similar to the following:
 
 ```bash
-kadena account add --type=manual --account-alias=pistolas-testnet --account-name=k:bbccc99ec9eeed17d60159fbb88b09e30ec5e63226c34544e64e750ba424d35e --fungible=coin --verify --network=testnet --chain-id=1
+kadena account add --from=key --account-alias=pistolas-testnet --account-name=k:bbccc99ec9eeed17d60159fbb88b09e30ec5e63226c34544e64e750ba424d35e --fungible=coin --verify --network=testnet --chain-id=1
 ```
 
 This command verifies the account details on the Kadena test network and displays a confirmation message similar to the following:
@@ -122,7 +122,7 @@ The account configuration "pistolas-testnet" has been saved in .kadena/accounts/
 To add an account by providing public keys manually, you can run a command similar to the following:
 
 ```bash
-kadena account add --type="manual" --account-alias=pistolas-publickey --account-name=k:3e7e7db00e2e575a5260b8705ab7663574b186657451d6990316af6bc5108b59 --fungible="coin" --public-keys=3e7e7db00e2e575a5260b8705ab7663574b186657451d6990316af6bc5108b59,99d30af3fa91d78cc06cf53a0d4eb2d7fa2a5a72944cc5451311b455a67a3c1c --predicate=keys-any
+kadena account add --from="key" --account-alias=pistolas-publickey --account-name=k:3e7e7db00e2e575a5260b8705ab7663574b186657451d6990316af6bc5108b59 --fungible="coin" --public-keys=3e7e7db00e2e575a5260b8705ab7663574b186657451d6990316af6bc5108b59,99d30af3fa91d78cc06cf53a0d4eb2d7fa2a5a72944cc5451311b455a67a3c1c --predicate=keys-any
 ```
 
 This command prompts you to specify whether you want to verify the account information before adding the account.
@@ -137,13 +137,13 @@ For example:
 To add an account from a wallet, you can run a command similar to the following:
 
 ```bash
-kadena account add --type="wallet" --wallet-name="wallet_name" --account-alias="account_alias" --fungible="coin" --public-keys="7c8939951b61614c30f837d7b02fe4982565962b5665d0e0f836b79720747cb2" --predicate="keys-all"
+kadena account add --from="wallet" --wallet-name="wallet_name" --account-alias="account_alias" --fungible="coin" --public-keys="7c8939951b61614c30f837d7b02fe4982565962b5665d0e0f836b79720747cb2" --predicate="keys-all"
 ```
 
-To add an account with wallet type and auto generate keys, you can run a command similar to the following:
+To add an account from a wallet and automatically generate new keys, you can run a command similar to the following:
 
 ```bash
-kadena account add --type="wallet" --wallet-name="wallet-name" --account-alias="account_alias_testing" --fungible="coin" --public-keys="your_public_key,_generate_" --predicate="keys-all" --password-file="./kadenawallet-pw.txt"
+kadena account add --from="wallet" --wallet-name="wallet-name" --account-alias="account_alias_testing" --fungible="coin" --public-keys="your_public_key,_generate_" --predicate="keys-all" --password-file="./kadenawallet-pw.txt"
 ```
 
 ## kadena account details

--- a/packages/apps/docs/src/docs/reference/cli/cli-tx.md
+++ b/packages/apps/docs/src/docs/reference/cli/cli-tx.md
@@ -33,6 +33,8 @@ Use the following actions to specify the operation you want to perform.
 | send | Send a signed transaction to the network.|
 | status | Get the status of a transaction.|
 | list | List transactions.|
+| local | Submit Pact code as a local call. |
+| history | Display a formatted list of transactions with their details.
 
 ## Flags
 
@@ -457,3 +459,145 @@ transaction-kQSKbcjN3z-signed.json Yes
 tx-simple.json                     No    
 tx-transfer-testnet.json           No    
 ```
+
+## kadena tx local
+
+Use `kadena tx local` to submit Pact code as a local call. 
+This command can be useful for testing Pact code without submitting the transaction to the blockchain.
+
+### Basic usage
+
+The basic syntax for the `kadena tx local` command is:
+
+```bash
+kadena tx local [arguments] [flags]
+```
+
+### Arguments
+
+You can use the following command-line arguments with the `kadena tx local` command:
+
+| Use this argument | To do this |
+| ----------------- | ---------- |
+| -n, --network _networkName_ | Specify the Kadena network to connect to for calling the `/local` endpoint. The default is the `/local` endpoint on the Kadena test network. |
+| -c, --chain-id _chainID_ | Specify the chain identifier to connect to for calling the `/local` endpoint. Valid values are "0" to "19". The default is the `/local` endpoint on chain 0. |
+| -g, --gas-limit _gasLimit_ | Specify a gas limit for executing the local transaction. |
+
+### Examples
+
+To execute a simple Pact expression using the `/local` endpoint on the default network and chain, you can run a command similar to the following: 
+
+```bash
+kadena tx local "(+ 2 2)"
+```
+
+This command evaluates the `(+ 2 2)` expressions displays the following output:
+
+```bash
+Local transaction on network testnet chain 0:
+4
+```
+
+To execute a Pact expression using the `/local` endpoint on a specific chain and set a gas limit for the transaction, you can run a command similar to the following: 
+
+```bash
+kadena tx local --network testnet --chain-id 3 --gas-limit 4 "(* 3 4)"
+```
+
+If the gas limit is too low, the command fails with an error message similar to the following:
+
+```bash
+Local transaction on network testnet chain 3:
+Error from local call:
+Gas limit (4) exceeded: 6
+```
+
+If you adjust the gas limit, the command succeeds:
+
+```bash
+kadena tx local --network testnet --chain-id 3 --gas-limit 10 "(* 3 4)"
+Local transaction on network testnet chain 3:
+12
+```
+
+To execute a Pact command that includes strings, you can escape the inner quotations marks with a command similar to the following:
+
+```bash
+kadena tx local --chain-id 3 '(base64-encode "once in a lifetime")'
+```
+
+The command evaluates the expression and displays the following output:
+
+```bash
+Local transaction on network testnet chain 3:
+"b25jZSBpbiBhIGxpZmV0aW1l"
+
+```
+
+## kadena tx history
+
+Use `kadena tx history` to list your transactions history. 
+
+### Basic usage
+
+The basic syntax for the `kadena tx history` command is:
+
+```bash
+kadena tx list [arguments] [flags]
+```
+
+### Arguments
+
+You can use the following command-line arguments with the `kadena tx history` command:
+
+| Use this argument | To do this |
+| ----------------- | ---------- |
+| -d, --directory _configDirectory_ | Specify the path to the configuration folder. The default is the current working directory. |
+
+### Examples
+
+To list the transaction history in your current working directory, you can run the following command:
+
+```bash
+kadena tx history
+```
+
+This command displays output similar to the following:
+
+```bash
+Request Key    EYh5uvPiUSBXS0KC7XDVKQxabgm7jXtdray_CBK_XRs
+Network Host   http://localhost:8080                      
+Network ID     development                                
+Chain ID       3                                          
+Time           2024-06-18 14:06                           
+Status         success                                    
+Transaction ID 1438 
+                     
+Request Key    m32rYeSP3iBoNZNZhkknHTDdIokPzBjy3xeI-Md1Dn0
+Network Host   http://localhost:8080                      
+Network ID     development                                
+Chain ID       3                                          
+Time           2024-06-18 14:16                           
+Status         success                                    
+Transaction ID 1471                 
+```
+
+To format the output in JSON, you can include the `--json` command-line options:
+
+```bash
+kadena tx history --json
+```
+
+```bash
+{
+  "EYh5uvPiUSBXS0KC7XDVKQxabgm7jXtdray_CBK_XRs": 
+  {
+    "dateTime": "2024-06-18T21:06:51.366Z",
+    "cmd": "{\"payload\":{\"exec\":{\"code\":\"(coin.transfer-create \\\"k:0b8fb7b68f6e058143d5c57094a9be9835811d936ae486120ef036cc4ff9b31a\\\" \\\"k:6887c4cce24a0ac69e0db0e3e1db6d2d97edb6b7935da7c19f1651b71ade398f\\\" (read-keyset \\\"account-guard\\\") 2.0)\",\"data\":{\"account-guard\":{\"keys\":[\"6887c4cce24a0ac69e0db0e3e1db6d2d97edb6b7935da7c19f1651b71ade398f\"],\"pred\":\"keys-all\"}}}},\"nonce\":\"\",\"networkId\":\"development\",\"meta\":{\"sender\":\"k:0b8fb7b68f6e058143d5c57094a9be9835811d936ae486120ef036cc4ff9b31a\",\"chainId\":\"3\",\"creationTime\":1718744764,\"gasLimit\":2000,\"gasPrice\":1e-8,\"ttl\":7200},\"signers\":[{\"pubKey\":\"0b8fb7b68f6e058143d5c57094a9be9835811d936ae486120ef036cc4ff9b31a\",\"clist\":[{\"name\":\"coin.TRANSFER\",\"args\":[\"k:0b8fb7b68f6e058143d5c57094a9be9835811d936ae486120ef036cc4ff9b31a\",\"k:6887c4cce24a0ac69e0db0e3e1db6d2d97edb6b7935da7c19f1651b71ade398f\",2]},{\"name\":\"coin.GAS\",\"args\":[]}]}]}",
+    "networkId": "development",
+    "chainId": "3",
+    "networkHost": "http://localhost:8080",
+    "status": "success",
+    "txId": 1438
+  }
+}


### PR DESCRIPTION
…istory

### Kadena CLI updates to reference doc

Related Issue/Asana ticket: https://app.asana.com/0/1205969628270714/1207307903477051 

Short description: Updates:
- Change `kadena account add --type `to `--from`
- Add `kadena tx local`
- Add `kadena tx history`

<!--
Examples:

Title: Add Search Functionality to User Dashboard.
Related Issue: #1234
Short Description:
Implements a new search bar in the user dashboard to allow quick navigation and filtering of project lists based on user input. This feature enhances user experience by providing a more efficient way to locate specific projects.

Title: Fix Memory Leak in Data Processing Module.
Asana ticket: https://app.asana.com/0/1205801361945248/1207389790540430
Short Description:
Resolves a critical memory leak occurring in the data processing module when handling large datasets. This fix improves system stability and performance under heavy load conditions.
-->

### Test scenarios

- description of the (manually) executed test scenarios

<!--
Examples:

Add Search Functionality to User Dashboard
* Search Function Test: Verifies that entering a keyword in the search bar returns a list of projects containing that keyword.
* Empty Result Test: Confirms that a message is displayed when no projects match the search criteria.
* Performance Test: Ensures that the search functionality returns results within 2 seconds under typical load conditions.

Fix Memory Leak in Data Processing Module
* Memory Usage Test: Monitors memory usage during data processing to ensure that no unexpected memory growth occurs.
* Regression Test: Confirms that the data processing outputs remain consistent with previous versions post-fix.
* Stress Test: Executes the data processing module under high load to validate stability improvements.
-->

### Reminders (if applicable)

- [ ] I ran `pnpm install` and `pnpm test` in the root of the monorepo
      (optionally with `--filter=...package...` to exclude non-affected
      projects)
- [ ] I ran `pnpm changeset` in the root of the monorepo
- [ ] Test coverage has not decreased
- [ ] Docs have been updated to reflect changes in PR (don't forget
      docs.kadena.io)
