### PR TITLE
fix: grid components were not behaving correct due to layers

### DIFF
--- a/.changeset/cool-dolls-add.md
+++ b/.changeset/cool-dolls-add.md
@@ -1,0 +1,5 @@
+---
+"@kadena/react-ui": patch
+---
+
+fix the grid styles which were being applied to a layer while the base styling was being applied via atoms, all styles aren't applied on a layer for layout components

--- a/packages/libs/react-ui/src/components/Layout/Grid/Grid.css.ts
+++ b/packages/libs/react-ui/src/components/Layout/Grid/Grid.css.ts
@@ -1,6 +1,6 @@
 /* eslint @typescript-eslint/naming-convention: 0 */
+import { style, styleVariants } from '@vanilla-extract/css';
 import mapValues from 'lodash.mapvalues';
-import { style, styleVariants } from '../../../styles';
 import { breakpoints, mapToProperty } from '../../../styles/themeUtils';
 
 export const gridContainerClass = style({


### PR DESCRIPTION
The grid styles were being applied to a layer but all the other styles were being applied via the atoms function. This caused a mismatch and certain styles weren't applied. 

As you don't have any use overriding the styles of a layout component I removed the layer from the layout components.