### PR TITLE
text component extended with text size inherit

### DIFF
--- a/.changeset/wicked-crews-burn.md
+++ b/.changeset/wicked-crews-burn.md
@@ -1,0 +1,5 @@
+---
+'@kadena/kode-ui': minor
+---
+
+Text size extended with inherit

--- a/packages/libs/kode-ui/src/components/Typography/Text/Text.css.ts
+++ b/packages/libs/kode-ui/src/components/Typography/Text/Text.css.ts
@@ -1,4 +1,4 @@
-import { style } from "../../../styles";
+import { style } from '../../../styles';
 
 export const inheritedSizeClass = style({
   fontSize: 'inherit !important',

--- a/packages/libs/kode-ui/src/components/Typography/Text/Text.css.ts
+++ b/packages/libs/kode-ui/src/components/Typography/Text/Text.css.ts
@@ -1,0 +1,6 @@
+import { style } from "../../../styles";
+
+export const inheritedSizeClass = style({
+  fontSize: 'inherit !important',
+  lineHeight: 'inherit !important',
+});

--- a/packages/libs/kode-ui/src/components/Typography/Text/Text.stories.tsx
+++ b/packages/libs/kode-ui/src/components/Typography/Text/Text.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import { Text } from './Text';
 import { Heading } from '../Heading/Heading';
+import { Text } from './Text';
 
 const meta: Meta<typeof Text> = {
   title: 'Typography/Text',
@@ -51,7 +51,9 @@ export const InheritText: Story = {
     size: 'inherit',
     color: 'emphasize',
   },
-  render: (props) => <Heading as="h1">
-    Header with <Text {...props}>{props.children}</Text> parent size
-  </Heading>,
+  render: (props) => (
+    <Heading as="h1">
+      Header with <Text {...props}>{props.children}</Text> parent size
+    </Heading>
+  ),
 };

--- a/packages/libs/kode-ui/src/components/Typography/Text/Text.stories.tsx
+++ b/packages/libs/kode-ui/src/components/Typography/Text/Text.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 import { Text } from './Text';
+import { Heading } from '../Heading/Heading';
 
 const meta: Meta<typeof Text> = {
   title: 'Typography/Text',
@@ -41,4 +42,16 @@ export const Primary: Story = {
     children: 'text',
   },
   render: (props) => <Text {...props}>{props.children}</Text>,
+};
+
+export const InheritText: Story = {
+  name: 'Text w/ inherited size',
+  args: {
+    children: 'text inheriting',
+    size: 'inherit',
+    color: 'emphasize',
+  },
+  render: (props) => <Heading as="h1">
+    Header with <Text {...props}>{props.children}</Text> parent size
+  </Heading>,
 };

--- a/packages/libs/kode-ui/src/components/Typography/Text/Text.tsx
+++ b/packages/libs/kode-ui/src/components/Typography/Text/Text.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { colorVariants, transformVariants } from '../typography.css';
 import { fontMap } from './constants';
+import { inheritedSizeClass } from './Text.css';
 
 export interface ITextProps {
   as?: 'p' | 'span' | 'code';
@@ -11,7 +12,7 @@ export interface ITextProps {
   className?: string;
   color?: keyof typeof colorVariants;
   bold?: boolean;
-  size?: 'small' | 'smallest' | 'base';
+  size?: 'inherit' | 'small' | 'smallest' | 'base';
   transform?: keyof typeof transformVariants;
   variant?: 'body' | 'code' | 'ui';
   ariaLabel?: HTMLAttributes<HTMLSpanElement>['aria-label'];
@@ -42,8 +43,16 @@ export const Text = ({
   bold,
   id,
 }: ITextProps) => {
+  let isInheritedSize = false;
+
+  if (size === 'inherit') {
+    isInheritedSize = true;
+    size = 'base';
+  }
+
   const classList = classNames(
     fontMap[variant][size][bold ? 'bold' : 'regular'],
+    isInheritedSize ? inheritedSizeClass : '',
     colorVariants[color],
     transformVariants[transform],
     className,


### PR DESCRIPTION
### Modify this title

Related Issue/Asana ticket: \_

Short description: \_

<!--
Examples:

Title: Add Search Functionality to User Dashboard.
Related Issue: #1234
Short Description:
Implements a new search bar in the user dashboard to allow quick navigation and filtering of project lists based on user input. This feature enhances user experience by providing a more efficient way to locate specific projects.

Title: Fix Memory Leak in Data Processing Module.
Asana ticket: https://app.asana.com/0/1205801361945248/1207389790540430
Short Description:
Resolves a critical memory leak occurring in the data processing module when handling large datasets. This fix improves system stability and performance under heavy load conditions.
-->

### Test scenarios

- description of the (manually) executed test scenarios

<!--
Examples:

Add Search Functionality to User Dashboard
* Search Function Test: Verifies that entering a keyword in the search bar returns a list of projects containing that keyword.
* Empty Result Test: Confirms that a message is displayed when no projects match the search criteria.
* Performance Test: Ensures that the search functionality returns results within 2 seconds under typical load conditions.

Fix Memory Leak in Data Processing Module
* Memory Usage Test: Monitors memory usage during data processing to ensure that no unexpected memory growth occurs.
* Regression Test: Confirms that the data processing outputs remain consistent with previous versions post-fix.
* Stress Test: Executes the data processing module under high load to validate stability improvements.
-->

### Reminders (if applicable)

- [ ] I ran `pnpm install` and `pnpm test` in the root of the monorepo
      (optionally with `--filter=...package...` to exclude non-affected
      projects)
- [ ] I ran `pnpm changeset` in the root of the monorepo
- [ ] Test coverage has not decreased
- [ ] Docs have been updated to reflect changes in PR (don't forget
      docs.kadena.io)
