### PR TITLE
Minor Grammar Correction In Docs (1).

### DIFF
--- a/packages/apps/docs/src/docs/learn/accounts-keys.md
+++ b/packages/apps/docs/src/docs/learn/accounts-keys.md
@@ -17,7 +17,7 @@ In simple terms, an **account name** is a unique name on the blockchain that can
 
 ## Defining a keyset
 
-A keyset is a specific type of **guard** that consists of one or public keys and a **predicate** that specifies how many of the keys are required to perform an operation. In JSON, a keyset looks similar to the following example:
+A keyset is a specific type of **guard** that consists of one or more public keys and a **predicate** that specifies how many of the keys are required to perform an operation. In JSON, a keyset looks similar to the following example:
 
 ```json
 {


### PR DESCRIPTION
Title
Fix Grammar in Documentation: Update 'Of one public' to 'of one or more public'

Related Issue/Asana Ticket
N/A

Short Description
This pull request corrects minor grammar in the documentation, changing 'of one public' to 'of one or more public.'

Test Scenarios
Visual inspection of the documentation to confirm grammar changes.