### PR TITLE
fix(dw): share tx

### DIFF
--- a/packages/apps/dev-wallet/src/pages/signature-builder/signature-builder.tsx
+++ b/packages/apps/dev-wallet/src/pages/signature-builder/signature-builder.tsx
@@ -209,6 +209,7 @@ export function SignatureBuilder() {
           }>),
         );
         await transactionRepository.updateTransaction({
+          ...tx,
           ...txWithMetaData,
           sigs: updatedTx.sigs,
           status:

--- a/packages/apps/dev-wallet/src/pages/transaction/components/ExpandedTransaction.tsx
+++ b/packages/apps/dev-wallet/src/pages/transaction/components/ExpandedTransaction.tsx
@@ -30,7 +30,7 @@ import {
   MonoShare,
 } from '@kadena/kode-icons/system';
 import classNames from 'classnames';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CommandView } from './CommandView.tsx';
 import { statusPassed, TxPipeLine } from './TxPipeLine.tsx';
 
@@ -87,6 +87,26 @@ export function ExpandedTransaction({
   };
   const Title = isDialog ? DialogHeader : Stack;
   const Content = isDialog ? DialogContent : Stack;
+  const [selectedTab, setSelectedTab] = useState('command-details');
+  const activeTabs = [
+    'command-details',
+    transaction.preflight && 'preflight',
+    transaction.request && 'request',
+    'result' in transaction && transaction.result && 'result',
+    transaction.continuation?.proof && 'spv',
+    contTx && 'cont-command-details',
+    contTx?.preflight && 'cont-preflight',
+    contTx?.request && 'cont-request',
+    contTx && 'result' in contTx && contTx.result && 'cont-result',
+  ].filter(Boolean) as string[];
+
+  useEffect(() => {
+    const lastTab = activeTabs[activeTabs.length - 1];
+    if (lastTab !== selectedTab) {
+      setSelectedTab(lastTab);
+    }
+  }, [activeTabs.length]);
+
   return (
     <>
       <Title>
@@ -141,8 +161,15 @@ export function ExpandedTransaction({
                   </Notification>
                 </Stack>
               )}
-            <Tabs isContained>
-              <TabItem title="Command Details">
+            <Tabs
+              isContained
+              selectedKey={selectedTab}
+              onSelectionChange={(key) => {
+                console.log('key', key);
+                setSelectedTab(key as any);
+              }}
+            >
+              <TabItem key="command-details" title="Command Details">
                 <Stack gap={'sm'} flexDirection={'column'}>
                   <Stack justifyContent={'space-between'}>
                     <Heading variant="h4">Command Details</Heading>
@@ -215,7 +242,7 @@ export function ExpandedTransaction({
 
               {transaction.preflight &&
                 ((
-                  <TabItem title="Preflight Result">
+                  <TabItem key="preflight" title="Preflight Result">
                     <JsonView
                       title="Preflight Result"
                       data={transaction.preflight}
@@ -224,17 +251,17 @@ export function ExpandedTransaction({
                 ) as any)}
 
               {transaction.request && (
-                <TabItem title="Request">
+                <TabItem key="request" title="Request">
                   <JsonView title="Request" data={transaction.request} />
                 </TabItem>
               )}
               {'result' in transaction && transaction.result && (
-                <TabItem title="Result">
+                <TabItem key="result" title="Result">
                   <JsonView title="Result" data={transaction.result} />
                 </TabItem>
               )}
               {transaction.continuation?.proof && (
-                <TabItem title="SPV Proof">
+                <TabItem key="spv" title="SPV Proof">
                   <JsonView
                     title="Result"
                     data={transaction.continuation?.proof}
@@ -243,14 +270,17 @@ export function ExpandedTransaction({
                 </TabItem>
               )}
               {contTx && [
-                <TabItem title="cont: Command Details">
+                <TabItem
+                  key="cont-command-details"
+                  title="cont: Command Details"
+                >
                   <Stack gap={'sm'} flexDirection={'column'}>
                     <Heading variant="h4">Command Details</Heading>
                     <CommandView transaction={contTx} onSign={onSign} />
                   </Stack>
                 </TabItem>,
                 contTx.preflight && (
-                  <TabItem title="cont: Preflight Result">
+                  <TabItem key="cont-preflight" title="cont: Preflight Result">
                     <JsonView
                       title="Continuation Preflight Result"
                       data={contTx.preflight}
@@ -258,7 +288,7 @@ export function ExpandedTransaction({
                   </TabItem>
                 ),
                 contTx.request && (
-                  <TabItem title="cont: Request">
+                  <TabItem key="cont-request" title="cont: Request">
                     <JsonView
                       title="Continuation Request"
                       data={contTx.request}
@@ -266,7 +296,7 @@ export function ExpandedTransaction({
                   </TabItem>
                 ),
                 'result' in contTx && contTx.result && (
-                  <TabItem title="cont: Result">
+                  <TabItem key="cont-result" title="cont: Result">
                     <JsonView
                       title="Continuation Result"
                       data={contTx.result}


### PR DESCRIPTION
### Modify this title

Related Issue/Asana ticket: \_

Short description: \_

<!--
Examples:

Title: Add Search Functionality to User Dashboard.
Related Issue: #1234
Short Description:
Implements a new search bar in the user dashboard to allow quick navigation and filtering of project lists based on user input. This feature enhances user experience by providing a more efficient way to locate specific projects.

Title: Fix Memory Leak in Data Processing Module.
Asana ticket: https://app.asana.com/0/1205801361945248/1207389790540430
Short Description:
Resolves a critical memory leak occurring in the data processing module when handling large datasets. This fix improves system stability and performance under heavy load conditions.
-->

### Test scenarios

- description of the (manually) executed test scenarios

<!--
Examples:

Add Search Functionality to User Dashboard
* Search Function Test: Verifies that entering a keyword in the search bar returns a list of projects containing that keyword.
* Empty Result Test: Confirms that a message is displayed when no projects match the search criteria.
* Performance Test: Ensures that the search functionality returns results within 2 seconds under typical load conditions.

Fix Memory Leak in Data Processing Module
* Memory Usage Test: Monitors memory usage during data processing to ensure that no unexpected memory growth occurs.
* Regression Test: Confirms that the data processing outputs remain consistent with previous versions post-fix.
* Stress Test: Executes the data processing module under high load to validate stability improvements.
-->

### Reminders (if applicable)

- [ ] I ran `pnpm install` and `pnpm test` in the root of the monorepo
      (optionally with `--filter=...package...` to exclude non-affected
      projects)
- [ ] I ran `pnpm changeset` in the root of the monorepo
- [ ] Test coverage has not decreased
- [ ] Docs have been updated to reflect changes in PR (don't forget
      docs.kadena.io)
