### PR TITLE
FEAT: Enable blob reporter and merging reports

### DIFF
--- a/.github/actions/merge-publish-reports/action.yaml
+++ b/.github/actions/merge-publish-reports/action.yaml
@@ -1,0 +1,41 @@
+name: 'Merge & Publish Reports'
+inputs:
+inputs:
+  GITHUB_TOKEN:
+      description: 'Github Token'
+      required: true
+  REPORT_DIR:
+      description: 'Directory in which the test report is stored'
+      required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Download blob reports from GitHub Actions Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: all-blob-reports
+        pattern: blob-report-*
+        merge-multiple: true
+
+    - name: Merge into HTML Report
+      run: pnpm dlx playwright merge-reports --reporter html ./all-blob-reports
+  
+     - name: Create timestamp
+       shell: bash
+       if: ${{ !cancelled() }}
+       id : timestamp
+       run: echo "timestamp=$(date --utc +%Y%m%d_%H%M%SZ)" >> "$GITHUB_OUTPUT"
+
+     - name: Publish E2E Report
+       if: ${{ !cancelled() }}
+       uses: peaceiris/actions-gh-pages@v4
+       with:
+          github_token: ${{ inputs.GITHUB_TOKEN }}
+          publish_dir: ${{ inputs.REPORT_DIR }} # from what folder to take files. It takes only contents
+          destination_dir: ${{ github.event.number }}/${{ steps.timestamp.outputs.timestamp }}
+      
+      - name: Add Link to Summary
+        shell: bash
+        if: ${{ !cancelled() }}
+        run: echo "### E2E Report - https://${{ github.repository_owner }}.github.io/kadena.js/${{ github.event.number }}/${{ steps.timestamp.outputs.timestamp }}/" >> $GITHUB_STEP_SUMMARY
+  

--- a/.github/actions/merge-publish-reports/action.yaml
+++ b/.github/actions/merge-publish-reports/action.yaml
@@ -1,6 +1,5 @@
 name: 'Merge & Publish Reports'
 inputs:
-inputs:
   GITHUB_TOKEN:
       description: 'Github Token'
       required: true
@@ -18,24 +17,25 @@ runs:
         merge-multiple: true
 
     - name: Merge into HTML Report
+      shell: bash
       run: pnpm dlx playwright merge-reports --reporter html ./all-blob-reports
   
-     - name: Create timestamp
-       shell: bash
-       if: ${{ !cancelled() }}
-       id : timestamp
-       run: echo "timestamp=$(date --utc +%Y%m%d_%H%M%SZ)" >> "$GITHUB_OUTPUT"
+    - name: Create timestamp
+      shell: bash
+      if: ${{ !cancelled() }}
+      id : timestamp
+      run: echo "timestamp=$(date --utc +%Y%m%d_%H%M%SZ)" >> "$GITHUB_OUTPUT"
 
-     - name: Publish E2E Report
-       if: ${{ !cancelled() }}
-       uses: peaceiris/actions-gh-pages@v4
-       with:
-          github_token: ${{ inputs.GITHUB_TOKEN }}
-          publish_dir: ${{ inputs.REPORT_DIR }} # from what folder to take files. It takes only contents
-          destination_dir: ${{ github.event.number }}/${{ steps.timestamp.outputs.timestamp }}
+    - name: Publish E2E Report
+      if: ${{ !cancelled() }}
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ inputs.GITHUB_TOKEN }}
+        publish_dir: ${{ inputs.REPORT_DIR }} # from what folder to take files. It takes only contents
+        destination_dir: ${{ github.event.number }}/${{ steps.timestamp.outputs.timestamp }}
       
-      - name: Add Link to Summary
-        shell: bash
-        if: ${{ !cancelled() }}
-        run: echo "### E2E Report - https://${{ github.repository_owner }}.github.io/kadena.js/${{ github.event.number }}/${{ steps.timestamp.outputs.timestamp }}/" >> $GITHUB_STEP_SUMMARY
+    - name: Add Link to Summary
+      shell: bash
+      if: ${{ !cancelled() }}
+      run: echo "### E2E Report - https://${{ github.repository_owner }}.github.io/kadena.js/${{ github.event.number }}/${{ steps.timestamp.outputs.timestamp }}/" >> $GITHUB_STEP_SUMMARY
   

--- a/.github/actions/merge-publish-reports/action.yaml
+++ b/.github/actions/merge-publish-reports/action.yaml
@@ -28,7 +28,7 @@ runs:
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ inputs.GITHUB_TOKEN }}
-        publish_dir: playwright-report/
+        publish_dir: playwright-report
         destination_dir: ${{ github.event.number }}/${{ steps.timestamp.outputs.timestamp }}
       
     - name: Add Link to Summary

--- a/.github/actions/merge-publish-reports/action.yaml
+++ b/.github/actions/merge-publish-reports/action.yaml
@@ -3,9 +3,6 @@ inputs:
   GITHUB_TOKEN:
       description: 'Github Token'
       required: true
-  REPORT_DIR:
-      description: 'Directory in which the test report is stored'
-      required: true
 runs:
   using: 'composite'
   steps:
@@ -31,7 +28,7 @@ runs:
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ inputs.GITHUB_TOKEN }}
-        publish_dir: ${{ inputs.REPORT_DIR }} # from what folder to take files. It takes only contents
+        publish_dir: ./playwright-report/ # from what folder to take files. It takes only contents
         destination_dir: ${{ github.event.number }}/${{ steps.timestamp.outputs.timestamp }}
       
     - name: Add Link to Summary

--- a/.github/actions/merge-publish-reports/action.yaml
+++ b/.github/actions/merge-publish-reports/action.yaml
@@ -28,7 +28,7 @@ runs:
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ inputs.GITHUB_TOKEN }}
-        publish_dir: ./playwright-report/ # from what folder to take files. It takes only contents
+        publish_dir: playwright-report/
         destination_dir: ${{ github.event.number }}/${{ steps.timestamp.outputs.timestamp }}
       
     - name: Add Link to Summary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       with:
           fetch-depth: 2
           show-progress: false
-          
+
     -  name: Runner Setup
        uses: ./.github/actions/runner-setup  
 
@@ -146,7 +146,7 @@ jobs:
         merge-multiple: true
 
     - name: Merge into HTML Report
-      run: npx playwright merge-reports --reporter html ./all-blob-reports
+      run: pnpm dlx playwright merge-reports --reporter html ./all-blob-reports
 
     - name: Upload HTML report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,12 +115,39 @@ jobs:
         with:
           test-object: ${{ matrix.app }}
 
-      - uses: actions/upload-artifact@v4
-        if: always()
+      - name: Upload Blob Report  
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
         with:
-          name: playwright-report-${{ matrix.app }}
-          path: packages/e2e/e2e-${{ matrix.app }}/playwright-report/
-          retention-days: 30
+          name: blob-report-${{ matrix.app }}
+          path: packages/e2e/e2e-${{ matrix.app }}/blob-report/
+          retention-days: 1
+
+  merge-reports:
+    if: ${{ !cancelled() }}
+    needs: [end-to-end-tests]
+
+    runs-on: ubuntu-latest
+    steps:
+    -  name: Runner Setup
+       uses: ./.github/actions/runner-setup  
+
+    - name: Download blob reports from GitHub Actions Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: all-blob-reports
+        pattern: blob-report-*
+        merge-multiple: true
+
+    - name: Merge into HTML Report
+      run: npx playwright merge-reports --reporter html ./all-blob-reports
+
+    - name: Upload HTML report
+      uses: actions/upload-artifact@v4
+      with:
+        name: end-to-end-test-report
+        path: playwright-report
+        retention-days: 14
 
   ci-gate:
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,6 @@ jobs:
       with:
         path: all-blob-reports
         pattern: blob-report-*
-        merge-multiple: true
 
     - name: Merge into HTML Report
       run: pnpm dlx playwright merge-reports --reporter html ./all-blob-reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
     
     - name: Merge & Publish Report
       uses: ./.github/actions/merge-publish-reports
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
 
   ci-gate:
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI (build, lint, test)
 # All pull requests, and
 # Workflow dispatch allows you to run this workflow manually from the Actions tab
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,12 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
+
+    - uses: actions/checkout@v4
+      with:
+          fetch-depth: 2
+          show-progress: false
+          
     -  name: Runner Setup
        uses: ./.github/actions/runner-setup  
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           path: packages/e2e/e2e-${{ matrix.app }}/blob-report/
           retention-days: 1
 
-  merge-reports:
+  merge-publish-reports:
     if: ${{ !cancelled() }}
     needs: [end-to-end-tests]
 
@@ -136,27 +136,10 @@ jobs:
           show-progress: false
 
     -  name: Runner Setup
-       uses: ./.github/actions/runner-setup  
-
-    - name: Download blob reports from GitHub Actions Artifacts
-      uses: actions/download-artifact@v4
-      with:
-        path: all-blob-reports
-        pattern: blob-report-*
-        merge-multiple: true
+       uses: ./.github/actions/runner-setup 
     
-    - name: Display structure of downloaded files
-      run: ls -R all-blob-reports
-
-    - name: Merge into HTML Report
-      run: pnpm dlx playwright merge-reports --reporter html ./all-blob-reports
-
-    - name: Upload HTML report
-      uses: actions/upload-artifact@v4
-      with:
-        name: end-to-end-test-report
-        path: playwright-report
-        retention-days: 14
+    - name: Merge & Publish Report
+      uses: ./.github/actions/merge-publish-reports
 
   ci-gate:
     if: always()
@@ -164,6 +147,7 @@ jobs:
       - build
       - integration-tests
       - end-to-end-tests
+      - merge-publish-reports
     runs-on: Ubuntu-latest
     steps:
       - name: Check required jobs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,10 @@ jobs:
       with:
         path: all-blob-reports
         pattern: blob-report-*
+        merge-multiple: true
+    
+    - name: Display structure of downloaded files
+      run: ls -R all-blob-reports
 
     - name: Merge into HTML Report
       run: pnpm dlx playwright merge-reports --reporter html ./all-blob-reports

--- a/.github/workflows/report-cleanup.yaml
+++ b/.github/workflows/report-cleanup.yaml
@@ -1,0 +1,30 @@
+name: Prune old E2E Reports
+
+on:
+ workflow_dispatch:
+ schedule:
+    - cron: "0 0 * * 6"   # Every Saturday around midnight
+  
+
+jobs:
+  delete_old_reports:
+    runs-on: ubuntu-latest
+    permissions:
+        contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: 
+          ref: gh-pages
+
+      - name: Run Cleanup
+        run: |
+         chmod +x ./cleanup.sh
+         ./cleanup.sh
+
+      - name: Commit all changed files back to the repository
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: gh-pages
+          commit_message: Delete folders older than 30 days

--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ temp
 #Playwright
 /packages/*/*/test-results
 /packages/*/*/playwright-report
-
+/packages/*/*/blob-report
 # cache-sh
 .cache-sh
 

--- a/packages/e2e/e2e-base/playwright.config.ts
+++ b/packages/e2e/e2e-base/playwright.config.ts
@@ -10,10 +10,6 @@ export const baseConfig: PlaywrightTestConfig = {
   retries: process.env.CI !== undefined ? 1 : 0,
   workers: 1,
   reportSlowTests: null,
-  reporter:
-    process.env.CI !== undefined
-      ? [['list'], ['blob']]
-      : [['list'], ['html', { open: 'never' }]],
   use: {
     headless: process.env.CI !== undefined,
     baseURL: 'http://localhost:3000/',

--- a/packages/e2e/e2e-base/playwright.config.ts
+++ b/packages/e2e/e2e-base/playwright.config.ts
@@ -10,7 +10,10 @@ export const baseConfig: PlaywrightTestConfig = {
   retries: process.env.CI !== undefined ? 1 : 0,
   workers: 1,
   reportSlowTests: null,
-  reporter: [['list'], ['html', { open: 'never' }]],
+  reporter:
+    process.env.CI !== undefined
+      ? [['list'], ['blob']]
+      : [['list'], ['html', { open: 'never' }]],
   use: {
     headless: process.env.CI !== undefined,
     baseURL: 'http://localhost:3000/',

--- a/packages/e2e/e2e-docs/playwright.config.ts
+++ b/packages/e2e/e2e-docs/playwright.config.ts
@@ -5,7 +5,7 @@ const config: PlaywrightTestConfig = {
   ...baseConfig,
   reporter:
     process.env.CI !== undefined
-      ? [['list'], ['blob', {outputFile: 'blob-docs.zip'}]]
+      ? [['list'], ['blob', { outputFile: 'blob-docs.zip' }]]
       : [['list'], ['html', { open: 'never' }]],
   webServer: {
     command: `pnpm --filter @kadena/docs start`,

--- a/packages/e2e/e2e-docs/playwright.config.ts
+++ b/packages/e2e/e2e-docs/playwright.config.ts
@@ -5,7 +5,7 @@ const config: PlaywrightTestConfig = {
   ...baseConfig,
   reporter:
     process.env.CI !== undefined
-      ? [['list'], ['blob', { outputFile: 'blob-docs.zip' }]]
+      ? [['list'], ['blob', { outputFile: './blob-report/blob-docs.zip' }]]
       : [['list'], ['html', { open: 'never' }]],
   webServer: {
     command: `pnpm --filter @kadena/docs start`,

--- a/packages/e2e/e2e-docs/playwright.config.ts
+++ b/packages/e2e/e2e-docs/playwright.config.ts
@@ -3,6 +3,10 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   ...baseConfig,
+  reporter:
+    process.env.CI !== undefined
+      ? [['list'], ['blob', {outputFile: 'blob-docs.zip'}]]
+      : [['list'], ['html', { open: 'never' }]],
   webServer: {
     command: `pnpm --filter @kadena/docs start`,
     url: 'http://localhost:3000',

--- a/packages/e2e/e2e-graph/playwright.config.ts
+++ b/packages/e2e/e2e-graph/playwright.config.ts
@@ -3,6 +3,10 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   ...baseConfig,
+  reporter:
+    process.env.CI !== undefined
+      ? [['list'], ['blob', { outputFile: 'blob-graph.zip' }]]
+      : [['list'], ['html', { open: 'never' }]],
   webServer: {
     timeout: 90000,
     command: `pnpm --filter @kadena/graph start:generate`,

--- a/packages/e2e/e2e-graph/playwright.config.ts
+++ b/packages/e2e/e2e-graph/playwright.config.ts
@@ -5,7 +5,7 @@ const config: PlaywrightTestConfig = {
   ...baseConfig,
   reporter:
     process.env.CI !== undefined
-      ? [['list'], ['blob', { outputFile: 'blob-graph.zip' }]]
+      ? [['list'], ['blob', { outputFile: './blob-report/blob-graph.zip' }]]
       : [['list'], ['html', { open: 'never' }]],
   webServer: {
     timeout: 90000,

--- a/packages/e2e/e2e-proof-of-us/playwright.config.ts
+++ b/packages/e2e/e2e-proof-of-us/playwright.config.ts
@@ -4,6 +4,10 @@ import { devices } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   ...baseConfig,
+  reporter:
+    process.env.CI !== undefined
+      ? [['list'], ['blob', { outputFile: 'blob-pou.zip' }]]
+      : [['list'], ['html', { open: 'never' }]],
   timeout: 1800000,
   projects: [
     {

--- a/packages/e2e/e2e-proof-of-us/playwright.config.ts
+++ b/packages/e2e/e2e-proof-of-us/playwright.config.ts
@@ -6,7 +6,7 @@ const config: PlaywrightTestConfig = {
   ...baseConfig,
   reporter:
     process.env.CI !== undefined
-      ? [['list'], ['blob', { outputFile: 'blob-pou.zip' }]]
+      ? [['list'], ['blob', { outputFile: './blob-report/blob-pou.zip' }]]
       : [['list'], ['html', { open: 'never' }]],
   timeout: 1800000,
   projects: [

--- a/packages/e2e/e2e-tools/playwright.config.ts
+++ b/packages/e2e/e2e-tools/playwright.config.ts
@@ -23,7 +23,7 @@ const config: PlaywrightTestConfig = {
       testDir: 'tests',
       dependencies: ['setup'],
       use: {
-        storageState: './setup/storageState.json',  
+        storageState: './setup/storageState.json',
       },
     },
   ],

--- a/packages/e2e/e2e-tools/playwright.config.ts
+++ b/packages/e2e/e2e-tools/playwright.config.ts
@@ -3,6 +3,10 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   ...baseConfig,
+  reporter:
+    process.env.CI !== undefined
+      ? [['list'], ['blob', { outputFile: 'blob-tools.zip' }]]
+      : [['list'], ['html', { open: 'never' }]],
   webServer: {
     command: `pnpm --filter @kadena/tools start`,
     url: 'http://localhost:3000',

--- a/packages/e2e/e2e-tools/playwright.config.ts
+++ b/packages/e2e/e2e-tools/playwright.config.ts
@@ -23,7 +23,7 @@ const config: PlaywrightTestConfig = {
       testDir: 'tests',
       dependencies: ['setup'],
       use: {
-        storageState: './setup/storageState.json',
+        storageState: './setup/storageState.json',  
       },
     },
   ],

--- a/packages/e2e/e2e-tools/playwright.config.ts
+++ b/packages/e2e/e2e-tools/playwright.config.ts
@@ -5,7 +5,7 @@ const config: PlaywrightTestConfig = {
   ...baseConfig,
   reporter:
     process.env.CI !== undefined
-      ? [['list'], ['blob', { outputFile: 'blob-tools.zip' }]]
+      ? [['list'], ['blob', { outoutputFile: './blob-report/blob-tools.zip' }]]
       : [['list'], ['html', { open: 'never' }]],
   webServer: {
     command: `pnpm --filter @kadena/tools start`,


### PR DESCRIPTION
### Merge Test Reports for various projects and publish them to GH pages.

Related Issue/Asana ticket: https://app.asana.com/0/1206316065856327/1207502644848065/f

Short description: \_
Prior to this PR, running end-to-end tests in CI would result in three separate HTML reports that would be added as artifacts to the run. Inspecting them meant downloading them individually and opening up the index.html.  This was considered tedious and slow.

This PR aims to resolve these barriers by essentially doing two things:

1. Add post processing, merging these three reports in to 1 report.
2. Publishing the merged HTML report to Github pages to make viewing it as easy as clicking the link.

Upon completion, the report link is added to the github summary 
![image](https://github.com/kadena-community/kadena.js/assets/72976986/659d189d-cb59-480d-b41a-4a7905fd10d4)
In case a testcase fails or is considered flaky, devs can directly open up the trace file from the report without having to manually upload it to trace.playwright.dev