### PR TITLE
fix(dw): add share btn next to preflight and describe it

### DIFF
--- a/packages/apps/dev-wallet/src/pages/transaction/components/TxPipeLine.tsx
+++ b/packages/apps/dev-wallet/src/pages/transaction/components/TxPipeLine.tsx
@@ -221,15 +221,29 @@ function TxStatusList({
               {sendDisabled ? 'Transaction is pending' : 'Ready to preflight'}
             </Stack>
           </Text>
+          <Text size="small">
+            Preflight will test your transaction first to avoid paying gas for a
+            failed submission.
+          </Text>
           {variant === 'expanded' && (
-            <Button
-              isCompact
-              onClick={() => onPreflight()}
-              isDisabled={sendDisabled}
-              startVisual={<MonoViewInAr />}
-            >
-              Preflight transaction
-            </Button>
+            <Stack gap={'sm'}>
+              <Button
+                isCompact
+                onClick={() => onPreflight()}
+                isDisabled={sendDisabled}
+                startVisual={<MonoViewInAr />}
+              >
+                Preflight
+              </Button>
+              <Button
+                variant="outlined"
+                startVisual={<MonoShare />}
+                isCompact
+                onClick={copyTx}
+              >
+                {copied ? 'copied' : 'Share'}
+              </Button>
+            </Stack>
           )}
         </Stack>
       ),
@@ -282,14 +296,24 @@ function TxStatusList({
             </Stack>
           </Text>
           {variant === 'expanded' && (
-            <Button
-              isCompact
-              onClick={() => onSubmit()}
-              isDisabled={sendDisabled}
-              startVisual={<MonoViewInAr />}
-            >
-              Send transaction
-            </Button>
+            <Stack gap={'sm'}>
+              <Button
+                isCompact
+                onClick={() => onSubmit()}
+                isDisabled={sendDisabled}
+                startVisual={<MonoViewInAr />}
+              >
+                Send tx
+              </Button>
+              <Button
+                variant="outlined"
+                startVisual={<MonoShare />}
+                isCompact
+                onClick={copyTx}
+              >
+                {copied ? 'copied' : 'Share'}
+              </Button>
+            </Stack>
           )}
         </Stack>
       ),

--- a/packages/apps/dev-wallet/src/pages/transaction/components/TxTile.tsx
+++ b/packages/apps/dev-wallet/src/pages/transaction/components/TxTile.tsx
@@ -171,7 +171,9 @@ export const TxTile = ({
               paddingBlockEnd={'sm'}
             >
               <Text size="small">
-                The transaction is Signed; you can now call preflight
+                {sendDisabled
+                  ? 'Waiting for redistribution to complete'
+                  : 'The transaction is Signed; you can now call preflight'}
               </Text>
             </Stack>
           </>

--- a/packages/apps/dev-wallet/src/pages/transfer/Steps/TransferForm.tsx
+++ b/packages/apps/dev-wallet/src/pages/transfer/Steps/TransferForm.tsx
@@ -406,10 +406,26 @@ export function TransferForm({
     onSubmit(
       {
         ...data,
+        receivers: [
+          ...data.receivers,
+          ...xchainSameAccount.map((x) => ({
+            amount: x.amount,
+            address: senderAccount.address,
+            chain: x.target,
+            xchain: true,
+            chunks: [
+              {
+                amount: x.amount,
+                chainId: x.source,
+              },
+            ],
+            discoveredAccount: senderAccount,
+          })),
+        ],
         gasPayer: data.gasPayer || data.senderAccount,
         creationTime: data.creationTime ?? Math.floor(Date.now() / 1000),
       },
-      [...xchainSameAccount, ...redistribution],
+      [...redistribution],
     );
   }
 


### PR DESCRIPTION
### Modify this title

Related Issue/Asana ticket: \_

Short description: \_

<!--
Examples:

Title: Add Search Functionality to User Dashboard.
Related Issue: #1234
Short Description:
Implements a new search bar in the user dashboard to allow quick navigation and filtering of project lists based on user input. This feature enhances user experience by providing a more efficient way to locate specific projects.

Title: Fix Memory Leak in Data Processing Module.
Asana ticket: https://app.asana.com/0/1205801361945248/1207389790540430
Short Description:
Resolves a critical memory leak occurring in the data processing module when handling large datasets. This fix improves system stability and performance under heavy load conditions.
-->

### Test scenarios

- description of the (manually) executed test scenarios

<!--
Examples:

Add Search Functionality to User Dashboard
* Search Function Test: Verifies that entering a keyword in the search bar returns a list of projects containing that keyword.
* Empty Result Test: Confirms that a message is displayed when no projects match the search criteria.
* Performance Test: Ensures that the search functionality returns results within 2 seconds under typical load conditions.

Fix Memory Leak in Data Processing Module
* Memory Usage Test: Monitors memory usage during data processing to ensure that no unexpected memory growth occurs.
* Regression Test: Confirms that the data processing outputs remain consistent with previous versions post-fix.
* Stress Test: Executes the data processing module under high load to validate stability improvements.
-->

### Reminders (if applicable)

- [ ] I ran `pnpm install` and `pnpm test` in the root of the monorepo
      (optionally with `--filter=...package...` to exclude non-affected
      projects)
- [ ] I ran `pnpm changeset` in the root of the monorepo
- [ ] Test coverage has not decreased
- [ ] Docs have been updated to reflect changes in PR (don't forget
      docs.kadena.io)
