### PR TITLE
ag/graph/fix bug retrieving transfers

### DIFF
--- a/.changeset/unlucky-llamas-ring.md
+++ b/.changeset/unlucky-llamas-ring.md
@@ -1,0 +1,5 @@
+---
+'@kadena/graph': patch
+---
+
+Fix issues with performance of Graph queries on fungibleAccount.transfers

--- a/packages/apps/graph/generated-schema.graphql
+++ b/packages/apps/graph/generated-schema.graphql
@@ -481,7 +481,10 @@ type Query {
   """
   transaction(blockHash: String, minimumDepth: Int, requestKey: String!): Transaction
 
-  """Retrieve transactions. Default page size is 20."""
+  """
+  Retrieve transactions. Default page size is 20.
+   At least one of accountName, fungibleName, blockHash, or requestKey must be provided.
+  """
   transactions(accountName: String, after: String, before: String, blockHash: String, chainId: String, first: Int, fungibleName: String, last: Int, maxHeight: Int, minHeight: Int, minimumDepth: Int, requestKey: String): QueryTransactionsConnection!
 
   """Retrieve all transactions by a given public key."""

--- a/packages/apps/graph/src/graph/objects/fungible-account.ts
+++ b/packages/apps/graph/src/graph/objects/fungible-account.ts
@@ -167,19 +167,12 @@ export default builder.node(
               await Promise.all([
                 await prismaClient.transfer.count({
                   where: {
-                    senderAccount: parent.accountName,
-                    // NOT: {
-                    //   receiverAccount: parent.accountName,
-                    // },
-                    moduleName: parent.fungibleName,
-                  },
-                }),
-                await prismaClient.transfer.count({
-                  where: {
-                    receiverAccount: parent.accountName,
-                    // NOT: {
-                    //   senderAccount: parent.accountName,
-                    // },
+                    OR: [
+                      { senderAccount: parent.accountName },
+                      {
+                        receiverAccount: parent.accountName,
+                      },
+                    ],
                     moduleName: parent.fungibleName,
                   },
                 }),
@@ -197,7 +190,7 @@ export default builder.node(
                 await prismaClient.transfer.findMany({
                   ...condition,
                   where: {
-                    receiverAccount: parent.accountName,
+                    senderAccount: parent.accountName,
                     NOT: {
                       receiverAccount: parent.accountName,
                     },

--- a/packages/apps/graph/src/graph/query/transactions.ts
+++ b/packages/apps/graph/src/graph/query/transactions.ts
@@ -62,7 +62,8 @@ const generateTransactionFilter = async (args: {
 
 builder.queryField('transactions', (t) =>
   t.prismaConnection({
-    description: 'Retrieve transactions. Default page size is 20.',
+    description:
+      'Retrieve transactions. Default page size is 20.\n At least one of accountName, fungibleName, blockHash, or requestKey must be provided.',
     type: Prisma.ModelName.Transaction,
     cursor: 'blockHash_requestKey',
     edgesNullable: false,
@@ -162,6 +163,23 @@ builder.queryField('transactions', (t) =>
             },
           ]);
         }
+
+        if (
+          stringNullOrEmpty(args.accountName) &&
+          stringNullOrEmpty(args.fungibleName) &&
+          stringNullOrEmpty(args.blockHash) &&
+          stringNullOrEmpty(args.requestKey)
+        ) {
+          throw new ZodError([
+            {
+              code: 'custom',
+              message:
+                'At least one of accountName, fungibleName, blockHash, or requestKey must be provided',
+              path: ['transactions'],
+            },
+          ]);
+        }
+
         let transactions: Transaction[] = [];
         let skip = 0;
         const take = query.take;

--- a/packages/apps/graph/src/graph/query/transactions.ts
+++ b/packages/apps/graph/src/graph/query/transactions.ts
@@ -119,6 +119,25 @@ builder.queryField('transactions', (t) =>
       }),
     }),
     async totalCount(__parent, args) {
+      // at least one of these should be in the args
+      // accountName && fungibleName
+      // blockHash
+      // requestKey
+      if (
+        stringNullOrEmpty(args.accountName) &&
+        stringNullOrEmpty(args.fungibleName) &&
+        stringNullOrEmpty(args.blockHash) &&
+        stringNullOrEmpty(args.requestKey)
+      ) {
+        throw new ZodError([
+          {
+            code: 'custom',
+            message:
+              'At least one of accountName, fungibleName, blockHash, or requestKey must be provided',
+            path: ['transactions'],
+          },
+        ]);
+      }
       try {
         return prismaClient.transaction.count({
           where: await generateTransactionFilter(args),
@@ -190,3 +209,7 @@ builder.queryField('transactions', (t) =>
     },
   }),
 );
+
+function stringNullOrEmpty(s: string | null | undefined): boolean {
+  return s === null || s === undefined || s === '';
+}


### PR DESCRIPTION
- fix(graph): bug where transactions weren't filtered correctly. Force that at least one of accountName, fungibleName, blockHash, or requestKey must be provided
- fix(graph): bug where transactions weren't filtered correctly. Force that at least one of accountName, fungibleName, blockHash, or requestKey must be provided
