### PR TITLE
fix(explorer): fix the tablinks in account

### DIFF
--- a/.changeset/early-apes-give.md
+++ b/.changeset/early-apes-give.md
@@ -1,0 +1,5 @@
+---
+'@kadena/explorer': patch
+---
+
+fix the account tabs links

--- a/packages/apps/explorer/src/components/routing/useRouter.tsx
+++ b/packages/apps/explorer/src/components/routing/useRouter.tsx
@@ -15,5 +15,5 @@ export const useRouter = () => {
 
   const asPath = removeNetworkFromPath(router.asPath, networks);
 
-  return { ...router, replace, push, asPath };
+  return { ...router, replace, push, asPath, activeNetwork };
 };

--- a/packages/apps/explorer/src/pages/[networkId]/account/[accountName].tsx
+++ b/packages/apps/explorer/src/pages/[networkId]/account/[accountName].tsx
@@ -70,7 +70,8 @@ const Account: FC = () => {
 
     const regExp = new RegExp(/[?#].*/);
 
-    const newUrl = `${router.asPath.replace(regExp, '')}#${tab}`;
+    const newUrl = `/${router.activeNetwork.networkId}${router.asPath.replace(regExp, '')}#${tab}`;
+
     window.history.replaceState(
       { ...window.history.state, as: newUrl, url: newUrl },
       '',

--- a/packages/apps/explorer/src/pages/index.tsx
+++ b/packages/apps/explorer/src/pages/index.tsx
@@ -7,6 +7,15 @@ const Home: React.FC = () => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const DEFAULTNETWORKID = 'mainnet01';
+  if (!ctx.req.headers.cookie) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: `/${DEFAULTNETWORKID}`,
+      },
+    };
+  }
   const cookieValues = ctx.req.headers
     .cookie!.split(';')
     .reduce<Record<string, { key: string; value: string }>>((acc, val) => {
@@ -18,7 +27,9 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
       return acc;
     }, {});
 
-  const network = cookieValues[selectedNetworkKey] ?? { value: 'mainnet01' };
+  const network = cookieValues[selectedNetworkKey] ?? {
+    value: DEFAULTNETWORKID,
+  };
 
   return {
     redirect: {


### PR DESCRIPTION
there was an issue on account page. when you clicked the tabs the networkid would be removed from the url