### PR TITLE
fix: search bar had overflow scroll and made global style for anchors…

### DIFF
--- a/packages/apps/docs/src/components/Layout/basestyles.css.ts
+++ b/packages/apps/docs/src/components/Layout/basestyles.css.ts
@@ -8,10 +8,11 @@ globalStyle('html, body', {
   overscrollBehaviorY: 'none',
 });
 
-globalStyle('a', {
+globalStyle('a:not(nav a)', {
   color: tokens.kda.foundation.color.link.brand.primary.default,
   textDecoration: 'underline',
 });
+
 globalStyle('a:hover', {
   color: tokens.kda.foundation.color.link.brand.primary['@hover'],
   textDecoration: 'none',

--- a/packages/apps/docs/src/components/Search/styles.css.ts
+++ b/packages/apps/docs/src/components/Search/styles.css.ts
@@ -19,7 +19,7 @@ export const tabClass = style([
     display: 'flex',
     height: '100%',
     flexDirection: 'column',
-    overflowY: 'scroll',
+    overflowY: 'auto',
     overflowX: 'visible',
   }),
 ]);


### PR DESCRIPTION
In this PR I've fixed the styles for the search modal. There were some strange artifacts on screen caused by the overflow scroll css rule. 
This rule is now on auto and will only show a scrollbar if needed.

The other issue was that due to the new layering of the react-ui styles a global selector in the docs layout provided an anchor tag with a color and underline. This is not what we want in the navigation. So in this PR the globalStyle rule is more specific to target anchor tags outside of a navigation.