### PR TITLE
Simplify bottom section, remove second Edit button, change blue to ne…

### DIFF
--- a/packages/apps/docs/src/components/BottomPageSection/BottomPageSection.tsx
+++ b/packages/apps/docs/src/components/BottomPageSection/BottomPageSection.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link';
 import type { FC } from 'react';
 import React from 'react';
 import { PageHelpful } from '../PageHelpful/PageHelpful';
-import { EditPage } from './components/EditPage';
 import { Subscribe } from './components/Subscribe';
 import {
   bottomWrapperClass,

--- a/packages/apps/docs/src/components/BottomPageSection/BottomPageSection.tsx
+++ b/packages/apps/docs/src/components/BottomPageSection/BottomPageSection.tsx
@@ -21,7 +21,6 @@ interface IProps {
 }
 
 export const BottomPageSection: FC<IProps> = ({
-  editLink,
   navigation,
   layout = 'default',
 }) => {
@@ -45,11 +44,8 @@ export const BottomPageSection: FC<IProps> = ({
 
   return (
     <footer className={classes}>
-      <Grid columns={{ xs: 1, lg: 3, xl: 4 }}>
-        <GridItem columnSpan={1}>
-          <EditPage editLink={editLink} />
-        </GridItem>
-        <GridItem columnSpan={{ xs: 1, lg: 2, xl: 3 }}>
+      <Grid columns={{ xs: 1, xl: 4 }}>
+        <GridItem columnSpan={{ xs: 1, xl: 4 }}>
           <Stack
             flexDirection="row"
             justifyContent="space-between"
@@ -62,8 +58,6 @@ export const BottomPageSection: FC<IProps> = ({
                 }
                 href={navigation?.previous.root}
               >
-                previous:
-                <br />
                 {navigation?.previous.title}
               </Link>
             )}
@@ -72,8 +66,6 @@ export const BottomPageSection: FC<IProps> = ({
                 onClick={() => onClickAction('next', navigation?.next?.root)}
                 href={navigation?.next.root}
               >
-                next:
-                <br />
                 {navigation?.next.title}
               </Link>
             )}
@@ -88,7 +80,7 @@ export const BottomPageSection: FC<IProps> = ({
         width="100%"
         gap={{ xs: 'xl', lg: 'xs' }}
       >
-        <PageHelpful editLink={editLink} />
+        <PageHelpful />
         <Subscribe />
       </Stack>
     </footer>

--- a/packages/apps/docs/src/components/DocsCard/styles.css.ts
+++ b/packages/apps/docs/src/components/DocsCard/styles.css.ts
@@ -29,7 +29,7 @@ export const cardClass = style([
   }),
   {
     transition: 'all .3s ease',
-    backgroundColor: tokens.kda.foundation.color.palette.blue.n1,
+    backgroundColor: tokens.kda.foundation.color.neutral.n1,
     color: tokens.kda.foundation.color.text.base.default,
   },
 ]);

--- a/packages/apps/docs/src/components/Layout/Full/Full.tsx
+++ b/packages/apps/docs/src/components/Layout/Full/Full.tsx
@@ -88,9 +88,7 @@ export const Full: FC<IPageProps> = ({
               editLink={frontmatter.editLink}
             />
             {children}
-            <BottomPageSection
-              navigation={frontmatter.navigation}
-            />
+            <BottomPageSection navigation={frontmatter.navigation} />
           </article>
         </div>
         <BackgroundGradient />

--- a/packages/apps/docs/src/components/Layout/Full/Full.tsx
+++ b/packages/apps/docs/src/components/Layout/Full/Full.tsx
@@ -89,7 +89,6 @@ export const Full: FC<IPageProps> = ({
             />
             {children}
             <BottomPageSection
-              editLink={frontmatter.editLink}
               navigation={frontmatter.navigation}
             />
           </article>


### PR DESCRIPTION
…utral

### Modify this title

Related Issue/Asana ticket: \_

Short description: \_

<!--
Examples:

Title: Add Search Functionality to User Dashboard.
Related Issue: #1234
Short Description:
Implements a new search bar in the user dashboard to allow quick navigation and filtering of project lists based on user input. This feature enhances user experience by providing a more efficient way to locate specific projects.

Title: Fix Memory Leak in Data Processing Module.
Asana ticket: https://app.asana.com/0/1205801361945248/1207389790540430
Short Description:
Resolves a critical memory leak occurring in the data processing module when handling large datasets. This fix improves system stability and performance under heavy load conditions.
-->

### Test scenarios

- description of the (manually) executed test scenarios

<!--
Examples:

Add Search Functionality to User Dashboard
* Search Function Test: Verifies that entering a keyword in the search bar returns a list of projects containing that keyword.
* Empty Result Test: Confirms that a message is displayed when no projects match the search criteria.
* Performance Test: Ensures that the search functionality returns results within 2 seconds under typical load conditions.

Fix Memory Leak in Data Processing Module
* Memory Usage Test: Monitors memory usage during data processing to ensure that no unexpected memory growth occurs.
* Regression Test: Confirms that the data processing outputs remain consistent with previous versions post-fix.
* Stress Test: Executes the data processing module under high load to validate stability improvements.
-->

### Reminders (if applicable)

- [ ] I ran `pnpm install` and `pnpm test` in the root of the monorepo
      (optionally with `--filter=...package...` to exclude non-affected
      projects)
- [ ] I ran `pnpm changeset` in the root of the monorepo
- [ ] Test coverage has not decreased
- [ ] Docs have been updated to reflect changes in PR (don't forget
      docs.kadena.io)
