### PR TITLE
fix(graph): optimize event polling interval and correct lastEventId query

### DIFF
--- a/.changeset/grumpy-taxis-grab.md
+++ b/.changeset/grumpy-taxis-grab.md
@@ -1,0 +1,6 @@
+---
+'@kadena/graph': patch
+---
+
+Fixed issue where using the subscription for Events would scan the whole events
+table

--- a/packages/apps/graph/generated-schema.graphql
+++ b/packages/apps/graph/generated-schema.graphql
@@ -413,7 +413,7 @@ type Query {
   ): QueryCompletedBlockHeightsConnection!
 
   """
-  Retrieve events by qualifiedName (e.g. `coin.TRANSFER`). Default page size is 0500.
+  Retrieve events by qualifiedName (e.g. `coin.TRANSFER`). Default page size is 500.
   
         The parametersFilter is a stringified JSON object that matches the [JSON object property filters](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-json-fields#filter-on-object-property) from Prisma.
   

--- a/packages/apps/graph/issue_events.md
+++ b/packages/apps/graph/issue_events.md
@@ -1,0 +1,33 @@
+# Issue events
+
+## Analysis
+
+When opening subscriptions for qualifiedEventNames or requestKeys, we're looking
+every second for a new record. When we find one, we return it to the consumer.
+
+We poll every second, which could lead to the depletion of connections to the
+database
+
+Maybe some queries take more than a second, which leads to a buildup of queries
+that are not being processed.
+
+## Mitigations & Solutions
+
+1. We can increase the polling interval to 5 seconds, which would reduce the
+   number of queries to the database.
+2. If a query takes more than 5 seconds, the next polling will be ignored. The
+   maximum timeout of a query is already set at 15 seconds. So we miss a max of
+   2 polls
+3. For every event we do a separate query. It would be better to create a single
+   polling mechanism that'll check for all events that have open subscription
+
+## Actual issue
+
+The query that polls for events is using a `lastEventId` to get the next event.
+The problem was that `lastEventId` was never set, which resulted in the query
+being executed for the whole database every time.
+
+
+## Fix
+
+The fix was to set the `lastEventId` to the last event available in the database

--- a/packages/apps/graph/src/graph/subscription/events.ts
+++ b/packages/apps/graph/src/graph/subscription/events.ts
@@ -86,7 +86,7 @@ async function* iteratorFn(
       yield newEvents;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 5000));
   }
 }
 
@@ -156,12 +156,18 @@ async function getLastEvents(
 
 async function getLatestEventId(): Promise<number | null> {
   try {
-    const lastEventId = await prismaClient.event.aggregate({
-      _max: {
-        id: true,
+    const lastEventId = await prismaClient.event.findFirst({
+      orderBy: {
+        id: 'desc',
       },
+      take: 1,
     });
-    return lastEventId._max.id;
+
+    if (!lastEventId) {
+      throw new Error('No event found');
+    }
+
+    return lastEventId.id;
   } catch (error) {
     return null;
   }


### PR DESCRIPTION
When opening subscriptions for qualifiedEventNames or requestKeys, we're looking
every second for a new record. When we find one, we return it to the consumer.

We poll every second, which could lead to the depletion of connections to the
database

Maybe some queries take more than a second, which leads to a buildup of queries
that are not being processed.

## Mitigations & Solutions

1. We can increase the polling interval to 5 seconds, which would reduce the
   number of queries to the database.
2. If a query takes more than 5 seconds, the next polling will be ignored. The
   maximum timeout of a query is already set at 15 seconds. So we miss a max of
   2 polls
3. For every event we do a separate query. It would be better to create a single
   polling mechanism that'll check for all events that have open subscription

## Actual issue

The query that polls for events is using a `lastEventId` to get the next event.
The problem was that `lastEventId` was never set, which resulted in the query
being executed for the whole database every time.


## Fix

The fix was to set the `lastEventId` to the last event available in the database