### PR TITLE
fix(kadena-cli): pass correct template string when --template is used

### DIFF
--- a/.changeset/breezy-zoos-heal.md
+++ b/.changeset/breezy-zoos-heal.md
@@ -1,0 +1,6 @@
+---
+'@kadena/kadena-cli': patch
+---
+
+fix a bug where a template filename is passed to createAndWriteTransaction
+instead of the actual template string

--- a/packages/tools/kadena-cli/src/commands/tx/commands/txCreateTransaction.ts
+++ b/packages/tools/kadena-cli/src/commands/tx/commands/txCreateTransaction.ts
@@ -164,7 +164,7 @@ export const createTransactionCommandNew = createCommand(
     const result = await createAndWriteTransaction(
       templateVariables.templateVariables,
       outputFile.outFile,
-      template.template,
+      template.templateConfig.template,
     );
 
     assertCommandError(result);


### PR DESCRIPTION
### Modify this title

Related Issue/Asana ticket: https://github.com/kadena-community/kadena.js/issues/2832

Short description: \_
Title: Fix `--template` flag but
Related Issue:[ #2832](https://github.com/kadena-community/kadena.js/issues/2832)
Short Description: When the --template flag is used, the template file name string is passed into `createAndWriteTransaction` instead of the template string which is then used. This is leading to error that the template can't be parsed.

### Test scenarios
Execute a `tx add` command with added `-template=transfer.ktpl` flag.
