### PR TITLE
fix(kadena-cli): error when there is no kadena directory

### DIFF
--- a/.changeset/real-seahorses-beg.md
+++ b/.changeset/real-seahorses-beg.md
@@ -1,0 +1,5 @@
+---
+'@kadena/kadena-cli': patch
+---
+
+Fixed error when there is no kadena directory

--- a/packages/tools/kadena-cli/src/commands/config/tests/configInit.test.ts
+++ b/packages/tools/kadena-cli/src/commands/config/tests/configInit.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { WORKING_DIRECTORY } from '../../../constants/config.js';
-import { services } from '../../../services/index.js';
+import { Services, services } from '../../../services/index.js';
 import { mockPrompts, runCommand } from '../../../utils/test.util.js';
 
 describe('config init', () => {
@@ -14,6 +14,14 @@ describe('config init', () => {
     }
   });
 
+  it('service without kadena dir', async () => {
+    delete process.env.KADENA_DIR;
+    const newServices = new Services();
+    expect(() => newServices.config.getDirectory()).toThrow(
+      'Kadena directory not found. use `kadena config init` to create one.',
+    );
+  });
+
   it('should create a network config', async () => {
     mockPrompts({
       select: {
@@ -21,7 +29,8 @@ describe('config init', () => {
       },
     });
 
-    await runCommand('config init');
+    const output = await runCommand('config init');
+    expect(output.stderr).includes('Created configuration directory:');
     expect(
       await services.filesystem.fileExists(
         path.join(networkPath, 'devnet.yaml'),

--- a/packages/tools/kadena-cli/src/constants/config.ts
+++ b/packages/tools/kadena-cli/src/constants/config.ts
@@ -1,8 +1,6 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-export const ENV_KADENA_DIR = process.env.KADENA_DIR;
-
 // app executable (for development run `npm link` or use the dev command)
 export const CLINAME = 'kadena';
 export const IS_TEST = process.env.VITEST === 'true';

--- a/packages/tools/kadena-cli/src/services/config/config.service.ts
+++ b/packages/tools/kadena-cli/src/services/config/config.service.ts
@@ -5,7 +5,6 @@ import path from 'node:path';
 import sanitize from 'sanitize-filename';
 import {
   ACCOUNT_DIR,
-  ENV_KADENA_DIR,
   HOME_KADENA_DIR,
   IS_TEST,
   WALLET_DIR,
@@ -111,6 +110,7 @@ export class ConfigService implements IConfigService {
     }
 
     // Priority 2: ENV KADENA_DIR
+    const ENV_KADENA_DIR = process.env.KADENA_DIR;
     if (ENV_KADENA_DIR !== undefined) {
       if (directoryExists(ENV_KADENA_DIR)) {
         this.directory = ENV_KADENA_DIR;
@@ -141,7 +141,6 @@ export class ConfigService implements IConfigService {
 
   public getDirectory(): string {
     if (this.directory === null) throw new KadenaError('no_kadena_directory');
-    // console.log({ directory: this.directory });
     return this.directory;
   }
 

--- a/packages/tools/kadena-cli/src/utils/helpers.ts
+++ b/packages/tools/kadena-cli/src/utils/helpers.ts
@@ -165,25 +165,30 @@ const defaultNetworkSchema = z.object({
 });
 
 export const getDefaultNetworkName = async (): Promise<string | undefined> => {
-  const defaultNetworksSettingsFilePath = getNetworksSettingsFilePath();
-  if (defaultNetworksSettingsFilePath === null) return;
+  try {
+    const defaultNetworksSettingsFilePath = getNetworksSettingsFilePath();
 
-  const isDefaultNetworkAvailable = await services.filesystem.fileExists(
-    defaultNetworksSettingsFilePath,
-  );
+    if (defaultNetworksSettingsFilePath === null) return;
 
-  if (!isDefaultNetworkAvailable) return;
+    const isDefaultNetworkAvailable = await services.filesystem.fileExists(
+      defaultNetworksSettingsFilePath,
+    );
 
-  const content = await services.filesystem.readFile(
-    defaultNetworksSettingsFilePath,
-  );
+    if (!isDefaultNetworkAvailable) return;
 
-  const network = content !== null ? load(content) : null;
+    const content = await services.filesystem.readFile(
+      defaultNetworksSettingsFilePath,
+    );
 
-  const parse = defaultNetworkSchema.safeParse(network);
+    const network = content !== null ? load(content) : null;
 
-  if (parse.success) {
-    return parse.data.name;
+    const parse = defaultNetworkSchema.safeParse(network);
+
+    if (parse.success) {
+      return parse.data.name;
+    }
+  } catch (e) {
+    return undefined;
   }
 };
 


### PR DESCRIPTION
### Modify this title

Related Issue/Asana ticket: N/A

Short description: Fixed an error that happened when there was no kadena directory. Usually you would de asked to run `kadena config init` but this command gave the same error.

<!--
Examples:

Title: Add Search Functionality to User Dashboard.
Related Issue: #1234
Short Description:
Implements a new search bar in the user dashboard to allow quick navigation and filtering of project lists based on user input. This feature enhances user experience by providing a more efficient way to locate specific projects.

Title: Fix Memory Leak in Data Processing Module.
Asana ticket: https://app.asana.com/0/1205801361945248/1207389790540430
Short Description:
Resolves a critical memory leak occurring in the data processing module when handling large datasets. This fix improves system stability and performance under heavy load conditions.
-->

### Test scenarios

- description of the (manually) executed test scenarios

<!--
Examples:

Add Search Functionality to User Dashboard
* Search Function Test: Verifies that entering a keyword in the search bar returns a list of projects containing that keyword.
* Empty Result Test: Confirms that a message is displayed when no projects match the search criteria.
* Performance Test: Ensures that the search functionality returns results within 2 seconds under typical load conditions.

Fix Memory Leak in Data Processing Module
* Memory Usage Test: Monitors memory usage during data processing to ensure that no unexpected memory growth occurs.
* Regression Test: Confirms that the data processing outputs remain consistent with previous versions post-fix.
* Stress Test: Executes the data processing module under high load to validate stability improvements.
-->

### Reminders (if applicable)

- [x] I ran `pnpm install` and `pnpm test` in the root of the monorepo
      (optionally with `--filter=...package...` to exclude non-affected
      projects)
- [x] I ran `pnpm changeset` in the root of the monorepo
- [x] Test coverage has not decreased
- [x] Docs have been updated to reflect changes in PR (don't forget
      docs.kadena.io)
