### PR TITLE
Difficulty calculations - with orphan blocks

### DIFF
--- a/.changeset/small-cows-shout.md
+++ b/.changeset/small-cows-shout.md
@@ -1,0 +1,5 @@
+---
+"@kadena/graph": patch
+---
+
+Implement logic to handle difficulty calculations when there are orphan blocks

--- a/packages/apps/graph/src/services/network.ts
+++ b/packages/apps/graph/src/services/network.ts
@@ -62,7 +62,7 @@ export async function getHashRateAndTotalDifficulty(): Promise<{
     const blocks = await prismaClient.block.findMany({
       where: {
         height: {
-          gte: Number(currentHeight) - 4, //4 because with 3 sometimes we have less than 20 blocks
+          gte: Number(currentHeight) - 4, //it was verified that with 3 heights sometimes we did not have 20 blocks
         },
       },
       select: {


### PR DESCRIPTION
**In this PR I implemented logic to deal with total difficulty calculations when having multiple blocks for the same height and chain. At this point, these blocks are the latest ones and can at max have confirmation depth 3, so we cannot determine if they are canonical or orphans. For that reason, the implemented behavior is to average the difficulty of the two blocks in the same chain. What was verified also is that in most cases these 2 blocks have the same difficulty anyways.**



### Modify this title

Related Issue/Asana ticket: \_

Short description: \_

<!--
Examples:

Title: Add Search Functionality to User Dashboard.
Related Issue: #1234
Short Description:
Implements a new search bar in the user dashboard to allow quick navigation and filtering of project lists based on user input. This feature enhances user experience by providing a more efficient way to locate specific projects.

Title: Fix Memory Leak in Data Processing Module.
Asana ticket: https://app.asana.com/0/1205801361945248/1207389790540430
Short Description:
Resolves a critical memory leak occurring in the data processing module when handling large datasets. This fix improves system stability and performance under heavy load conditions.
-->

### Test scenarios

- description of the (manually) executed test scenarios

<!--
Examples:

Add Search Functionality to User Dashboard
* Search Function Test: Verifies that entering a keyword in the search bar returns a list of projects containing that keyword.
* Empty Result Test: Confirms that a message is displayed when no projects match the search criteria.
* Performance Test: Ensures that the search functionality returns results within 2 seconds under typical load conditions.

Fix Memory Leak in Data Processing Module
* Memory Usage Test: Monitors memory usage during data processing to ensure that no unexpected memory growth occurs.
* Regression Test: Confirms that the data processing outputs remain consistent with previous versions post-fix.
* Stress Test: Executes the data processing module under high load to validate stability improvements.
-->

### Reminders (if applicable)

- [ ] I ran `pnpm install` and `pnpm test` in the root of the monorepo
      (optionally with `--filter=...package...` to exclude non-affected
      projects)
- [ ] I ran `pnpm changeset` in the root of the monorepo
- [ ] Test coverage has not decreased
- [ ] Docs have been updated to reflect changes in PR (don't forget
      docs.kadena.io)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207469215063343