### PR TITLE
Fix/dw/w accounts

### DIFF
--- a/packages/apps/dev-wallet/src/App/Layout/Layout.tsx
+++ b/packages/apps/dev-wallet/src/App/Layout/Layout.tsx
@@ -6,7 +6,8 @@ import {
 } from '@kadena/kode-icons/system';
 
 import { NetworkSelector } from '@/Components/NetworkSelector/NetworkSelector';
-import { Stack, Themes, useTheme } from '@kadena/kode-ui';
+import { useWallet } from '@/modules/wallet/wallet.hook';
+import { Badge, Stack, Themes, useTheme } from '@kadena/kode-ui';
 import {
   SideBarFooter,
   SideBarFooterItem,
@@ -17,11 +18,13 @@ import classNames from 'classnames';
 import { FC, useMemo } from 'react';
 import { Link, Outlet, useLocation } from 'react-router-dom';
 import { usePatchedNavigate } from '../../utils/usePatchedNavigate';
+import { KLogo } from './KLogo';
 import { SideBar } from './SideBar';
 import {
   isExpandedMainClass,
   isNotExpandedClass,
   mainContainerClass,
+  mobileNetworkClass,
 } from './style.css';
 
 export const Layout: FC = () => {
@@ -29,6 +32,7 @@ export const Layout: FC = () => {
   const location = useLocation();
   const navigate = usePatchedNavigate();
   const { isExpanded } = useLayout();
+  const { activeNetwork } = useWallet();
 
   const innerLocation = useMemo(
     () => ({
@@ -44,10 +48,28 @@ export const Layout: FC = () => {
     setTheme(newTheme);
   };
 
+  const network = activeNetwork?.name || activeNetwork?.networkId;
+
   return (
     <>
       <SideBarLayout
         location={innerLocation}
+        logo={
+          <Stack gap={'sm'} flexDirection={'row'} alignItems={'center'}>
+            <Link to="/">
+              <KLogo height={40} />
+            </Link>
+            {network && (
+              <Badge
+                size="sm"
+                style="highContrast"
+                className={mobileNetworkClass}
+              >
+                {network}
+              </Badge>
+            )}
+          </Stack>
+        }
         sidebar={<SideBar />}
         footer={
           <SideBarFooter>

--- a/packages/apps/dev-wallet/src/App/Layout/style.css.ts
+++ b/packages/apps/dev-wallet/src/App/Layout/style.css.ts
@@ -26,3 +26,12 @@ export const mainContainerClass = style({
     },
   },
 });
+
+export const mobileNetworkClass = style({
+  display: 'flex',
+  '@media': {
+    'screen and (min-width: 640px)': {
+      display: 'none',
+    },
+  },
+});

--- a/packages/apps/dev-wallet/src/Components/AccountItem/AccountItem.tsx
+++ b/packages/apps/dev-wallet/src/Components/AccountItem/AccountItem.tsx
@@ -2,6 +2,7 @@ import {
   IOwnedAccount,
   IWatchedAccount,
 } from '@/modules/account/account.repository';
+import { isKeysetGuard } from '@/modules/account/guards';
 import { useWallet } from '@/modules/wallet/wallet.hook';
 import { hashStyle } from '@/pages/activities/style.css';
 import { noStyleLinkClass } from '@/pages/home/style.css';
@@ -11,7 +12,7 @@ import { Link } from 'react-router-dom';
 import { ListItem } from '../ListItem/ListItem';
 
 export function AccountItem({
-  account: { uuid, alias, address, overallBalance, contract },
+  account: { uuid, alias, address, overallBalance, contract, guard },
 }: {
   account: IOwnedAccount | IWatchedAccount;
 }) {
@@ -53,6 +54,11 @@ export function AccountItem({
                 variant="transparent"
                 onClick={(e) => {
                   e.preventDefault();
+                  if (address.startsWith('w:') && isKeysetGuard(guard)) {
+                    navigator.clipboard.writeText(
+                      `${address}:${guard.keys.join(':')}`,
+                    );
+                  }
                   navigator.clipboard.writeText(address);
                 }}
               >

--- a/packages/apps/dev-wallet/src/Components/AccountItem/AccountItem.tsx
+++ b/packages/apps/dev-wallet/src/Components/AccountItem/AccountItem.tsx
@@ -1,7 +1,4 @@
-import {
-  IOwnedAccount,
-  IWatchedAccount,
-} from '@/modules/account/account.repository';
+import { IAccount } from '@/modules/account/account.repository';
 import { isKeysetGuard } from '@/modules/account/guards';
 import { useWallet } from '@/modules/wallet/wallet.hook';
 import { hashStyle } from '@/pages/activities/style.css';
@@ -14,7 +11,7 @@ import { ListItem } from '../ListItem/ListItem';
 export function AccountItem({
   account: { uuid, alias, address, overallBalance, contract, guard },
 }: {
-  account: IOwnedAccount | IWatchedAccount;
+  account: IAccount;
 }) {
   const { fungibles } = useWallet();
   const getSymbol = (contract: string) =>
@@ -58,8 +55,9 @@ export function AccountItem({
                     navigator.clipboard.writeText(
                       `${address}:${guard.keys.join(':')}`,
                     );
+                  } else {
+                    navigator.clipboard.writeText(address);
                   }
-                  navigator.clipboard.writeText(address);
                 }}
               >
                 <MonoContentCopy />


### PR DESCRIPTION
### Modify this title

Related Issue/Asana ticket: \_

Short description: \_

<!--
Examples:

Title: Add Search Functionality to User Dashboard.
Related Issue: #1234
Short Description:
Implements a new search bar in the user dashboard to allow quick navigation and filtering of project lists based on user input. This feature enhances user experience by providing a more efficient way to locate specific projects.

Title: Fix Memory Leak in Data Processing Module.
Asana ticket: https://app.asana.com/0/1205801361945248/1207389790540430
Short Description:
Resolves a critical memory leak occurring in the data processing module when handling large datasets. This fix improves system stability and performance under heavy load conditions.
-->

### Test scenarios

- description of the (manually) executed test scenarios

<!--
Examples:

Add Search Functionality to User Dashboard
* Search Function Test: Verifies that entering a keyword in the search bar returns a list of projects containing that keyword.
* Empty Result Test: Confirms that a message is displayed when no projects match the search criteria.
* Performance Test: Ensures that the search functionality returns results within 2 seconds under typical load conditions.

Fix Memory Leak in Data Processing Module
* Memory Usage Test: Monitors memory usage during data processing to ensure that no unexpected memory growth occurs.
* Regression Test: Confirms that the data processing outputs remain consistent with previous versions post-fix.
* Stress Test: Executes the data processing module under high load to validate stability improvements.
-->

### Reminders (if applicable)

- [ ] I ran `pnpm install` and `pnpm test` in the root of the monorepo
      (optionally with `--filter=...package...` to exclude non-affected
      projects)
- [ ] I ran `pnpm changeset` in the root of the monorepo
- [ ] Test coverage has not decreased
- [ ] Docs have been updated to reflect changes in PR (don't forget
      docs.kadena.io)
