### PR TITLE
feat(client): add gas estimation + change default TTL to 15 min

### DIFF
--- a/.changeset/calm-bats-joke.md
+++ b/.changeset/calm-bats-joke.md
@@ -1,0 +1,5 @@
+---
+'@kadena/client-utils': minor
+---
+
+Add gas price estimate helper

--- a/.changeset/clever-sheep-play.md
+++ b/.changeset/clever-sheep-play.md
@@ -1,0 +1,5 @@
+---
+'@kadena/client': minor
+---
+
+Change default ttl to 15 minutes

--- a/packages/e2e/e2e-graph/tests/transaction.test.ts
+++ b/packages/e2e/e2e-graph/tests/transaction.test.ts
@@ -82,7 +82,7 @@ test.describe('Query: getTransactions', () => {
               gasLimit: 2500,
               gasPrice: 1e-8,
               sender: sourceAccount.account,
-              ttl: 28800,
+              ttl: 900,
               chainId: 0,
             },
             payload: {
@@ -347,7 +347,7 @@ test.describe('Query: getTransactions', () => {
               gasLimit: 2500,
               gasPrice: 1e-8,
               sender: sourceAccount.account,
-              ttl: 28800,
+              ttl: 900,
               chainId: 1,
             },
             payload: {
@@ -484,7 +484,7 @@ test.describe('Query: getTransactions', () => {
               gasLimit: 2500,
               gasPrice: 1e-8,
               sender: sourceAccount.account,
-              ttl: 28800,
+              ttl: 900,
               chainId: 0,
             },
             payload: {

--- a/packages/libs/client-utils/README.md
+++ b/packages/libs/client-utils/README.md
@@ -70,18 +70,112 @@ const balance = await getBalance(
   .execute();
 ```
 
-### Future work
+## Gas Price Estimation
 
-- `npx create @kadena/client-utils`
+This module also provides tools for estimating optimal gas prices and analyzing
+gas usage from recent blocks on the Kadena blockchain.
 
-  - to allow community members to create their own interfaces for their
-    smart-contracts
+```ts
+import {
+  estimateGasPrice,
+  getBlocksGasInformation,
+} from '@kadena/client-utils';
+```
 
-- @kadena/client-utils/
-  - faucet
-  - marmalade
-  - principles
-  - namespace
+### `estimateGasPrice`
+
+Estimates a suitable gas price by analyzing recent block data. The estimated
+value is the median of the minimum gas prices from a set of 20 recent blocks,
+after filtering out any empty blocks.
+
+#### **Signature**
+
+```ts
+estimateGasPrice(parameters: IGasPriceEstimateProperties): Promise<number>
+```
+
+#### **Parameters**
+
+- `host?` _(string)_: Optional base URL of the Chainweb API (defaults to
+  Kadena's mainnet/testnet based on `networkId`).
+- `chainId` _(string)_: Chain ID (e.g., `"0"` through `"19"`).
+- `networkId` _(string)_: Network ID (e.g., `"mainnet01"`, `"testnet04"`).
+- `height?` _(number)_: Optional block max height ( default the chian height).
+- `items?` _(number)_: Number of blocks to fetch (default: `20`).
+
+#### **Returns**
+
+- `Promise<number>`: Estimated gas price (defaults to `1e-7` if no transactions
+  are found).
+
+#### **Example**
+
+```ts
+const price = await estimateGasPrice({
+  chainId: '0',
+  networkId: 'mainnet01',
+});
+console.log(`Suggested gas price: ${price}`);
+```
+
+---
+
+### `getBlocksGasInformation`
+
+Fetches recent block data and returns gas usage statistics for each block. This
+information can be used to estimate gas prices based on custom criteria.
+
+#### **Signature**
+
+```ts
+getBlocksGasInformation(parameters: IGasPriceEstimateProperties): Promise<IBlockGasInformation[]>
+```
+
+#### **Parameters**
+
+- `host?` _(string)_: Optional base URL of the Chainweb API (defaults to
+  Kadena's mainnet/testnet based on `networkId`).
+- `chainId` _(string)_: Chain ID (e.g., `"0"` through `"19"`).
+- `networkId` _(string)_: Network ID (e.g., `"mainnet01"`, `"testnet04"`).
+- `height?` _(number)_: Optional block max height ( default the chian height).
+- `items?` _(number)_: Number of blocks to fetch (default: `20`).
+
+#### **Returns**
+
+- `Promise<IBlockGasInformation[]>`: Array of gas information objects per block.
+
+#### **Example**
+
+```ts
+const blocks = await getBlocksGasInformation({
+  chainId: '0',
+  networkId: 'mainnet01',
+});
+console.log(blocks);
+```
+
+### `IBlockGasInformation` Structure
+
+Each block's gas info includes:
+
+- `blockHeight`: Block number
+- `totalGasConsumed`: Sum of actual gas used by all txs
+- `totalGasLimit`: Sum of declared gas limits
+- `totalGasPaid`: Total `gasPrice * gasLimit` of all txs
+- `txCount`: Number of transactions
+- `blockGasUsedPercent`: Gas usage vs block capacity
+- `gasPriceStats`:
+  - `min`: Minimum gas price
+  - `max`: Maximum gas price
+  - `avg`: Average gas price
+  - `median`: Median gas price
+
+### Notes
+
+- Uses `https://api.chainweb.com` for mainnet and
+  `https://api.testnet.chainweb.com` for testnet by default.
+- Block gas capacity is assumed as `150000`.
+- Skips blocks with zero transactions when estimating gas price.
 
 [1]:
   https://githubbox.com/kadena-community/kadena.js/tree/main/packages/libs/client-utils/codesandbox

--- a/packages/libs/client-utils/README.md
+++ b/packages/libs/client-utils/README.md
@@ -99,7 +99,8 @@ estimateGasPrice(parameters: IGasPriceEstimateProperties): Promise<number>
 - `host?` _(string)_: Optional base URL of the Chainweb API (defaults to
   Kadena's mainnet/testnet based on `networkId`).
 - `chainId` _(string)_: Chain ID (e.g., `"0"` through `"19"`).
-- `networkId` _(string)_: Network ID (e.g., `"mainnet01"`, `"testnet04"`).
+- `networkId?` _(string)_: Network ID (e.g., `"mainnet01"`, `"testnet04"` -
+  default `"mainnet01"` ).
 - `height?` _(number)_: Optional block max height ( default the chian height).
 - `items?` _(number)_: Number of blocks to fetch (default: `20`).
 
@@ -136,7 +137,8 @@ getBlocksGasInformation(parameters: IGasPriceEstimateProperties): Promise<IBlock
 - `host?` _(string)_: Optional base URL of the Chainweb API (defaults to
   Kadena's mainnet/testnet based on `networkId`).
 - `chainId` _(string)_: Chain ID (e.g., `"0"` through `"19"`).
-- `networkId` _(string)_: Network ID (e.g., `"mainnet01"`, `"testnet04"`).
+- `networkId?` _(string)_: Network ID (e.g., `"mainnet01"`, `"testnet04"` -
+  default `"mainnet01"` ).
 - `height?` _(number)_: Optional block max height ( default the chian height).
 - `items?` _(number)_: Number of blocks to fetch (default: `20`).
 

--- a/packages/libs/client-utils/etc/client-utils-core.api.md
+++ b/packages/libs/client-utils/etc/client-utils-core.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import type { ChainId } from '@kadena/client';
+import type { ChainId as ChainId_2 } from '@kadena/types';
 import { IClient } from '@kadena/client';
 import { ICommand } from '@kadena/types';
 import { ICommandResult } from '@kadena/chainweb-node-client';
@@ -22,6 +23,10 @@ import type { PactValue } from '@kadena/types';
 export const asyncPipe: IAsyncPipe;
 
 // Warning: (ae-forgotten-export) The symbol "IClientConfig" needs to be exported by the entry point index.d.ts
+//
+// @alpha
+export const calculateGasConsumption: (command: IPartialPactCommand | ((cmd?: IPartialPactCommand | (() => IPartialPactCommand)) => IPartialPactCommand), host?: IClientConfig['host'], client?: IClient) => Promise<unknown>;
+
 // Warning: (ae-forgotten-export) The symbol "IAccount" needs to be exported by the entry point index.d.ts
 //
 // @alpha (undocumented)
@@ -400,8 +405,21 @@ export const dirtyReadClient: <T = PactValue>(args_0: Omit<IClientConfig, "sign"
     }], [], T extends Promise<any> ? T : Promise<T>>;
 };
 
-// @alpha
-export const estimateGas: (command: IPartialPactCommand | ((cmd?: IPartialPactCommand | (() => IPartialPactCommand)) => IPartialPactCommand), host?: IClientConfig['host'], client?: IClient) => Promise<unknown>;
+// @alpha @deprecated
+export const estimateGas: (command: IPartialPactCommand | ((cmd?: IPartialPactCommand | (() => IPartialPactCommand)) => IPartialPactCommand), host?: IClientConfig['host'], client?: IClient) => Promise<{
+    gasLimit: unknown;
+    gasPrice: number;
+}>;
+
+// Warning: (ae-forgotten-export) The symbol "IGasPriceEstimateProperties" needs to be exported by the entry point index.d.ts
+//
+// @public
+export function estimateGasPrice({ host, height, chainId: chain, networkId, items, }: IGasPriceEstimateProperties): Promise<number>;
+
+// Warning: (ae-forgotten-export) The symbol "IBlockGasInformation" needs to be exported by the entry point index.d.ts
+//
+// @public
+export function getBlocksGasInformation({ host, height, chainId, networkId, items, }: IGasPriceEstimateProperties): Promise<IBlockGasInformation[]>;
 
 // @alpha (undocumented)
 export const

--- a/packages/libs/client-utils/etc/client-utils-core.api.md
+++ b/packages/libs/client-utils/etc/client-utils-core.api.md
@@ -405,7 +405,7 @@ export const dirtyReadClient: <T = PactValue>(args_0: Omit<IClientConfig, "sign"
     }], [], T extends Promise<any> ? T : Promise<T>>;
 };
 
-// @alpha @deprecated
+// @alpha
 export const estimateGas: (command: IPartialPactCommand | ((cmd?: IPartialPactCommand | (() => IPartialPactCommand)) => IPartialPactCommand), host?: IClientConfig['host'], client?: IClient) => Promise<{
     gasLimit: unknown;
     gasPrice: number;

--- a/packages/libs/client-utils/src/core/estimate-gas.ts
+++ b/packages/libs/client-utils/src/core/estimate-gas.ts
@@ -62,6 +62,7 @@ export const estimateGas = async (
       host: typeof host === 'string' ? host : undefined,
       networkId: cmd.networkId,
       chainId: cmd.meta.chainId,
-    }),
+      // fallback to minimum gas price if estimation fails
+    }).catch(() => 1e-8),
   };
 };

--- a/packages/libs/client-utils/src/core/estimate-gas.ts
+++ b/packages/libs/client-utils/src/core/estimate-gas.ts
@@ -9,7 +9,7 @@ import { composeWithDefaults, getClient, throwIfFails } from './utils/helpers';
  * estimate gas for a command
  * @alpha
  */
-export const estimateGas = (
+export const calculateGasConsumption = (
   command:
     | IPartialPactCommand
     | ((
@@ -22,14 +22,38 @@ export const estimateGas = (
     (cmd) =>
       composeWithDefaults(cmd)({
         meta: {
-          gasLimit: 10000,
+          gasLimit: 140000,
           gasPrice: 1.0e-8,
         } as IPartialPactCommand['meta'],
       }),
     createTransaction,
     (tx) => client.local(tx, { preflight: true, signatureVerification: false }),
     throwIfFails,
-    (response) => ({ gasLimit: response.gas, gasPrice: 1.0e-8 }),
+    (response) => response.gas,
   );
   return pipeLine(command);
+};
+
+/**
+ * estimate gas for a command;
+ * this function always returns a gasPrice of 1.0e-8, if you want to estimate the gas price use `estimateGasPrice` which is more accurate
+ * @alpha
+ * @deprecated for gasLimit use `calculateGasConsumption` and for gasPrice use `estimateGasPrice`
+ * @see {@link estimateGasPrice}
+ * @see {@link calculateGasConsumption}
+ */
+export const estimateGas = async (
+  command:
+    | IPartialPactCommand
+    | ((
+        cmd?: IPartialPactCommand | (() => IPartialPactCommand),
+      ) => IPartialPactCommand),
+  host?: IClientConfig['host'],
+  client = getClient(host),
+) => {
+  const gasLimit = await calculateGasConsumption(command, host, client);
+  return {
+    gasLimit,
+    gasPrice: 1.0e-8,
+  };
 };

--- a/packages/libs/client-utils/src/core/estimateGasPrice/estimateGasPrice.ts
+++ b/packages/libs/client-utils/src/core/estimateGasPrice/estimateGasPrice.ts
@@ -84,7 +84,7 @@ export const fetchBlockInformation = async ({
 export interface IGasPriceEstimateProperties {
   host?: string;
   chainId: ChainId;
-  networkId: string;
+  networkId?: string;
   height?: number | undefined;
   items?: number;
 }
@@ -108,7 +108,7 @@ export async function getBlocksGasInformation({
   host,
   height,
   chainId,
-  networkId,
+  networkId = 'mainnet01',
   items = 20,
 }: IGasPriceEstimateProperties) {
   let maxHeight: number | undefined = height;

--- a/packages/libs/client-utils/src/core/estimateGasPrice/estimateGasPrice.ts
+++ b/packages/libs/client-utils/src/core/estimateGasPrice/estimateGasPrice.ts
@@ -1,0 +1,177 @@
+import type { ChainId } from '@kadena/types';
+import type { IBlockChainData } from './utils';
+import { calculateGasInformation, calculateGasPrice } from './utils';
+
+/**
+ *
+ * Fetches the current height of the chain from the cut endpoint.
+ * @param host - The base URL of the Chainweb API.
+ * @param chainId - The chain ID.
+ * @param networkId - The network ID (e.g., mainnet01, testnet04).
+ * @returns The current height of the chain.
+ * @throws An error if the cut height cannot be fetched.
+ * @example
+ * const height = await getChainHeight({
+ *   baseUrl: 'https://api.chainweb.com',
+ *   chain: '0',
+ *   networkId: 'mainnet01',
+ * });
+ * console.log('Current chain height:', height);
+ * // Output: Current chain height: 12345678
+ */
+export const getChainHeight = async ({
+  host,
+  chainId,
+  networkId,
+}: {
+  host: string;
+  chainId: ChainId;
+  networkId: string;
+}) => {
+  const baseUrl = host.endsWith('/') ? host.slice(0, host.length - 1) : host;
+  const cut = (await fetch(`${baseUrl}/chainweb/0.0/${networkId}/cut`).then(
+    (res) => res.json(),
+  )) as { hashes: Record<string, { height: number }> };
+  if (cut?.hashes?.[chainId]?.height) {
+    return cut?.hashes[chainId].height;
+  } else {
+    throw new Error('Failed to fetch cut height');
+  }
+};
+
+/**
+ * Fetches block information from the Chainweb API.
+ * @param host - The base URL of the Chainweb API.
+ * @param chainId - The chain ID.
+ * @param networkId - The network ID (e.g., mainnet01, testnet04).
+ * @param minHeight - The minimum block height to fetch.
+ * @param maxHeight - The maximum block height to fetch.
+ * @returns An object containing block information.
+ * @throws An error if the block information cannot be fetched.
+ * @example
+ * const blocks = await fetchBlockInformation({
+ *   baseUrl: 'https://api.chainweb.com',
+ *   chain: '0',
+ *   networkId: 'mainnet01',
+ *   minHeight: 12345678,
+ *   maxHeight: 12345700,
+ * });
+ * console.log('Block information:', blocks);
+ * // Output: Block information: { items: [...] }
+ *
+ */
+export const fetchBlockInformation = async ({
+  host,
+  chainId,
+  networkId,
+  minHeight,
+  maxHeight,
+}: {
+  host: string;
+  chainId: string;
+  networkId: string;
+  minHeight: number;
+  maxHeight: number;
+}) => {
+  const baseUrl = host.endsWith('/') ? host.slice(0, host.length - 1) : host;
+  const blocks = (await fetch(
+    `${baseUrl}/chainweb/0.0/${networkId}/chain/${chainId}/block?minheight=${minHeight}&maxheight=${maxHeight}`,
+  ).then((res) => res.json())) as IBlockChainData;
+
+  return blocks;
+};
+
+export interface IGasPriceEstimateProperties {
+  host?: string;
+  chainId: ChainId;
+  networkId: string;
+  height?: number | undefined;
+  items?: number;
+}
+
+const DEFAULT_HOSTS: Record<string, string> = {
+  mainnet01: 'https://api.chainweb.com',
+  testnet04: 'https://api.testnet.chainweb.com',
+};
+
+/**
+ * Fetches gas information for a given set of blocks. this can be used to calculate the gas price.
+ * @param host - The base URL of the Chainweb API.
+ * @param height - The block height to start fetching from (optional).
+ * @param chainId - The chain ID.
+ * @param networkId - The network ID (e.g., mainnet01, testnet04).
+ * @param items - The number of blocks to fetch (default is 20).
+ * @returns An array of gas information for each block.
+ * @public
+ */
+export async function getBlocksGasInformation({
+  host,
+  height,
+  chainId,
+  networkId,
+  items = 20,
+}: IGasPriceEstimateProperties) {
+  let maxHeight: number | undefined = height;
+  if (host === undefined) {
+    host = DEFAULT_HOSTS[networkId];
+    if (!host) {
+      throw new Error(`Unknown networkId: ${networkId}`);
+    }
+  }
+
+  if (maxHeight === undefined) {
+    // fetch the max height from the cut endpoint if not provided
+    const blockHeight = await getChainHeight({
+      host: host,
+      chainId: chainId,
+      networkId,
+    });
+    // consider one more block to account for the current block; we then fetch 21 blocks
+    maxHeight = blockHeight + 1;
+  }
+
+  const minHeight = Math.max(maxHeight - items, 0);
+
+  const blocks = await fetchBlockInformation({
+    host: host,
+    chainId: chainId,
+    networkId,
+    minHeight,
+    maxHeight,
+  });
+
+  if (blocks.items.length === items + 1) {
+    // ignore the first block if we have items + 1 blocks; because we added one more block to the max height
+    blocks.items.shift();
+  }
+
+  return calculateGasInformation(blocks);
+}
+
+/**
+ * Estimates the gas price based on the provided parameters.
+ * @param host - The base URL of the Chainweb API.
+ * @param height - The block height to start fetching from (optional).
+ * @param chainId - The chain ID.
+ * @param networkId - The network ID (e.g., mainnet01, testnet04).
+ * @param items - The number of blocks to fetch (default is 20).
+ * @returns The estimated gas price. which is the median of the minimum gas prices from the blocks. this discards blocks with no transactions.
+ * @public
+ */
+export async function estimateGasPrice({
+  host,
+  height,
+  chainId: chain,
+  networkId,
+  items = 20,
+}: IGasPriceEstimateProperties) {
+  const gasData = await getBlocksGasInformation({
+    host,
+    height,
+    chainId: chain,
+    networkId,
+    items,
+  });
+
+  return calculateGasPrice(gasData);
+}

--- a/packages/libs/client-utils/src/core/estimateGasPrice/index.ts
+++ b/packages/libs/client-utils/src/core/estimateGasPrice/index.ts
@@ -1,0 +1,1 @@
+export { estimateGasPrice, getBlocksGasInformation } from './estimateGasPrice';

--- a/packages/libs/client-utils/src/core/estimateGasPrice/tests/estimateGasPrice.test.ts
+++ b/packages/libs/client-utils/src/core/estimateGasPrice/tests/estimateGasPrice.test.ts
@@ -1,0 +1,164 @@
+import { base64UrlEncode } from '@kadena/cryptography-utils';
+import { describe, expect, it } from 'vitest';
+import {
+  calculateGasInformation,
+  calculateGasPrice,
+  MINIMUM_GAS_PRICE,
+} from '../utils';
+
+const base64 = (object: Record<string, unknown>): string => {
+  return base64UrlEncode(JSON.stringify(object));
+};
+
+describe('calculateGasInformation', () => {
+  it('summarizes block data to gas information', async () => {
+    const blocks = {
+      items: [
+        {
+          header: {
+            height: 1,
+          },
+          payloadWithOutputs: {
+            transactions: [
+              [
+                base64({
+                  hash: 'test-hash-1',
+                  cmd: JSON.stringify({
+                    meta: { gasPrice: 0.1, gasLimit: 10 },
+                  }),
+                }),
+                base64({ gas: 8 }),
+              ],
+              [
+                base64({
+                  hash: 'test-hash-2',
+                  cmd: JSON.stringify({
+                    meta: { gasPrice: 0.2, gasLimit: 5 },
+                  }),
+                }),
+                base64({ gas: 4 }),
+              ],
+            ] satisfies [string, string][],
+          },
+        },
+      ],
+    };
+    const gasInfo = calculateGasInformation(blocks, {
+      maxBlockCapacity: 24,
+    });
+
+    expect(gasInfo).toEqual([
+      {
+        blockHeight: 1,
+        totalGasConsumed: 12,
+        totalGasLimit: 15,
+        totalGasPaid: 1.6,
+        txCount: 2,
+        blockGasUsedPercent: 50,
+        gasPriceStats: {
+          min: 0.1,
+          max: 0.2,
+          avg: 0.15,
+          median: 0.15,
+        },
+      },
+    ]);
+  });
+});
+
+describe('calculateGasPrice', () => {
+  it('returns median of mins', () => {
+    const gasData = [
+      {
+        txCount: 3,
+        gasPriceStats: {
+          min: 0.1,
+        },
+      },
+      {
+        txCount: 2,
+        gasPriceStats: {
+          min: 0.3,
+        },
+      },
+    ];
+
+    const gasPrice = calculateGasPrice(gasData);
+
+    expect(gasPrice).toEqual(0.2);
+  });
+  it('returns median of mins', () => {
+    const gasData = [
+      {
+        txCount: 3,
+        gasPriceStats: {
+          min: 0.1,
+        },
+      },
+      {
+        txCount: 2,
+        gasPriceStats: {
+          min: 0.3,
+        },
+      },
+      {
+        txCount: 2,
+        gasPriceStats: {
+          min: 0.21,
+        },
+      },
+    ];
+
+    const gasPrice = calculateGasPrice(gasData);
+
+    expect(gasPrice).toEqual(0.21);
+  });
+
+  it('discards empty blocks', () => {
+    const gasData = [
+      {
+        txCount: 3,
+        gasPriceStats: {
+          min: 0.1,
+        },
+      },
+      {
+        txCount: 0,
+        gasPriceStats: {
+          min: 0,
+        },
+      },
+      {
+        txCount: 2,
+        gasPriceStats: {
+          min: 0.3,
+        },
+      },
+    ];
+
+    const gasPrice = calculateGasPrice(gasData);
+
+    expect(gasPrice).toEqual(0.2);
+  });
+
+  it('returns min gas price if all blocks empty', () => {
+    const gasData = [
+      {
+        txCount: 0,
+        gasPriceStats: {
+          min: 0,
+        },
+      },
+      {
+        txCount: 0,
+        gasPriceStats: {
+          min: 0,
+        },
+      },
+    ];
+
+    const gasPrice = calculateGasPrice(gasData);
+
+    expect(gasPrice).toEqual(MINIMUM_GAS_PRICE);
+  });
+});

--- a/packages/libs/client-utils/src/core/estimateGasPrice/utils.ts
+++ b/packages/libs/client-utils/src/core/estimateGasPrice/utils.ts
@@ -75,16 +75,27 @@ export function calculateGasInformation(
   const gasData = blocks.items.map((block) => {
     const txData = block.payloadWithOutputs.transactions.map(
       ([payload, result]) => {
-        const tx = JSON.parse(base64UrlDecode(payload));
-        const command = JSON.parse(tx.cmd);
-        const gasConsumed = JSON.parse(base64UrlDecode(result)).gas;
-        return {
-          hash: tx.hash,
-          gasPrice: command.meta.gasPrice,
-          gasLimit: command.meta.gasLimit,
-          consumedGas: gasConsumed,
-          gasPaid: command.meta.gasPrice * gasConsumed,
-        };
+        try {
+          const tx = JSON.parse(base64UrlDecode(payload));
+          const command = JSON.parse(tx.cmd);
+          const gasConsumed = JSON.parse(base64UrlDecode(result)).gas;
+          return {
+            hash: tx.hash,
+            gasPrice: command.meta.gasPrice,
+            gasLimit: command.meta.gasLimit,
+            consumedGas: gasConsumed ?? command.meta.gasLimit,
+            gasPaid: command.meta.gasPrice * gasConsumed,
+          };
+        } catch (e) {
+          console.error('Error parsing transaction data:', e);
+          return {
+            hash: 'N/A',
+            gasPrice: 0,
+            gasLimit: 0,
+            consumedGas: 0,
+            gasPaid: 0,
+          };
+        }
       },
     );
 
@@ -151,5 +162,5 @@ export function calculateGasPrice(
 
   const estimate = median(mins);
 
-  return estimate || MINIMUM_GAS_PRICE;
+  return Math.max(estimate ?? 0, MINIMUM_GAS_PRICE);
 }

--- a/packages/libs/client-utils/src/core/estimateGasPrice/utils.ts
+++ b/packages/libs/client-utils/src/core/estimateGasPrice/utils.ts
@@ -1,0 +1,155 @@
+import { base64UrlDecode } from '@kadena/cryptography-utils';
+import { PactNumber } from '@kadena/pactjs';
+
+export const MINIMUM_GAS_PRICE = 1e-8;
+
+export const MAX_BLOCK_CAPACITY = 150000;
+
+export const median = (sortedArray: number[]): number => {
+  if (sortedArray.length === 0) {
+    return 0;
+  }
+  if (sortedArray.length % 2 === 1) {
+    return sortedArray[Math.floor(sortedArray.length / 2)];
+  } else {
+    return new PactNumber(sortedArray[sortedArray.length / 2 - 1])
+      .plus(sortedArray[sortedArray.length / 2])
+      .dividedBy(2)
+      .toNumber();
+  }
+};
+
+export const average = (arr: number[]): number => {
+  if (arr.length === 0) {
+    return 0;
+  }
+  return arr
+    .reduce((acc, gasFee) => acc.plus(gasFee), new PactNumber(0))
+    .dividedBy(arr.length)
+    .toNumber();
+};
+
+/**
+ * Interface representing the subset of structure of the block data returned from the Chainweb API
+ * this is not the full structure of the block data, but only the relevant parts for calculating gas fees.
+ */
+export interface IBlockChainData {
+  items: Array<{
+    header: {
+      height: number;
+    };
+    payloadWithOutputs: { transactions: Array<[string, string]> };
+  }>;
+}
+
+/**
+ * Interface representing the gas information for a block.
+ * This includes the total gas consumed, total gas limit, total gas paid, transaction count,
+ * block gas used percentage, and gas price statistics (min, max, avg, median).
+ * @public
+ */
+export interface IBlockGasInformation {
+  blockHeight: number;
+  totalGasConsumed: number; // sum of all gas consumed in the block transactions extracted from gas field of tx result
+  totalGasLimit: number; // sum of all gas limits in the block transactions extracted from gasLimit field of tx command
+  totalGasPaid: number; // sum of all gasPrice * gasLimit in the block transactions extracted from meta field of tx command
+  txCount: number; // number of transactions in the block
+  blockGasUsedPercent: number; // percentage of gas used in the block (totalGasConsumed / MAX_BLOCK_CAPACITY)
+  gasPriceStats: {
+    min: number; // minimum gas price in the block transactions
+    max: number; // maximum gas price in the block transactions
+    avg: number; // average gas price in the block transactions (does not consider usage)
+    median: number; // median gas price in the block transactions
+  };
+}
+
+/**
+ * Calculates gas information for a given set of blocks.
+ * @param blocks - An object containing block information.
+ * @returns An array of gas information for each block.
+ */
+export function calculateGasInformation(
+  blocks: IBlockChainData,
+  { maxBlockCapacity = MAX_BLOCK_CAPACITY } = {},
+) {
+  const gasData = blocks.items.map((block) => {
+    const txData = block.payloadWithOutputs.transactions.map(
+      ([payload, result]) => {
+        const tx = JSON.parse(base64UrlDecode(payload));
+        const command = JSON.parse(tx.cmd);
+        const gasConsumed = JSON.parse(base64UrlDecode(result)).gas;
+        return {
+          hash: tx.hash,
+          gasPrice: command.meta.gasPrice,
+          gasLimit: command.meta.gasLimit,
+          consumedGas: gasConsumed,
+          gasPaid: command.meta.gasPrice * gasConsumed,
+        };
+      },
+    );
+
+    const totalGasConsumed = txData.reduce((acc, tx) => {
+      return acc + tx.consumedGas;
+    }, 0);
+
+    const totalGasLimit = txData.reduce((acc, tx) => {
+      return acc + tx.gasLimit;
+    }, 0);
+
+    const totalGasPaid = txData.reduce((acc, tx) => {
+      return acc + tx.gasPaid;
+    }, 0);
+
+    const txGasPrice = txData
+      .map((tx: { gasPrice: number }) => tx.gasPrice)
+      .sort((a, b) => a - b);
+    const minGasPrice = txGasPrice[0] ?? 0;
+    const maxGasPrice = txGasPrice[txGasPrice.length - 1] ?? 0;
+
+    const gasInformation: IBlockGasInformation = {
+      blockHeight: block.header.height,
+      totalGasConsumed,
+      totalGasLimit,
+      totalGasPaid,
+      txCount: txData.length,
+      blockGasUsedPercent: (totalGasConsumed * 100) / maxBlockCapacity,
+      gasPriceStats: {
+        min: minGasPrice,
+        max: maxGasPrice,
+        avg: average(txGasPrice),
+        median: median(txGasPrice),
+      },
+    };
+    return gasInformation;
+  });
+
+  const sorted = gasData.sort((a, b) => b.blockHeight - a.blockHeight);
+
+  return sorted;
+}
+
+/**
+ * Calculates the gas price based on the provided gas data.
+ * @param gasData - An array of gas data for each block.
+ * @param considerCongestion - A boolean indicating whether to consider usage in the calculation.
+ * @returns The estimated gas price.
+ * @example
+ * const estimatedGasPrice = calculateGasPrice(gasData);
+ * console.log('Estimated gas price:', estimatedGasPrice);
+ * // Output: Estimated gas price: 0.00000001
+ */
+export function calculateGasPrice(
+  gasData: Array<{
+    txCount: number;
+    gasPriceStats: { min: number };
+  }>,
+) {
+  const mins = gasData
+    .filter((b) => b.txCount > 0)
+    .map((data) => data.gasPriceStats.min)
+    .sort((a, b) => a - b);
+
+  const estimate = median(mins);
+
+  return estimate || MINIMUM_GAS_PRICE;
+}

--- a/packages/libs/client-utils/src/core/index.ts
+++ b/packages/libs/client-utils/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from './client-helpers';
 export * from './estimate-gas';
+export * from './estimateGasPrice';
 export * from './global-config';
 export * from './utils/asyncPipe';
 export * from './utils/with-emitter';

--- a/packages/libs/client-utils/src/core/test/cross-chain-client.test.ts
+++ b/packages/libs/client-utils/src/core/test/cross-chain-client.test.ts
@@ -81,8 +81,8 @@ describe('crossChainClient', () => {
     )
       .on('sign', (tx) => {
         expect(tx).toEqual({
-          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
-          hash: 'uoS6m3KFHVs-8ByRWfiOweZobK1YzV7WloA1DWM1gd4',
+          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":900,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
+          hash: '7dtowRVlY9CfyKCNOAkrbhfr1uHUEkBlu-CuvFezt5o',
           sigs: [{ sig: 'sig-hash' }],
         });
       })
@@ -131,8 +131,8 @@ describe('crossChainClient', () => {
       })
       .on('gas-station', (data) => {
         expect(data).toEqual({
-          cmd: '{"networkId":"test-network","payload":{"cont":{"data":{},"pactId":"test-pact-id","step":1,"proof":"test-spv-proof","rollback":false}},"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"test-gas-station","ttl":28800,"creationTime":1698278400,"chainId":"2"},"nonce":"kjs:nonce:1698278400000","signers":[]}',
-          hash: '5Wz0TmL_2kKEKpB2BiKwmOlesITo-I19nxrGFtN6mXw',
+          cmd: '{"networkId":"test-network","payload":{"cont":{"data":{},"pactId":"test-pact-id","step":1,"proof":"test-spv-proof","rollback":false}},"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"test-gas-station","ttl":900,"creationTime":1698278400,"chainId":"2"},"nonce":"kjs:nonce:1698278400000","signers":[]}',
+          hash: 'Q5hyJ2Ed_y15xgsPMIq3SICz_z8mRtogaEx7D9l1h-E',
           sigs: [],
         });
       })
@@ -214,8 +214,8 @@ describe('crossChainClient', () => {
     )
       .on('sign', (tx) => {
         expect(tx).toEqual({
-          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
-          hash: 'uoS6m3KFHVs-8ByRWfiOweZobK1YzV7WloA1DWM1gd4',
+          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":900,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
+          hash: '7dtowRVlY9CfyKCNOAkrbhfr1uHUEkBlu-CuvFezt5o',
           sigs: [{ sig: 'sig-hash' }],
         });
       })
@@ -260,8 +260,8 @@ describe('crossChainClient', () => {
       })
       .on('sign-continuation', (tx) => {
         expect(tx).toEqual({
-          cmd: '{"networkId":"test-network","payload":{"cont":{"data":{},"pactId":"test-pact-id","step":1,"proof":"test-spv-proof","rollback":false}},"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"target-chain-gas-payer","ttl":28800,"creationTime":1698278400,"chainId":"2"},"nonce":"kjs:nonce:1698278400000","signers":[{"pubKey":"pk-target-chain-gas-payer","scheme":"ED25519","clist":[{"name":"coin.GAS","args":[]}]}]}',
-          hash: '98unmynMm1cd0PSZtIKTSrGrb4pXckPfFo2huVELHiI',
+          cmd: '{"networkId":"test-network","payload":{"cont":{"data":{},"pactId":"test-pact-id","step":1,"proof":"test-spv-proof","rollback":false}},"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"target-chain-gas-payer","ttl":900,"creationTime":1698278400,"chainId":"2"},"nonce":"kjs:nonce:1698278400000","signers":[{"pubKey":"pk-target-chain-gas-payer","scheme":"ED25519","clist":[{"name":"coin.GAS","args":[]}]}]}',
+          hash: 'OY3QVENpMQ3kHEfqcoqgH0Ze_mU78aTQEt7nyAISuYw',
           sigs: [{ sig: 'sig-cont-hash' }],
         });
       })

--- a/packages/libs/client-utils/src/core/test/preflight-client.test.ts
+++ b/packages/libs/client-utils/src/core/test/preflight-client.test.ts
@@ -40,8 +40,8 @@ describe('preflightClient', () => {
     )
       .on('sign', (tx) => {
         expect(tx).toEqual({
-          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
-          hash: 'uoS6m3KFHVs-8ByRWfiOweZobK1YzV7WloA1DWM1gd4',
+          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":900,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
+          hash: '7dtowRVlY9CfyKCNOAkrbhfr1uHUEkBlu-CuvFezt5o',
           sigs: [{ sig: 'sig-hash' }],
         });
       })

--- a/packages/libs/client-utils/src/core/test/submit-client.test.ts
+++ b/packages/libs/client-utils/src/core/test/submit-client.test.ts
@@ -48,8 +48,8 @@ describe('submitClient', () => {
     )
       .on('sign', (tx) => {
         expect(tx).toEqual({
-          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":28800,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
-          hash: 'uoS6m3KFHVs-8ByRWfiOweZobK1YzV7WloA1DWM1gd4',
+          cmd: '{"networkId":"test-network","payload":{"exec":{"code":"(test 1 2 3)","data":{}}},"signers":[{"pubKey":"pk","scheme":"ED25519"}],"meta":{"gasLimit":2500,"gasPrice":1e-8,"sender":"","ttl":900,"creationTime":1698278400,"chainId":"1"},"nonce":"kjs:nonce:1698278400000"}',
+          hash: '7dtowRVlY9CfyKCNOAkrbhfr1uHUEkBlu-CuvFezt5o',
           sigs: [{ sig: 'sig-hash' }],
         });
       })

--- a/packages/libs/client-utils/src/faucet/test/fund-existing-account-on-testnet.test.ts
+++ b/packages/libs/client-utils/src/faucet/test/fund-existing-account-on-testnet.test.ts
@@ -36,7 +36,7 @@ describe('fundExistingAccountOnTestnetCommand', () => {
         gasLimit: 2500,
         gasPrice: 1e-8,
         sender: 'faucetAccount',
-        ttl: 28800,
+        ttl: 900,
         chainId: '1',
       },
       networkId: 'testnet04',

--- a/packages/libs/client-utils/src/faucet/test/fund-new-account-on-testnet.test.ts
+++ b/packages/libs/client-utils/src/faucet/test/fund-new-account-on-testnet.test.ts
@@ -67,7 +67,7 @@ describe('fundNewAccountOnTestnetCommand', () => {
         gasLimit: 2500,
         gasPrice: 1e-8,
         sender: 'faucet-account',
-        ttl: 28800,
+        ttl: 900,
         chainId: '1',
       },
       networkId: 'testnet04',

--- a/packages/libs/client-utils/src/integration-tests/estimate-gas-price.int.test.ts
+++ b/packages/libs/client-utils/src/integration-tests/estimate-gas-price.int.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { estimateGasPrice, getBlocksGasInformation } from '../core';
+import { MINIMUM_GAS_PRICE } from '../core/estimateGasPrice/utils';
+
+describe('estimateGasPrice', () => {
+  it('fetch and returns gas price for specific height', async () => {
+    const gasPrice = await estimateGasPrice({
+      networkId: 'testnet04',
+      chainId: '0',
+      height: 5000000,
+    });
+
+    expect(gasPrice).toBe(MINIMUM_GAS_PRICE);
+  });
+
+  it('fetch and returns gas price for latest height', async () => {
+    const gasPrice = await estimateGasPrice({
+      networkId: 'testnet04',
+      chainId: '0',
+    });
+
+    expect(gasPrice).toBeGreaterThan(0);
+  });
+});
+
+describe('getBlocksGasInformation', async () => {
+  it('fetch and returns gas information for specific height', async () => {
+    const gasInformation = await getBlocksGasInformation({
+      networkId: 'testnet04',
+      chainId: '0',
+      height: 5300000,
+    });
+
+    const [firstBlock] = gasInformation;
+
+    console.log('gasInformation', firstBlock);
+
+    expect(firstBlock).toStrictEqual({
+      blockHeight: 5300000,
+      totalGasConsumed: 0,
+      totalGasLimit: 0,
+      totalGasPaid: 0,
+      txCount: 0,
+      blockGasUsedPercent: 0,
+      gasPriceStats: { min: 0, max: 0, avg: 0, median: 0 },
+    });
+  });
+  it('fetch and returns gas information for latest height', async () => {
+    const gasInformation = await getBlocksGasInformation({
+      networkId: 'testnet04',
+      chainId: '0',
+    });
+
+    const [firstBlock] = gasInformation;
+
+    expect(firstBlock.blockHeight).toBeGreaterThan(5300000);
+  });
+});

--- a/packages/libs/client-utils/vitest.config.ts
+++ b/packages/libs/client-utils/vitest.config.ts
@@ -24,6 +24,8 @@ const localConfig = defineConfig({
         'src/scripts/**/*',
         // its a script and auxiliary files that deploys marmalade namespaces and contracts
         'src/nodejs/marmalade/deployment/**/*',
+        // we have integration for this
+        'src/core/estimateGasPrice/estimateGasPrice.ts',
         'src/webauthn/**/*',
       ],
       provider: 'v8',

--- a/packages/libs/client/src/composePactCommand/composePactCommand.ts
+++ b/packages/libs/client/src/composePactCommand/composePactCommand.ts
@@ -43,7 +43,7 @@ const finalizeCommand = (
       gasLimit: 2500,
       gasPrice: 1.0e-8,
       sender: '',
-      ttl: 8 * 60 * 60, // 8 hours,
+      ttl: 15 * 60, // 15 minutes,
       creationTime: Math.floor(Date.now() / 1000),
     };
     finalCommand.meta = {

--- a/packages/libs/client/src/createTransactionBuilder/tests/createTransactionBuilder.test.ts
+++ b/packages/libs/client/src/createTransactionBuilder/tests/createTransactionBuilder.test.ts
@@ -140,7 +140,7 @@ describe('createTransactionBuilder', () => {
         gasLimit: 2500,
         gasPrice: 1e-8,
         sender: '',
-        ttl: 28800,
+        ttl: 900,
       },
       nonce: 'kjs:nonce:1690416000000',
     });

--- a/packages/libs/client/src/signing/keypair/tests/signWithKeypair.test.ts
+++ b/packages/libs/client/src/signing/keypair/tests/signWithKeypair.test.ts
@@ -76,7 +76,7 @@ describe('signWithKeypair', () => {
       {
         pubKey:
           '09e82da78d531e2d16852a923e9fe0f80f3b67a9b8d92c7f05e4782222252e12',
-        sig: '5bdcceab829c628afc2afe28d18e5efdc724f0ebc18e1aa10b03c07123f23bdd698a197aba39fc035c0a71c5c821f2f8e12fd6fb138dc33e6d2323b3bbd1b40e',
+        sig: '6d4db9f196afaa8dfb056aee782a5d74edc6fcd91d0eab06883007bf267d63f3c2b0f4bc91e1e3c50d434148eabfb21201c63fcccdfb44da086b347a35fa530e',
       },
       {
         pubKey:
@@ -89,12 +89,12 @@ describe('signWithKeypair', () => {
       {
         pubKey:
           '09e82da78d531e2d16852a923e9fe0f80f3b67a9b8d92c7f05e4782222252e12',
-        sig: '5bdcceab829c628afc2afe28d18e5efdc724f0ebc18e1aa10b03c07123f23bdd698a197aba39fc035c0a71c5c821f2f8e12fd6fb138dc33e6d2323b3bbd1b40e',
+        sig: '6d4db9f196afaa8dfb056aee782a5d74edc6fcd91d0eab06883007bf267d63f3c2b0f4bc91e1e3c50d434148eabfb21201c63fcccdfb44da086b347a35fa530e',
       },
       {
         pubKey:
           '815224b7316e0053635a91fea90f1f5bb474831b257be1aaaf2129ff989824d8',
-        sig: 'b921a16a15e2ffa36bda28fb1dcb98ef75e83d94ac2f2736013981d73759ead51945b1df21de254429772cdd6bfe8ea3c63001dfd06a2e0b0322abd3de2c7600',
+        sig: '3f554a1d62a81e67e3bc6d6779ab62b1e4d8dbe6bcd0e611985065a9d124653012eb37e085ddfb3505cd704ea2666bf3404eadee2d915308543583e7581d7d0d',
       },
     ]);
   });
@@ -151,7 +151,7 @@ describe('signWithKeypair', () => {
       {
         pubKey:
           '09e82da78d531e2d16852a923e9fe0f80f3b67a9b8d92c7f05e4782222252e12',
-        sig: 'fbc3819d977cf8f770c5fc6b5a75a3099969a7945cec6a5d2bd1e7dd0130a68935d52f1cfce62046db885370511904e00a9a9d2fee84f653f5d324dce9a82a00',
+        sig: '3725906aaa22b8fa6651c591343e3463539d9e64f774390aff0332f8bcbe7b2315bef57ef4d9b65a2893faebee33890ddaadb6bdf69d176e51be07e4c112200a',
       },
     ]);
   });
@@ -185,12 +185,12 @@ describe('signWithKeypair', () => {
       {
         pubKey:
           '09e82da78d531e2d16852a923e9fe0f80f3b67a9b8d92c7f05e4782222252e12',
-        sig: '5bdcceab829c628afc2afe28d18e5efdc724f0ebc18e1aa10b03c07123f23bdd698a197aba39fc035c0a71c5c821f2f8e12fd6fb138dc33e6d2323b3bbd1b40e',
+        sig: '6d4db9f196afaa8dfb056aee782a5d74edc6fcd91d0eab06883007bf267d63f3c2b0f4bc91e1e3c50d434148eabfb21201c63fcccdfb44da086b347a35fa530e',
       },
       {
         pubKey:
           '815224b7316e0053635a91fea90f1f5bb474831b257be1aaaf2129ff989824d8',
-        sig: 'b921a16a15e2ffa36bda28fb1dcb98ef75e83d94ac2f2736013981d73759ead51945b1df21de254429772cdd6bfe8ea3c63001dfd06a2e0b0322abd3de2c7600',
+        sig: '3f554a1d62a81e67e3bc6d6779ab62b1e4d8dbe6bcd0e611985065a9d124653012eb37e085ddfb3505cd704ea2666bf3404eadee2d915308543583e7581d7d0d',
       },
     ]);
   });
@@ -232,15 +232,15 @@ describe('signWithKeypair', () => {
 
     expect(signedTx1.sigs).toEqual([
       {
-        sig: '522264b48dfefacd06ac6edc4b72e37629f946dbb464396b069b035d7c11e0b4852ea0c9ef4da8aeafb964ed348c1d0a416d9736af87e8d936bbb2c1bc7d5c0e',
         pubKey:
           '815224b7316e0053635a91fea90f1f5bb474831b257be1aaaf2129ff989824d8',
+        sig: '7a71acbd6031af32a9ac3310307c094862cebc495b0444fd812b88e5a81511fb3ec7b43dcac84cf976fe5868342e3c858e236913b86ac483bff36e79c02dff0b',
       },
     ]);
 
     expect(signedTx2.sigs).toEqual([
       {
-        sig: 'fbc3819d977cf8f770c5fc6b5a75a3099969a7945cec6a5d2bd1e7dd0130a68935d52f1cfce62046db885370511904e00a9a9d2fee84f653f5d324dce9a82a00',
+        sig: '3725906aaa22b8fa6651c591343e3463539d9e64f774390aff0332f8bcbe7b2315bef57ef4d9b65a2893faebee33890ddaadb6bdf69d176e51be07e4c112200a',
         pubKey:
           '09e82da78d531e2d16852a923e9fe0f80f3b67a9b8d92c7f05e4782222252e12',
       },

--- a/packages/libs/wallet-sdk/src/sdk/tests/crossChainFinishCreate.test.ts
+++ b/packages/libs/wallet-sdk/src/sdk/tests/crossChainFinishCreate.test.ts
@@ -69,7 +69,7 @@ describe('simpleTransferCreateCommand', () => {
         gasLimit: 850,
         gasPrice: 1e-8,
         sender: 'k:gasPayerKey',
-        ttl: 28800,
+        ttl: 900,
         creationTime: expect.any(Number),
         chainId: '0',
       },


### PR DESCRIPTION
**client**:
* Changed default TTL to 900 (15 min)

**cleint-utils**:
* `estimateGasPrice`:  estimate gas price on a chain
```TS
const currentGasPriceEstimation: number = await estimateGasPrice({ chainId: "0" });
```
* `getBlocksGasInformation`: returns useful information about gas 
```TS
const gasInformation :IBlockGasInformation[] = await getBlocksGasInformation({ chainId: "0" });

type IBlockGasInformation = Array<{
  blockHeight: number;
  totalGasConsumed: number; // sum of all gas consumed in the block transactions extracted from gas field of tx result
  totalGasLimit: number; // sum of all gas limits in the block transactions extracted from gasLimit field of tx command
  totalGasPaid: number; // sum of all gasPrice * gasLimit in the block transactions extracted from meta field of tx command
  txCount: number; // number of transactions in the block
  blockGasUsedPercent: number; // percentage of gas used in the block (totalGasConsumed / MAX_BLOCK_CAPACITY)
  gasPriceStats: {
    min: number; // minimum gas price in the block transactions
    max: number; // maximum gas price in the block transactions
    avg: number; // average gas price in the block transactions (does not consider usage)
    median: number; // median gas price in the block transactions
  }>;
}
```
