### PR TITLE
walletconnect-adapter: Add WalletConnect chains argument for Kadena networks

### DIFF
--- a/.changeset/curvy-frogs-behave.md
+++ b/.changeset/curvy-frogs-behave.md
@@ -1,0 +1,5 @@
+---
+'@kadena/wallet-adapter-walletconnect': minor
+---
+
+walletconnect-adapter: Include chains argument in modal instantiation

--- a/packages/libs/wallet-adapter-walletconnect/src/WalletConnectAdapter.ts
+++ b/packages/libs/wallet-adapter-walletconnect/src/WalletConnectAdapter.ts
@@ -56,6 +56,7 @@ export class WalletConnectAdapter extends BaseWalletAdapter {
     this.modal = new WalletConnectModal({
       themeMode: 'light',
       projectId: finalOptions.projectId,
+      chains: [`kadena:${this.networkId}`],
     });
   }
 


### PR DESCRIPTION

# Summary

This PR updates the WalletConnect Adapter modal instantiation to include the chains argument.
By passing the Kadena network (kadena:${this.networkId}), the modal now correctly displays wallet options that support Kadena, instead of only showing the QR code.
## Changes

    Added chains: [kadena:${this.networkId}] to the WalletConnect modal configuration.

## Before

    Modal displays unsupported Kadena wallets in addition to the QR code.

## After

    Modal only displayed the QR code without wallet options at the bottom.

