### PR TITLE
[docs] Chainweb API - Move data models and binary encoding into main docs

### DIFF
--- a/packages/apps/docs/src/docs/reference/chainweb/chainweb-data-models.md
+++ b/packages/apps/docs/src/docs/reference/chainweb/chainweb-data-models.md
@@ -1,0 +1,269 @@
+---
+title: Data models
+description:
+  Summarizes the data models used for different elements and attributes in Chainweb nodes.
+menu: Chainweb API
+label: Data models
+order: 2
+layout: full
+tags: ['chainweb', 'node api', 'chainweb api', 'api reference']
+---
+
+# Data models
+
+Data models summarize the parameters that define important Chainweb node elements.
+The information in the data models is the same as the information covered in the endpoint documentation.
+It's duplicated here as a quick reference.
+
+## Cut model
+
+| Parameter | Type | Description
+| --------- | ---- | -----------
+| origin | object | Defines a peer information object that consists of an `id` string and an `address` object. The `origin` parameter is required to use the `PUT /cut` endpoint. For more information, see the [Peer information](#peer-information-modelh-1716301923) data model.
+| height (required) | integer&nbsp;>=&nbsp;0 | Defines the cut height. The cut height is the sum of the height of all blocks of the cut. You should avoid using this value in any applications or tools because its semantics might change.
+| weight (required) | string | Defines the cut weight. The cut weight is the sum of the weights from all of the blocks included in the cut. The weight string consists of 43 characters from the [a-zA-Z0-9_-] character set.
+| hashes (required) | object | Defines an object that maps chain identifiers to their respective block `hash` and block `height`. The block `hash` property is a required string value with characters from the [a-zA-Z0-9_-] character set. The block `height` property is a required integer value >= 0. The `hashes` object includes the `height` and `hash` properties for each chain, as illustrated for chains 0 and 1 in the truncated JSON example.
+| instance | string | Defines the network identifier for the cut.
+| id | string | Defines a cut identifier.
+
+```json
+{
+  "origin": null,
+  "height": 30798466,
+  "weight": "b0wYplmNiTBXCwAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "hashes": {
+    "0": {
+      "height": 1539923,
+      "hash": "qEaSmWt_tDcJC9AGbgWY9x12LW5VED7hGgfyz9x_S3w"
+    },
+    "1": {
+      "height": 1539923,
+      "hash": "TJuC6nfhamfD517gspAZmqD9umR71nAgttDOi1JbBHw"
+    },
+  },
+  "id": "BBz7KeurYTeQ0hMGbwUbQC84cRbVcacoDQTye-3qkXI",
+  "instance": "mainnet01"
+}
+```
+
+## Block header model
+
+| Parameter | Type | Description
+| --------- | ---- | -----------
+| creationTime (required) | integer&nbsp;>=&nbsp;0 | Records the time the block was created. This timestamp is in microseconds since the start of the UNIX epoch.
+| parent (required) | string | Records the parent block hash. The block hash is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set.
+| height (required) | integer >= 0 | Identifies the block height for the block. The height of a block is the number of its predecessors in the block chain.
+| hash (required) | string | Block hash is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set.
+| chainId (required) | integer >= 0 | Specifies the Chainweb chain identifier. In Kadena, Chainweb chains are named by numbers starting from 0. Valid values depend on the current graph at the respective block height of the Chainweb version.
+| weight (required) | string | Specifies the block weight for the block. Block weight is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set. The weight of a block is the sum of the difficulties of the block and of all of its ancestors. The difficulty of a block is the maximum difficulty divided by the target. The string is a 256-bit little endian encoding of the numerical value.
+| featureFlags (required) | integer | Specifies a reserved value that must be 0.
+| epochStart (required) | integer >= 0 | Specifies a timestamp in microseconds since the start of the UNIX epoch.
+| adjacents (required) | object | Records the block hashes of the adjacent parents of the block. This is represented as an associative array that maps the adjacent chain ids to the respective block hash. Each block hash is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set.
+| payloadHash (required) | string | Specifies the block payload hash. The payload hash is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set.
+| chainwebVersion (required) | enum | Specifies the Chainweb network version identifier for the Kadena network. The valid values are "test-singleton", "development", "mainnet01", and "testnet04".
+| target (required) | string | Specifies the proof-of-work target for the block. The proof-of-work target for a block is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set. The string is a 256-bit little endian encoding of the numerical value.
+| nonce (required) | string non-empty [0-9]+ | Specifies the proof-of-work nonce for the block. This value is computed by the miner such that the block hash is smaller than the target.
+
+```json
+{
+  "creationTime": 1721071750065287,
+  "nonce": "16462985723698616006",
+  "parent": "g-N8bZuyno0rkPyJZShFQzU5Den2rey1qlflnJuizzQ",
+  "adjacents": {
+      "19": "YlpdztdOQ-ChRklldcC2oHbZlAMIiYAGRgzTZBXvRgY",
+      "14": "VosxlCQP8q0cPi3zd_yD_099Untb69bnIgIFlAioj9I",
+      "9": "GXv0fxVXgDQTtRTxMjWfr6JXXrSscoaCaxEDPC93QIg"
+  },
+  "target": "ikpunXJe5dbyqNaNMDhOWhBtJeLpVENWFQAAAAAAAAA",
+  "payloadHash": "bVqvJPaU98NLqPCMmaBy2v67XnzFi6c1Ei6NLZjZVvI",
+  "chainId": 4,
+  "weight": "FahB1Biuxv0BSQEAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  "height": 4953816,
+  "chainwebVersion": "mainnet01",
+  "epochStart": 1721068523032689,
+  "featureFlags": 0,
+  "hash": "tsFkxqNHy_WbdnDDTumV_2MFjMQTyJrzb8--dO3kjjM"
+},
+```
+
+## Payload model
+
+| Parameter | Type | Description
+| --------- | ---- | -----------
+| transactions (required) | Array of strings | Array of Base64Url encoded strings without padding that represent signed Pact transactions in JSON format.
+| minerData (required) | string [a-zA-Z0-9_-]+ | Miner information is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set. This information is included as part of the payload in the JSON object.
+| transactionsHash (required) | string | The transaction hash is a SHA256 hash. The hash is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set.
+| outputsHash (required) | string | The output hash is a SHA256 hash. The hash is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set.
+| payloadHash (required) | string | The block payload hash is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set.
+
+```json
+{
+  "transactions": [
+    "eyJoYXNoIjoiMi16Q3dmRFZZR010WHljd2pTLXRlNzh5U3l3T3JXcjNSdUhiQlJnNDdhRSIsInNpZ3MiOlt7InNpZyI6ImZiMTVkNzkyYTNkNDM1MDI5ODJmOGQ1MGUyMzA1NTI5OWEwZjdhMWRmMWE4YjUyMmE5NTMxNWUyZDljY2MyNmE1MzI4M2I5YTNhNDM5ZWE0ZGY4MGM1ZTIwMjg4NDhjNjFhMWY0MGM5OWIyOTYzOWM0NGNkYTgwMzBmYmViYjBjIn1dLCJjbWQiOiJ7XCJuZXR3b3JrSWRcIjpcIm1haW5uZXQwMVwiLFwicGF5bG9hZFwiOntcImV4ZWNcIjp7XCJkYXRhXCI6e30sXCJjb2RlXCI6XCIoY29pbi50cmFuc2ZlciBcXFwiZTc1NzU4ZGQyYTFjNTk2NDRjMjJlMDQyYzZlYzA3NTI2ZWE0ZTU3MTU0ZjlkYmMyMDc2ZThhODRhYzE5NGYzMlxcXCIgXFxcIjQ2NzdhMDllYTE2MDJlNGUwOWZlMDFlYjExOTZjZjQ3YzBmNDRhYTQ0YWFjOTAzZDVmNjFiZTdkYTM0MjUxMjhcXFwiIDMuNzc2KVwifX0sXCJzaWduZXJzXCI6W3tcInB1YktleVwiOlwiZTc1NzU4ZGQyYTFjNTk2NDRjMjJlMDQyYzZlYzA3NTI2ZWE0ZTU3MTU0ZjlkYmMyMDc2ZThhODRhYzE5NGYzMlwiLFwiY2xpc3RcIjpbe1wiYXJnc1wiOltdLFwibmFtZVwiOlwiY29pbi5HQVNcIn0se1wiYXJnc1wiOltcImU3NTc1OGRkMmExYzU5NjQ0YzIyZTA0MmM2ZWMwNzUyNmVhNGU1NzE1NGY5ZGJjMjA3NmU4YTg0YWMxOTRmMzJcIixcIjQ2NzdhMDllYTE2MDJlNGUwOWZlMDFlYjExOTZjZjQ3YzBmNDRhYTQ0YWFjOTAzZDVmNjFiZTdkYTM0MjUxMjhcIiwzLjc3Nl0sXCJuYW1lXCI6XCJjb2luLlRSQU5TRkVSXCJ9XX1dLFwibWV0YVwiOntcImNyZWF0aW9uVGltZVwiOjE2MDIzODI4MTQsXCJ0dGxcIjoyODgwMCxcImdhc0xpbWl0XCI6NjAwLFwiY2hhaW5JZFwiOlwiMFwiLFwiZ2FzUHJpY2VcIjoxLjBlLTUsXCJzZW5kZXJcIjpcImU3NTc1OGRkMmExYzU5NjQ0YzIyZTA0MmM2ZWMwNzUyNmVhNGU1NzE1NGY5ZGJjMjA3NmU4YTg0YWMxOTRmMzJcIn0sXCJub25jZVwiOlwiXFxcIjIwMjAtMTAtMTFUMDI6MjE6MTQuMTk0WlxcXCJcIn0ifQ"
+  ],
+  "minerData": "eyJhY2NvdW50IjoiYTFiMzE0MGNiN2NjODk1YzBlMDkxNzAyZWQwNTU3OWZiZTA1YzZlNjc0NWY4MmNlNjAzNzQ2YjQwMGM4MTU0OCIsInByZWRpY2F0ZSI6ImtleXMtYWxsIiwicHVibGljLWtleXMiOlsiYTFiMzE0MGNiN2NjODk1YzBlMDkxNzAyZWQwNTU3OWZiZTA1YzZlNjc0NWY4MmNlNjAzNzQ2YjQwMGM4MTU0OCJdfQ",
+  "transactionsHash": "lWcQRlj3MV7FSem8P4G-8GMRf1-O7zQqi_AwmWnk-N0",
+  "outputsHash": "9BzXZbhjSSevp4K0bYFqi1GdLjeX_DB-4u1T5Em8abs",
+  "payloadHash": "jcQOWz7K9qKnkUv4Z883D2ZjkFFGgccoSroWGaoogLM"
+}
+```
+
+## Payload with outputs model
+
+| Parameter | Type | Description
+| --------- | ---- | -----------
+| transactions (required) | Array of strings | Array with pairs of strings that represent transactions and their outputs. Signed Pact transactions and their outputs are both Base64Url-encoded strings—without padding—that represent signed Pact transactions in JSON format.
+| minerData (required) | string | Miner information is a Base64Url-encoded string—without padding—that consists of characters from the [a-zA-Z0-9_-] character set. This information is included as part of the payload JSON object.
+| transactionsHash (required) | string | The transaction hash is a SHA256 hash. The hash is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set.
+| outputsHash (required) | string | The output hash is a SHA256 hash. The hash is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set.
+| payloadHash (required) | string | The block payload hash is a Base64Url-encoded string—without padding—that consists of 43 characters from the [a-zA-Z0-9_-] character set.
+| coinbase (required) | string | Coinbase output is a Base64Url-encoded string—without padding—that consists of characters from the [a-zA-Z0-9_-] character set. This information is included as part of the payload output JSON object.
+
+
+```json
+{
+  "transactions": [],
+  "minerData": "eyJhY2NvdW50IjoiYTFiMzE0MGNiN2NjODk1YzBlMDkxNzAyZWQwNTU3OWZiZTA1YzZlNjc0NWY4MmNlNjAzNzQ2YjQwMGM4MTU0OCIsInByZWRpY2F0ZSI6ImtleXMtYWxsIiwicHVibGljLWtleXMiOlsiYTFiMzE0MGNiN2NjODk1YzBlMDkxNzAyZWQwNTU3OWZiZTA1YzZlNjc0NWY4MmNlNjAzNzQ2YjQwMGM4MTU0OCJdfQ",
+  "transactionsHash": "nT0j4xw2woMkdXXaopdurXIn24OG-jNMqQzUGfxV_MA",
+  "outputsHash": "4pXRrZ2K0_V0iGAxQCKrKdLjQTBZHBOQS7P-47kdnhY",
+  "payloadHash": "GpaWbHkHrCjRhY8hKE0qZ1WsBBaG3Y_zkFLV2sYumQA",
+  "coinbase": "eyJnYXMiOjAsInJlc3VsdCI6eyJzdGF0dXMiOiJzdWNjZXNzIiwiZGF0YSI6IldyaXRlIHN1Y2NlZWRlZCJ9LCJyZXFLZXkiOiJJa2hoV0VGQ2NURlFTMU5MYkdodVkwcHJNRjlOZERjMVgyeE1OMDVUTTNkSk5qSTNVV1pZV2w4NE5Xc2kiLCJsb2dzIjoiZ3Noak1kWFJrVGxKYmIxalZkQWJ6SVVDcGpQb1JBQ2pEbExzRzBXNkJEMCIsIm1ldGFEYXRhIjpudWxsLCJjb250aW51YXRpb24iOm51bGwsInR4SWQiOjEyNzIzNTB9"
+}
+```
+
+## Peer information model
+
+| Parameter | Type | Description
+| --------- | ---- | -----------
+| id (required) | string or null | The `id` is a Base64Url-encoded string—without padding—that consists of characters from the [a-zA-Z0-9_-] character set. This string represents the SHA256 fingerprint of the SSL certificate of the node. The field can be null only if the node uses an official CA-signed certificate.
+| address (required) | object | The `address` contains a `hostname` and `port` number. The `hostname` is a required string value in the form of a domain name, IPv4 IP address, or IPv6 IP address. The hostname must be a domain name only if the node uses a valid CA-signed SSL certificate. The `port` is a required integer value [1 .. 65535] that hosts the peer node.
+
+```json
+{
+  "address": {
+    "hostname": "85.238.99.91",
+    "port": 30004
+  },
+  "id": "PRLmVUcc9AH3fyfMYiWeC4nV2i1iHwc0-aM7iAO8h18"
+}
+```
+
+Note that it is generally easier to query the peer information for a node using a GET query for the peer database. 
+To get the Base64Url-encoded SHA256 fingerprint peer `id` for peers with self-signed certificates, run a command like this for the specified chainweb-node NODE:
+
+```bash
+echo |
+openssl s_client -showcerts -servername ${NODE} -connect ${NODE}:443 2>/dev/null |
+openssl x509 -fingerprint -noout -sha256 |
+sed 's/://g' |
+tail -c 65 |
+xxd -r -p |
+base64 |
+tr -d '=' |
+tr '/+' '_-'
+```
+
+For example, to get the peer id for a testnet bootstrap server:
+
+```bash
+echo |
+openssl s_client -showcerts -servername us-e1.chainweb.com  -connect us-e1.chainweb.com:443 2>/dev/null |
+openssl x509 -fingerprint -noout -sha256 |
+sed 's/://g' |
+tail -c 65 |
+xxd -r -p |
+base64 |
+tr -d '=' |
+tr '/+' '_-'
+```
+
+The output from running this command is the peer id:
+
+```bash
+vPELrRZEn3km96owfL0ANJbOBeeUGnEBOx0AGCTZsdA
+```
+
+## Chainweb node information model
+
+| Parameter | Type | Description
+| --------- | ---- | -----------
+| nodeNumberOfChains (required) | integer >= 10 | Number of chains in the network the node is part of.
+| nodeApiVersion (required) | string | Chainweb API version information for the node.
+| nodeChains (required) | Array of strings >= 0 items | Chain identifiers for the chains in the network the node is part of.
+| nodeVersion (required) | string | Network identifier for the network the node is part of. The valid values are  "test-singleton", "development", "mainnet01", and "testnet04".
+| nodeGraphHistory (required) | Array of integers | Array of all chain graphs indexed by the height of the first block with the respective graph. Graphs are encoded as adjacency lists.
+
+```json
+{
+  "nodeNumberOfChains": 20,
+  "nodeApiVersion": "0.0",
+  "nodeChains": [ "12", "13", "..."],
+  "nodeVersion": "mainnet01",
+  "nodeGraphHistory": [
+    [ 0,
+      [ ]
+    ],
+    [
+      852054,
+      [ ]
+    ]
+  ]
+}
+```
+
+## Collection page model
+
+| Parameter | Type | Description
+| --------- | ---- | -----------
+| limit (required) | integer >= 0 | The maximum number of items in the page. This number can be smaller but never be larger than the number of requested items.
+| next (required) | string or null | A cursor that can be used to query the next page. It should be used literally as the value for the `next` parameter in a follow-up request.
+| items (required) | any | The items in the page.
+
+```json
+{
+  "next": "inclusive:o1S4NNFhKWg8T1HEkmDvsTH9Ut9l3_qHRpp00yRKZIk",
+  "items": [
+    "AAAAAAAAAABRoiLHW7EFAB2lwAatTykipYZ3CZNPzLe-f5S-zUt8COtu0H12f_OZAwAFAAAAMpic85rur2MYf3zli8s8bHxTFjriFoMPTr6ZPs8sjxMKAAAAVBKuhU_hQmuvKlx88A5o-FH0rzNo59NsdxmOGNBQ-ycPAAAAMItdqgHZxf7j6l0oE8X-G9-VyMbnQmZrtSniuRe_EJ9CtyxsSb7daPIIYAaXMgSEsQ3dkxY5GjJjLwAAAAAAABqWlmx5B6wo0YWPIShNKmdVrAQWht2P85BS1drGLpkAAAAAADUJ-ARn7blgHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEIPAAAAAAAFAAAA-na5gFuxBQAFL-3CY4YuAJNGp9KhDkbrKkIPWYyq8WvtAaNPoUFWC16louSx8YN5",
+    "AAAAAAAAAAA0slHKW7EFAJNGp9KhDkbrKkIPWYyq8WvtAaNPoUFWC16louSx8YN5AwAFAAAAALcxv1ZiwwQ_QX9eOBZMbzIop6n7XtveS1FqOFwyvGMKAAAAC76ElC60qXSJQCHePpzzJxsCYvvrqvmkoHPyZnex-4QPAAAAKv0sz_rTANjoiJwMrdZFCJNFwdH0U_M5ouwMr3BXBfpCtyxsSb7daPIIYAaXMgSEsQ3dkxY5GjJjLwAAAAAAALJlIg1vY3w_9L63bePn1yk_5agvdEbIBBjm3adxc5xWAAAAAGzpBzdiVL9gHgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQUIPAAAAAAAFAAAA-na5gFuxBQALiBhXgqaHAb4VWug3oddEVy0X9y_jEkE2Kmi_vyGP5ovr-fDIz_Uf"
+    ],
+  "limit": 2
+}
+```
+
+## Miner information model
+
+| Parameter | Type | Description
+| --------- | ---- | -----------
+| account	| string | Account name is the miner account name. In most cases, the account name is the public key with the `k:` prefix.
+| predicate	| enum | The key predicate guard for the account. For accounts with a single key, this is usually `keys-all`.
+| public-keys	| Array of strings | Miner public key.
+
+```json
+{
+  "account": "miner",
+  "predicate": "keys-all",
+  "public-keys": [
+    "f880a433d6e2a13a32b6169030f56245efdd8c1b8a5027e9ce98a88e886bef27"
+  ]
+}
+```
+
+## Mining update event stream model
+
+The update event stream model describes the server-sent events that notify miners when new mining work becomes available. 
+The stream is terminated by the server in regular intervals and it is up to the client to request a new stream.
+
+Each event consists of a single line. 
+Events are separated by empty lines.
+
+| Parameter | Type | Description
+| --------- | ---- | -----------
+| events | Array | Each event	consists of the string value "event:New Cut".
+
+```text
+event:New Cut
+
+event:New Cut
+
+event:New Cut
+```

--- a/packages/apps/docs/src/docs/reference/chainweb/chainweb-encoding.md
+++ b/packages/apps/docs/src/docs/reference/chainweb/chainweb-encoding.md
@@ -1,0 +1,122 @@
+---
+title: Binary encoding
+description:
+  Provides reference information for the chainweb-node block header binary encoding.
+menu: Chainweb API
+label: Binary encoding
+order: 2
+layout: full
+tags: ['chainweb', 'node api', 'chainweb api', 'api reference']
+---
+
+# Block header binary encoding
+
+The binary format for chain graphs of degree three is defined in `Chainweb.BlockHeader`.
+
+| Size | Bytes | Value
+| ---- | ----- | -----
+| 8	| 0-7	| flags
+| 8	| 8-15 | time
+| 32 | 16-47 | parent
+| 110 | 48-157 | adjacents
+| 32 | 158-189 | target
+| 32 | 190-221 | payload
+| 4 | 222-225 | chain
+| 32 | 226-257 | weight
+| 8 | 258-265 | height
+| 4	| 266-269	| version
+| 8	| 270-277	| epoch start
+| 8	| 278-285	| nonce
+| 32 | 286-317 | hash
+
+total: 318 bytes
+
+## Adjacent parents record 
+
+The binary format for adjacent parents (length 3):
+
+| Bytes	| Value
+| ----- | -----
+| 0-1	| length
+| 2-109	| adjacents
+
+total: 110 bytes
+
+## Adjacent parent
+
+| Bytes	| Value
+| ----- | -----
+| 0-3	| chain
+| 4-35 | hash
+
+total: 36 bytes
+
+## Proof of work and field values
+
+Arithmetic operations and comparisons on `parent`, `target`, `weight`, and `hash` interpret the value as unsigned 256-bit integral numbers in little endian encoding. 
+All operations are performed using rational arithmetic of unlimited precision and the final result is rounded. 
+For details about how the result is rounded, consult the source code directly.
+
+### Time stamps
+
+The `time` and `epoch start` values are a little endian twos complement encoded integral numbers that count SI microseconds since the start of the POSIX/UNIX epoch (leap seconds are ignored). 
+These numbers are always positive (highest bit is 0).
+
+### Numbers
+
+The `height` is a little endian encoded unsigned integral 64 bit number.
+The `length` is a little endian encoded unsigned integral 16 bit number.
+
+### Version
+
+The `version` field identifies the Chainweb version. 
+It is a 32 bit value in little endian encoding. 
+Values up to 0x0000FFFF are reserved for production versions, including includes development and testnets.
+
+| Value	| Version
+| ----- | -------
+| 0x00000005 | mainnet01
+| 0x00000001 | development
+| 0x00000007 | testnet04
+
+### Other
+
+The `nonce` is any sequence of 8 bytes that is only compared for equality.
+The `chain` is any sequence of 4 bytes that identifies a chain and can be compared for equality.
+The `payload` is any sequence of 32 bytes that is a cryptographic hash of the payload associated with the block and can be compared for equality.
+flags are eight bytes of value 0x0 that are reserved for future use.
+
+## Work header binary encoding
+
+The work bytes received from the `/miner/work` endpoint is slightly different than the above header format. 
+These headers do not include the block hash, instead prefixing the header above (without hash) with chain id and hash target bytes.
+
+The first 36 bytes are informational. 
+Only the bytes from position 36 to the end are the subject of the proof of work hash computation.
+
+The final 8 bytes are the nonce. 
+The creation time is encoded in bytes 44-52 (see above for details of the encoding). 
+Miners are allowed, but not required, to update the time to reflect the solve time for the block more closely. 
+A larger value for the creation time increases the accuracy of the difficulty adjustment which is in the interest of miners.
+The high difficulty guarantees that the outcome of the race of winning blocks is determined by actual hash power. 
+However, blocks that are predated (that is, have a creation time that is in the future) are rejected during block header validation. 
+Leaving the time unchanged is a valid choice.
+
+Miners must not change or make any assumptions about the content of the "reserved" bytes.
+
+Defined in `Chainweb.Miner.Core`:
+
+| Size | Bytes | Work bytes |	Value
+| ---- | ----- | ---------- | -----
+| 4	| 0-3	| NA | chain
+| 32 | 4-35	| NA | hash-target
+| 8 | 36-43 | 0-7 | reserved
+| 8	| 44-51	| 8-15 | time
+| 298	| 52-313 | 16-277	| reserved
+| 8 | 314-321	| 278-285	| nonce
+
+total: 322 bytes
+
+For arithmetic comparisons the `hash-target` is interpreted as unsigned 256 bit integral number in little endian encoding.
+
+The `time` is a little endian twos complement encoded integral number that counts SI microseconds since the start of the POSIX/UNIX epoch (leap seconds are ignored). The value is always positive (highest bit is 0).


### PR DESCRIPTION
### Chainweb OpenAPI spec has _Data Models_ and _Binary Encoding_ sections.
https://kadena-io.github.io/chainweb-openapi/#tag/cut_model

This PR converts those sections to standard Markdown to be included in the docs site.

Related Issue/Asana ticket: \_

Short description: \_

<!--
Examples:

Title: Add Search Functionality to User Dashboard.
Related Issue: #1234
Short Description:
Implements a new search bar in the user dashboard to allow quick navigation and filtering of project lists based on user input. This feature enhances user experience by providing a more efficient way to locate specific projects.

Title: Fix Memory Leak in Data Processing Module.
Asana ticket: https://app.asana.com/0/1205801361945248/1207389790540430
Short Description:
Resolves a critical memory leak occurring in the data processing module when handling large datasets. This fix improves system stability and performance under heavy load conditions.
-->

### Test scenarios

- description of the (manually) executed test scenarios

<!--
Examples:

Add Search Functionality to User Dashboard
* Search Function Test: Verifies that entering a keyword in the search bar returns a list of projects containing that keyword.
* Empty Result Test: Confirms that a message is displayed when no projects match the search criteria.
* Performance Test: Ensures that the search functionality returns results within 2 seconds under typical load conditions.

Fix Memory Leak in Data Processing Module
* Memory Usage Test: Monitors memory usage during data processing to ensure that no unexpected memory growth occurs.
* Regression Test: Confirms that the data processing outputs remain consistent with previous versions post-fix.
* Stress Test: Executes the data processing module under high load to validate stability improvements.
-->

### Reminders (if applicable)

- [ ] I ran `pnpm install` and `pnpm test` in the root of the monorepo
      (optionally with `--filter=...package...` to exclude non-affected
      projects)
- [ ] I ran `pnpm changeset` in the root of the monorepo
- [ ] Test coverage has not decreased
- [ ] Docs have been updated to reflect changes in PR (don't forget
      docs.kadena.io)
