### PR TITLE
Aditional documentation

### DIFF
--- a/packages/apps/graph/generated-schema.graphql
+++ b/packages/apps/graph/generated-schema.graphql
@@ -403,6 +403,8 @@ type Query {
 
     """Default: all chains"""
     chainIds: [String!]
+
+    """Retrieve blocks from completed heights only. Default: true"""
     completedHeights: Boolean = true
     first: Int
     heightCount: Int = 3

--- a/packages/apps/graph/src/devnet/deployment/marmalade/config/namespaces.ts
+++ b/packages/apps/graph/src/devnet/deployment/marmalade/config/namespaces.ts
@@ -3,6 +3,7 @@ export interface IMarmaladeNamespaceConfig {
   namespaces: string[];
 }
 
+// Note: the order of these matters - the first file is the first to be processed and so on
 export const marmaladeNamespaceConfig: IMarmaladeNamespaceConfig[] = [
   {
     file: 'ns-marmalade.pact',

--- a/packages/apps/graph/src/devnet/deployment/marmalade/namespace.ts
+++ b/packages/apps/graph/src/devnet/deployment/marmalade/namespace.ts
@@ -45,6 +45,8 @@ export async function deployMarmamaladeNamespaces({
     await Promise.all(
       config.namespaces.map(async (namespace) => {
         let keysets;
+        /* The keysets for each file are hardcoded here for the ns-contract-admin and fungible-util files
+        By default they will be marmalade-admin and marmalade-user */
         if (config.file === 'ns-contract-admin.pact') {
           keysets = [
             {

--- a/packages/apps/graph/src/graph/query/completed-block-heights.ts
+++ b/packages/apps/graph/src/graph/query/completed-block-heights.ts
@@ -11,6 +11,8 @@ builder.queryField('completedBlockHeights', (t) =>
       'Retrieve all completed blocks from a given height. Default page size is 20.',
     args: {
       completedHeights: t.arg.boolean({
+        description:
+          'Retrieve blocks from completed heights only. Default: true',
         required: false,
         defaultValue: true,
       }),

--- a/packages/apps/graph/src/graph/query/events.ts
+++ b/packages/apps/graph/src/graph/query/events.ts
@@ -61,8 +61,6 @@ const generateEventsFilter = async (args: {
       ),
     }),
     ...((args.minHeight || args.maxHeight) && conditionsForHeight(args)),
-    // ...(args.minHeight && { height: { gte: args.minHeight } }),
-    // ...(args.maxHeight && { height: { lte: args.maxHeight } }),
   };
 };
 


### PR DESCRIPTION
### Modify this title

Related Issue/Asana ticket: \_

Short description: \_

<!--
Examples:

Title: Add Search Functionality to User Dashboard.
Related Issue: #1234
Short Description:
Implements a new search bar in the user dashboard to allow quick navigation and filtering of project lists based on user input. This feature enhances user experience by providing a more efficient way to locate specific projects.

Title: Fix Memory Leak in Data Processing Module.
Asana ticket: https://app.asana.com/0/1205801361945248/1207389790540430
Short Description:
Resolves a critical memory leak occurring in the data processing module when handling large datasets. This fix improves system stability and performance under heavy load conditions.
-->

### Test scenarios

- description of the (manually) executed test scenarios

<!--
Examples:

Add Search Functionality to User Dashboard
* Search Function Test: Verifies that entering a keyword in the search bar returns a list of projects containing that keyword.
* Empty Result Test: Confirms that a message is displayed when no projects match the search criteria.
* Performance Test: Ensures that the search functionality returns results within 2 seconds under typical load conditions.

Fix Memory Leak in Data Processing Module
* Memory Usage Test: Monitors memory usage during data processing to ensure that no unexpected memory growth occurs.
* Regression Test: Confirms that the data processing outputs remain consistent with previous versions post-fix.
* Stress Test: Executes the data processing module under high load to validate stability improvements.
-->

### Reminders (if applicable)

- [ ] I ran `pnpm install` and `pnpm test` in the root of the monorepo
      (optionally with `--filter=...package...` to exclude non-affected
      projects)
- [ ] I ran `pnpm changeset` in the root of the monorepo
- [ ] Test coverage has not decreased
- [ ] Docs have been updated to reflect changes in PR (don't forget
      docs.kadena.io)
