### PR TITLE
Chainwebjs: fix implementation of recent headers

### DIFF
--- a/packages/libs/chainwebjs/src/headers.ts
+++ b/packages/libs/chainwebjs/src/headers.ts
@@ -48,8 +48,8 @@ export async function recentHeaders(
   host: string,
 ): Promise<IBlockHeader[]> {
   const cut = await currentCut(network, host);
-  const start = cut.hashes['0'].height - depth - n + 1;
-  const end = cut.hashes['0'].height - depth;
+  const start = cut.hashes[`${chainId}`].height - depth - n + 1;
+  const end = cut.hashes[`${chainId}`].height - depth;
   const upper = cut.hashes[`${chainId}`].hash;
 
   return branch(chainId, [upper], [], start, end, n, 'json', network, host);

--- a/packages/libs/chainwebjs/vitest.config.ts
+++ b/packages/libs/chainwebjs/vitest.config.ts
@@ -11,6 +11,9 @@ const localConfig = defineConfig({
         branches: 87.5,
         statements: 86.31,
       },
+      exclude: [
+        '**/types.ts',
+      ],
     },
   },
 });


### PR DESCRIPTION
The implementation of recent headers uses as upper bound for the respective branch query the block on the respective chain form the latest cut. However, queried heights are computed based on the lastest height on chain 0. In cases when chain 0 is ahead of the queries chain the query fails if for small confirmation depths.

This PR fixes this issues by always using the height of the block on the respective chain as reference for computing queried block heights.

I tested this locally in an application that uses the chainwebjs package.
