### PR TITLE
feat(adapter) WalletConnect session persistence + reconnection; Non‑invasive MetaMask Snap detection

### DIFF
--- a/.changeset/giant-plants-learn.md
+++ b/.changeset/giant-plants-learn.md
@@ -1,0 +1,18 @@
+---
+'@kadena/wallet-adapter-metamask-snap': minor
+'@kadena/wallet-adapter-walletconnect': minor
+---
+
+WalletConnect Adapter
+
+- Persist active session topic in localStorage and restore on reload
+- Reuse existing pairings to avoid extra QR modal scans
+- Reconnect automatically if provider is still connected
+- Cleanup provider state and stored session on disconnect/deletion
+
+Snap Adapter
+
+- Detection is now non-invasive: `detectSnapProvider` no longer performs
+  `wallet_getSnaps` or any RPC that could trigger a MetaMask unlock prompt. All
+  snap installation/enablement and potential prompts are deferred to the adapter
+  `connect()` flow.

--- a/packages/libs/wallet-adapter-metamask-snap/README.md
+++ b/packages/libs/wallet-adapter-metamask-snap/README.md
@@ -14,15 +14,15 @@ yarn add @kadena/wallet-adapter-metamask-snap
 pnpm add @kadena/wallet-adapter-metamask-snap
 ```
 
-## Manual Usage of the Adapter or Detection
+## Manual Usage: Detection and Connect
 
 If you need lower-level access, the following are also exported:
 
 - **`SnapAdapter`**: The actual adapter class, in case you want to instantiate
   it manually without relying on the lazy-loading factory.
-- **`detectSnapProvider`**: A standalone function that checks whether the Kadena
-  Snap is available in MetaMask. It returns the provider if found, or `null`
-  otherwise.
+- **`detectSnapProvider`**: A standalone function that checks whether the
+  MetaMask provider is present. It returns the provider if found, or `null`
+  otherwise. Snap installation/enablement is handled during `connect()`.
 
 ```ts
 import {
@@ -33,7 +33,7 @@ import {
 (async () => {
   const provider = await detectSnapProvider({ silent: true });
   if (!provider) {
-    console.log('MetaMask Snap not available.');
+    console.log('MetaMask not detected.');
     return;
   }
   const adapter = new SnapAdapter({ provider });
@@ -42,12 +42,18 @@ import {
 })();
 ```
 
+## Detection Behavior
+
+- Detection is non-invasive. It only checks for the injected MetaMask provider
+  on `window.ethereum` and does not call `wallet_getSnaps` or other RPCs.
+- Any required prompts (unlocking MetaMask, installing/enabling the Kadena
+  Snap) occur during `adapter.connect()`.
+
 ## Other Notes
 
 - The adapter internally calls `kda_connect`, `kda_requestSign`,
   `kda_disconnect`, etc., using the `"kda_"` RPC prefix required by the Snap.
-- If you support multiple wallets in your app, the lazy import in `snapAdapter`
-  helps reduce initial bundle size, loading only when MetaMask with the Snap is
-  detected.
-- Ensure the user has MetaMask installed **and** the Kadena Snap enabled.
-  Detection will return `null` otherwise.
+- If you support multiple wallets in your app, the lazy import in
+  `snapAdapterFactory` helps reduce initial bundle size.
+- Ensure the user has MetaMask installed. The Kadena Snap will be installed or
+  enabled during connect if needed.

--- a/packages/libs/wallet-adapter-metamask-snap/src/__tests__/provider.test.ts
+++ b/packages/libs/wallet-adapter-metamask-snap/src/__tests__/provider.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ISnapProvider } from '../provider';
-import { defaultSnapOrigin, detectSnapProvider } from '../provider';
+import { detectSnapProvider } from '../provider';
 
 describe('detectSnapProvider', () => {
   beforeEach(() => {
@@ -15,18 +15,10 @@ describe('detectSnapProvider', () => {
     vi.useRealTimers();
   });
 
-  it('resolves to provider when window.ethereum exists, isMetaMask true, and snap installed', async () => {
-    const snaps = {
-      [defaultSnapOrigin]: {
-        id: defaultSnapOrigin,
-        version: '0.0.0',
-        enabled: true,
-        blocked: false,
-      },
-    };
+  it('resolves to provider when window.ethereum exists and isMetaMask true (no RPC calls)', async () => {
     const fakeProvider: ISnapProvider = {
       isMetaMask: true,
-      request: vi.fn().mockResolvedValue(snaps),
+      request: vi.fn(),
       on: () => {},
       off: () => {},
     };
@@ -35,9 +27,7 @@ describe('detectSnapProvider', () => {
 
     const result = await detectSnapProvider();
     expect(result).toBe(fakeProvider);
-    expect(fakeProvider.request).toHaveBeenCalledWith({
-      method: 'wallet_getSnaps',
-    });
+    expect(fakeProvider.request).not.toHaveBeenCalled();
   });
 
   it('resolves to undefined when window.ethereum exists but isMetaMask false', async () => {

--- a/packages/libs/wallet-adapter-metamask-snap/src/__tests__/snapAdapter.test.ts
+++ b/packages/libs/wallet-adapter-metamask-snap/src/__tests__/snapAdapter.test.ts
@@ -105,7 +105,7 @@ describe('SnapAdapter', () => {
       const network: INetworkInfo = {
         networkName: 'mainnet',
         networkId: 'mainnet01',
-        urls: ['https://api.chainweb.com'],
+        url: ['https://api.chainweb.com'],
       };
       vi.spyOn(adapter as any, '_getActiveNetwork').mockResolvedValueOnce(
         network,
@@ -122,7 +122,7 @@ describe('SnapAdapter', () => {
         {
           networkName: 'testnet',
           networkId: 'testnet04',
-          urls: ['https://api.testnet.chainweb.com'],
+          url: ['https://api.testnet.chainweb.com'],
         },
       ];
       vi.spyOn(adapter as any, '_getNetworks').mockResolvedValueOnce(networks);

--- a/packages/libs/wallet-adapter-metamask-snap/src/__tests__/snapAdapter.test.ts
+++ b/packages/libs/wallet-adapter-metamask-snap/src/__tests__/snapAdapter.test.ts
@@ -105,7 +105,7 @@ describe('SnapAdapter', () => {
       const network: INetworkInfo = {
         networkName: 'mainnet',
         networkId: 'mainnet01',
-        url: ['https://api.chainweb.com'],
+        urls: ['https://api.chainweb.com'],
       };
       vi.spyOn(adapter as any, '_getActiveNetwork').mockResolvedValueOnce(
         network,
@@ -122,7 +122,7 @@ describe('SnapAdapter', () => {
         {
           networkName: 'testnet',
           networkId: 'testnet04',
-          url: ['https://api.testnet.chainweb.com'],
+          urls: ['https://api.testnet.chainweb.com'],
         },
       ];
       vi.spyOn(adapter as any, '_getNetworks').mockResolvedValueOnce(networks);

--- a/packages/libs/wallet-adapter-metamask-snap/src/snapAdapterFactory.ts
+++ b/packages/libs/wallet-adapter-metamask-snap/src/snapAdapterFactory.ts
@@ -9,16 +9,16 @@ import { detectSnapProvider } from './provider';
  * MetaMask Snap Adapter Factory
  *
  * This function creates a MetaMask Snap wallet adapter factory that detects
- * the MetaMask provider with your Kadena Snap installed and returns a new
- * instance of the `SnapAdapter`. Detection is split out so that the
- * `WalletAdapterClient` can probe for the Snap without instantiating the adapter.
+ * the MetaMask provider and returns a new instance of the `SnapAdapter`.
+ * Detection is split out so that the `WalletAdapterClient` can probe for
+ * the Snap without instantiating the adapter.
  *
  * By using `await import("./SnapAdapter")`, this factory only loads the
  * Snap adapter code when it’s actually needed. This **lazy loading** can
  * significantly reduce your initial bundle size, especially if you
  * register multiple wallet adapters but only use one in a given session.
  *
- * @param options - Configuration options for the adapter (e.g. `silent`, `timeout`)
+ * @param options - Configuration options for the adapter (e.g. `silent`, `timeout`).
  * @returns A wallet adapter factory for the MetaMask Kadena Snap
  * @public
  */

--- a/packages/libs/wallet-adapter-walletconnect/src/WalletConnectAdapter.ts
+++ b/packages/libs/wallet-adapter-walletconnect/src/WalletConnectAdapter.ts
@@ -198,8 +198,9 @@ export class WalletConnectAdapter extends BaseWalletAdapter {
 
   private async subscribeToEvents(): Promise<void> {
     if (!this.client) throw new Error(ERRORS.FAILED_TO_CONNECT);
+
     this.client.on('session_ping', (args) => {
-      // console.log('[walletconnect]', 'session_ping', args);
+      console.log('[walletconnect]', 'session_ping', args);
     });
 
     this.client.on('session_event', (args) => {
@@ -216,14 +217,31 @@ export class WalletConnectAdapter extends BaseWalletAdapter {
       });
     });
 
-    this.client.on('session_delete', () => {
-      console.log('[walletconnect]', 'session_delete');
+    this.client.on('session_delete', ({ topic }) => {
+      console.log('[walletconnect]', 'session_delete', topic);
+      // Cleanup on session end
+      this.provider = undefined as any;
+      localStorage.removeItem('wc_session');
     });
   }
 
   private async checkPersistedState(): Promise<void> {
     if (!this.client) throw new Error(ERRORS.FAILED_TO_CONNECT);
 
+    // First, try localStorage
+    const storedTopic = localStorage.getItem('wc_session');
+    if (storedTopic !== null && storedTopic.trim() !== '') {
+      const session = this.client.session.get(storedTopic);
+      if (session !== undefined) {
+        await this.onSessionConnected(session);
+        return;
+      } else {
+        // cleanup invalid topic
+        localStorage.removeItem('wc_session');
+      }
+    }
+
+    // Fallback: use latest active session
     const sessions = this.client.session.getAll();
     if (sessions.length) {
       await this.onSessionConnected(sessions[sessions.length - 1]);
@@ -240,7 +258,21 @@ export class WalletConnectAdapter extends BaseWalletAdapter {
         await this.subscribeToEvents();
         await this.checkPersistedState();
       }
-      await this.connectWallet();
+      // If provider already has a connected session, just reuse it
+      if (this.provider?.connected) {
+        return this.getActiveAccount();
+      }
+
+      // Auto-detect paired device
+      const pairings = this.client.core.pairing.getPairings();
+      if (pairings.length > 0) {
+        // Reuse existing device pairing (no modal)
+        await this.connectWallet({ topic: pairings[0].topic });
+      } else {
+        // No known devices → fallback to QR modal
+        await this.connectWallet();
+      }
+
       return this.getActiveAccount();
     } catch (error) {
       console.error('Connection error:', error);
@@ -273,7 +305,11 @@ export class WalletConnectAdapter extends BaseWalletAdapter {
     }
     const session = await approval();
     await this.onSessionConnected(session);
-    this.modal.closeModal();
+
+    if (uri) this.modal.closeModal();
+
+    // Persist latest session for auto-reconnect
+    localStorage.setItem('wc_session', session.topic);
   }
 
   private async onSessionConnected(
@@ -305,6 +341,10 @@ export class WalletConnectAdapter extends BaseWalletAdapter {
       topic: this.provider.session.topic,
       reason: getSdkError('USER_DISCONNECTED'),
     });
+
+    // Clear state after disconnect
+    this.provider = undefined as any;
+    localStorage.removeItem('wc_session');
   }
 
   // when the contracts[] param is omitted the wallet returns all known fungible accounts


### PR DESCRIPTION
## Wallet Adapter:

### Snap Adapter

-  Move snap checks to `connect`; detection no longer calls `wallet_getSnaps`, avoiding premature unlock prompts. Prompts occur during connection.


###  WalletConnect
-  Persist active session topic, reuse existing pairings to reduce QR scans, auto‑reconnect when possible, and clean up state on disconnect/deletion.

### Test scenarios

 #### Snap Adapter

  - Detection with locked MetaMask does not trigger unlock.
  - Connect triggers unlock; installs/enables Kadena Snap if needed.
  - After connect, accounts and networks load correctly.

#### WalletConnect Adapter

  - Start a session, reload page: session restores without showing QR.
  - Existing pairing is reused; no extra QR shown.
  - If provider still connected, auto‑reconnect succeeds.
  - Disconnect clears `localStorage` and provider session state.